### PR TITLE
docs: restructure README, add docs/, fix stale claims

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,11 +27,11 @@ This project follows
 
 If you encounter an issue, please file a GitHub issue with the following:
 
-1. **Generate a diagnostic report** — in your Gemini CLI session, use the `/bug`
-   command. This creates a diagnostic file with session logs and environment
-   details. Attach it to the issue.
+1. **Generate a diagnostic report.** In your Gemini CLI session, use the
+   `/bug` command. This creates a diagnostic file with session logs and
+   environment details. Attach it to the issue.
 
-2. **Run presubmit** — run `npm run presubmit` and include the output. This
+2. **Run presubmit.** Run `npm run presubmit` and include the output. This
    helps determine whether the issue is environmental or a code bug.
 
 3. **Describe what you expected** vs. what actually happened, including the
@@ -77,7 +77,20 @@ npm run test:integration:real # Integration tests against real Google APIs
 ### Linting and formatting
 
 ```bash
-npm run lint          # Check for errors
-npm run lint -- --fix # Auto-fix
-npm run format        # Prettier
+npm run lint          # Check for errors (read-only)
+npm run lint -- --fix # Auto-fix lint
+npm run format        # Auto-fix formatting (Prettier)
 ```
+
+`npm run presubmit` runs `prettier --check` and `eslint` in read-only mode;
+it will fail rather than auto-fix. The husky pre-commit hook fixes staged
+files via lint-staged on commit, so a clean working tree usually passes.
+
+### Continuous integration
+
+Pull requests trigger four parallel jobs on GitHub Actions: `lint`,
+`test-unit`, `test-integration-fake`, and `test-smoke`. Each maps to one of
+the `npm run` scripts above. Jobs run hermetically (no ADC), so any test
+that inadvertently reaches `getAuthClient()` fails fast with a named error
+instead of timing out on metadata-server discovery. The workflow is at
+[`.github/workflows/node.js.yml`](.github/workflows/node.js.yml).

--- a/README.md
+++ b/README.md
@@ -270,6 +270,16 @@ integration tests, and a smoke test against the in-process fake API server;
 no credentials needed. After merge, `npm run postsubmit` re-runs the full
 presubmit suite plus a real-API integration pass.
 
+Presubmit is **read-only**. If formatting or lint fails, run
+`npm run format` and `npm run lint:fix` to fix, then re-run. The husky
+pre-commit hook auto-fixes staged files via lint-staged, so commits from a
+clean working tree usually pass without manual fixup.
+
+GitHub Actions runs the same checks on every pull request as four parallel
+jobs (`lint`, `test-unit`, `test-integration-fake`, `test-smoke`); each
+failure shows up as a separate PR check. The workflow is at
+[`.github/workflows/node.js.yml`](.github/workflows/node.js.yml).
+
 ```bash
 npm run presubmit               # Required before every PR
 npm run postsubmit              # After merge (real API credentials)

--- a/README.md
+++ b/README.md
@@ -110,11 +110,11 @@ Or enable them from the
 > **Propagation delay:** Newly enabled APIs can take 1–5 minutes to become
 > available. The server handles this automatically by retrying
 > `PERMISSION_DENIED` errors with exponential backoff. If you see retry messages
-> on first run, wait — don't restart.
+> on first run, wait; don't restart.
 
 ### 3. Connect Your MCP Client
 
-The server uses **stdio** transport — your MCP client launches it as a child
+The server uses **stdio** transport; your MCP client launches it as a child
 process. Add the config snippet for your client:
 
 <details>
@@ -205,53 +205,11 @@ Restart your MCP client, then ask:
 You should see the agent discover and list the available tools. If tools don't
 appear, see [Troubleshooting](#troubleshooting).
 
-### Configuration
+## Configuration
 
-The server is configured via environment variables.
-
-#### 1. MCP Client (Stdio mode)
-
-Add variables to the `env` block of your client's settings file. The client
-injects these into the server's environment on startup.
-
-```json
-{
-  "mcpServers": {
-    "cep": {
-      "command": "npx",
-      "args": ["-y", "@google/chrome-enterprise-premium-mcp@latest"],
-      "env": {
-        "GCP_STDIO": "true",
-        "GOOGLE_CLOUD_QUOTA_PROJECT": "your-project-id"
-      }
-    }
-  }
-}
-```
-
-#### 2. Standalone (HTTP mode)
-
-Variables can be passed inline or via a `.env` file in your working directory.
-See
-[`.env.example`](https://github.com/google/chrome-enterprise-premium-mcp/blob/main/.env.example)
-for all options.
-
-```bash
-PORT=8080 GCP_STDIO=false npx -y @google/chrome-enterprise-premium-mcp@latest
-```
-
-#### 3. Key Variables
-
-| Variable                     | Description                                          | Default |
-| :--------------------------- | :--------------------------------------------------- | :------ |
-| `GCP_STDIO`                  | `true` for Stdio (local); `false` for HTTP (remote). | `true`  |
-| `PORT`                       | Network port when `GCP_STDIO=false`.                 | `0`     |
-| `GOOGLE_CLOUD_QUOTA_PROJECT` | GCP project ID for API quotas.                       | -       |
-| `OAUTH_ENABLED`              | Set `true` to require OAuth (HTTP mode only).        | `false` |
-| `LOG_LEVEL`                  | Verbosity (`error`, `warn`, `info`, `debug`).        | `info`  |
-
-> [!NOTE]
-> When `GCP_STDIO=false` and `PORT` is not specified or is set to `0`, the server binds to a random available port. The actual assigned port will be logged at startup, for example: `Chrome Enterprise Premium MCP server listening on port X`.
+For environment variables, stdio vs. HTTP modes, and OAuth setup (including
+the current state of the managed OAuth client for CEP), see
+[`docs/configuration.md`](docs/configuration.md).
 
 ## Prerequisites
 
@@ -284,332 +242,64 @@ PORT=8080 GCP_STDIO=false npx -y @google/chrome-enterprise-premium-mcp@latest
 
 The server exposes tools for reading and managing Chrome Enterprise resources:
 
-- **Discovery** — get customer ID, list org units, count browser versions, list
+- **Discovery:** get customer ID, list org units, count browser versions, list
   customer profiles
-- **Licensing** — check CEP subscription status, check per-user license
+- **Licensing:** check CEP subscription status, check per-user license
   assignment
-- **DLP** — list/create/delete DLP rules, list/create/delete detectors (regex,
+- **DLP:** list/create/delete DLP rules, list/create/delete detectors (regex,
   word list, URL list), create default rule sets
-- **Connectors** — get connector policy status, enable Chrome Enterprise
+- **Connectors:** get connector policy status, enable Chrome Enterprise
   connectors
-- **Extensions** — check SEB extension status, install SEB extension
-- **Security** — get Chrome activity logs, check and enable required APIs
-- **Knowledge** — search the built-in Chrome Enterprise Premium knowledge base
+- **Extensions:** check SEB extension status, install SEB extension
+- **Security:** get Chrome activity logs, check and enable required APIs
+- **Knowledge:** search the built-in Chrome Enterprise Premium knowledge base
 
 ## Architecture
 
-```text
-/
-├── lib/
-│   ├── api/              # Google Cloud API clients
-│   │   ├── interfaces/   # Abstract client contracts
-│   │   ├── real_*.js     # Production clients (live Google APIs)
-│   │   └── fake_*.js     # Test doubles (local mock server)
-│   ├── util/             # Auth, retry logic, CEL validation, logging
-│   └── constants.js      # Centralized configuration
-├── prompts/              # MCP prompt definitions
-│   ├── definitions/      # Individual prompt implementations
-│   └── index.js
-├── tools/
-│   ├── definitions/      # Individual tool implementations
-│   ├── utils/            # Tool-specific utilities
-│   └── index.js          # Tool registration entry point
-├── test/                 # Unit, integration, and eval tests
-└── mcp-server.js         # Server entry point
-```
-
-Key design patterns:
-
-- **Client abstraction** — each Google API has an interface (`interfaces/`), a
-  real implementation (`real_*.js`), and a fake (`fake_*.js`). Tools depend on
-  the interface, making them testable without live API calls.
-- **Structured tool output** — tools return structured JSON with both
-  machine-readable data and human-readable summaries.
-- **Retry with backoff** — API calls retry on `PERMISSION_DENIED` (gRPC code 7)
-  to handle eventual consistency after enabling APIs.
-- **CEL validation** — DLP rule conditions are validated offline against the
-  Chrome CEL grammar before submission.
+The codebase has three layers: API clients in `lib/api/` (one interface +
+real implementation per Google API), MCP tools and prompts in `tools/` and
+`prompts/`, and the server entry point in `mcp-server.js`. Integration tests
+redirect the real API clients at an in-process Express fake under
+`test/helpers/`. For the directory layout, design patterns, and how the test
+backends are wired, see [`docs/architecture.md`](docs/architecture.md).
 
 ## Development
 
-### Fake vs. real backends
-
-Tests and evals can run against two backends:
-
-- **Fake** (default) — an in-process Express server
-  (`test/helpers/fake-api-server.js`) that simulates all five Google APIs.
-  Returns canned responses, tracks mutations, and resets state between tests. No
-  network calls, no credentials needed.
-- **Real** — calls the live Google APIs using your ADC credentials. Requires
-  authentication (Step 1) and API enablement (Step 2). Used for post-merge
-  validation.
-
-The `CEP_BACKEND` environment variable controls the backend. Integration test
-scripts accept `fake` or `real` as a positional argument.
-
-### Running tests
-
-> **Run `npm run presubmit` before every PR.** It runs unit tests, fake
-> integration tests, and a smoke test. If presubmit passes, your change is safe
-> to submit.
+Run `npm run presubmit` before every PR. It runs unit tests, fake-backend
+integration tests, and a smoke test against the in-process fake API server;
+no credentials needed. After merge, `npm run postsubmit` re-runs the full
+presubmit suite plus a real-API integration pass.
 
 ```bash
-# Before submitting (no credentials needed)
-npm run presubmit
-
-# After merge (requires real API credentials)
-npm run postsubmit
+npm run presubmit               # Required before every PR
+npm run postsubmit              # After merge (real API credentials)
+npm run test:unit               # Unit tests only
+npm run test:integration:fake   # Integration tests against the fake
+npm run test:smoke              # Server starts and responds
+npm run mcp-inspector           # Browser UI for invoking tools and prompts
+npm run lint                    # Check formatting and lint
+npm run lint -- --fix           # Auto-fix
+npm run format                  # Prettier on everything
 ```
 
-Individual test commands:
-
-```bash
-npm run test:unit                # Unit tests (test/local/)
-npm run test:integration:fake    # Integration tests (fake)
-npm run test:integration:real    # Integration tests (real)
-npm run test:smoke               # Server starts and responds
-npm test                         # Unit + smoke
-```
-
-### Evaluations
-
-Evals measure agent behavior end-to-end: a Gemini-powered agent calls MCP tools
-against the fake backend, and responses are graded by deterministic checks and
-an LLM judge. Requires `GEMINI_API_KEY`. See
-[test/evals/README.md](test/evals/README.md) for the full eval framework
-documentation.
-
-```bash
-npm run eval                     # All evals
-npm run eval:knowledge           # Knowledge grounding only
-npm run eval:agentic             # Tool use only
-npm run eval:full                # 3 judge runs per eval
-```
-
-The eval runner accepts flags for filtering and tuning:
-
-```bash
-# Run a specific eval by ID
-node test/evals/run.js --id m01
-
-# Run a category
-node test/evals/run.js --category mutation
-
-# Multiple judge runs for consistency
-node test/evals/run.js --runs 5
-
-# Skip the LLM judge (deterministic checks only)
-node test/evals/run.js --no-judge
-
-# Dry run: validate eval config without Gemini
-node test/evals/run.js --dry-run
-
-# Verbose: show full agent responses
-node test/evals/run.js --id k01 --verbose
-
-# Write JSON results to a file
-node test/evals/run.js --output results/eval.json
-```
-
-### Debugging
-
-The [MCP Inspector](https://github.com/modelcontextprotocol/inspector) provides
-a browser UI for invoking tools and prompts directly:
-
-```bash
-npm run mcp-inspector
-```
-
-### Linting and Formatting
-
-```bash
-npm run lint                     # Check for errors
-npm run lint -- --fix            # Auto-fix
-npm run format                   # Prettier
-```
-
-### HTTP Mode with OAuth
-
-The server also supports HTTP transport with optional OAuth — useful for shared
-or remote deployments where multiple users connect to a single server instance.
-
-In this mode, the MCP client (e.g., Gemini CLI) authenticates the end user via
-OAuth and passes their access token as a Bearer header. The server validates the
-token and uses it directly for Google API calls — ADC is not involved.
-
-```bash
-GCP_STDIO=false npx -y @google/chrome-enterprise-premium-mcp@latest
-```
-
-See `.env.example` for the full set of OAuth variables and how to configure
-them. The server exposes `.well-known/oauth-protected-resource` and
-`.well-known/oauth-authorization-server` endpoints so clients can auto-discover
-the OAuth flow.
+For evaluations (Gemini agent against fake backend, graded by deterministic
+checks and an LLM judge), see [`test/evals/README.md`](test/evals/README.md).
+For the test runner layout and how to add a test, see
+[`test/README.md`](test/README.md). For contributing, see
+[`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ## Troubleshooting
 
-### Authentication
-
-#### "Could not load the default credentials"
-
-ADC is not configured. Run the login command from
-[Step 1](#1-authenticate-with-google-cloud). Verify credentials exist afterward:
-
-```bash
-cat ~/.config/gcloud/application_default_credentials.json
-```
-
-If the file doesn't exist, login didn't complete (check for browser popup you
-may have missed).
-
-#### "Request had insufficient authentication scopes"
-
-Credentials were created without the required scopes — usually because
-`gcloud auth application-default login` was run without `--scopes`. The default
-scope (`cloud-platform`) does not cover Workspace APIs like Admin SDK or Chrome
-Management. You must delete and re-create credentials:
-
-```bash
-rm ~/.config/gcloud/application_default_credentials.json
-```
-
-Then re-run the full login command from
-[Step 1](#1-authenticate-with-google-cloud). There is no way to add scopes to
-existing ADC credentials.
-
-#### "API requires a quota project, which is not set by default"
-
-Google needs to know which project's API quotas and enablement to use. This
-error appears on the first API call, not at login:
-
-```bash
-gcloud auth application-default set-quota-project YOUR_PROJECT_ID
-```
-
-If you're unsure which project to use, run `gcloud projects list` and pick the
-one linked to your Workspace domain.
-
-#### "invalid_grant" or "Token has been revoked"
-
-Cached credentials are stale. Common causes: password change, admin revoked
-access, MFA re-enrollment, or token expired after 7 days of inactivity. Delete
-`~/.config/gcloud/application_default_credentials.json` and re-authenticate.
-
-#### `gcloud` is installed but `gcloud auth` fails with "command not found"
-
-Your shell can find `gcloud` but not the auth component. Run
-`gcloud components install` or reinstall the Cloud SDK. On macOS with Homebrew,
-`brew install google-cloud-sdk` sometimes doesn't add auth components — use the
-[official installer](https://cloud.google.com/sdk/docs/install) instead.
-
-### Permissions
-
-#### "The caller does not have permission" (403)
-
-This is almost always one of three things:
-
-1. **API not enabled** — run the `gcloud services enable` command from
-   [Step 2](#2-enable-required-apis). This is the most common cause on first
-   setup.
-2. **Missing Workspace admin role** — Chrome and Admin SDK APIs require a Google
-   Workspace admin role (Super Admin or delegated) configured in the
-   [Admin Console](https://admin.google.com/) > Account > Admin roles. GCP IAM
-   roles alone are not sufficient for Workspace APIs.
-3. **Missing GCP IAM role** — the user needs roles on the GCP project itself
-   (e.g., `roles/browser.admin`, `roles/serviceusage.serviceUsageAdmin`).
-
-#### "PERMISSION_DENIED" followed by retries
-
-Normal on first run. The server retries `PERMISSION_DENIED` (gRPC code 7) up to
-7 times with exponential backoff — the first retry waits 15 seconds. This
-handles the propagation delay after enabling APIs. If retries exhaust, the
-permission issue is real — check the three items above.
-
-### Node.js
-
-#### "Cannot find module" or "ERR_MODULE_NOT_FOUND"
-
-Dependencies are missing. Run `npm install` from the project root.
-
-#### "ExperimentalWarning: ... is an experimental feature"
-
-Harmless. Some Node.js features used by dependencies emit warnings on older Node
-versions. Upgrade to Node 20+ to suppress, or ignore them — they don't affect
-functionality.
-
-#### Wrong Node version
-
-The server requires Node >= 18. Check with `node --version`. If you're using
-[nvm](https://github.com/nvm-sh/nvm), make sure you've run `nvm use 18` (or
-higher) in the project directory. MCP clients launch `node` as a subprocess —
-they use whatever `node` is on the system PATH, which may differ from your
-shell's `nvm`-managed version.
-
-### MCP Client Integration
-
-#### Tools don't appear in the client
-
-1. **Restart the client** after editing its config file — most clients don't
-   hot-reload MCP config.
-2. **Use absolute paths** — the `args` path in your config must be absolute.
-   Relative paths resolve from the client's working directory, which is
-   unpredictable.
-3. **Check `node` visibility** — GUI apps (Claude Desktop, VS Code) may not
-   inherit your shell PATH. Try the full path to node:
-   `"command": "/usr/local/bin/node"` (find yours with `which node`).
-4. **Test manually** — run `npx -y @google/chrome-enterprise-premium-mcp@latest` in a terminal. You
-   should see
-   `[mcp] Chrome Enterprise Premium MCP server stdio transport connected` on
-   stderr. If you see errors instead, fix those first.
-
-#### Server starts but immediately exits
-
-Check stderr output. Common causes: missing `.env` values the server expects, or
-a port conflict if accidentally running in HTTP mode (`GCP_STDIO=false`).
+For known issues with auth, permissions, Node.js setup, and MCP client
+integration (including the `/mcp` reload tip when CEP tools do not show up
+right after restart), see
+[`docs/troubleshooting.md`](docs/troubleshooting.md).
 
 ## FAQ
 
-### Do I need a Chrome Enterprise Premium license?
-
-Yes. DLP rules, content detectors, Chrome connectors, and threat protection are
-CEP features — they require an active Chrome Enterprise Premium license
-[assigned to the relevant users](https://docs.cloud.google.com/chrome-enterprise-premium/docs/overview).
-Without it, most tools will return permission errors. A 60-day free trial is
-available from the Admin Console or Cloud Console.
-
-### Which Google Workspace edition do I need?
-
-Chrome Enterprise Premium is a paid add-on available with any Google Workspace
-edition. Chrome Enterprise Core (free) provides policy management for over 300
-policies but does not include DLP, threat protection, or Context-Aware Access.
-See
-[Chrome Enterprise Premium pricing](https://docs.cloud.google.com/chrome-enterprise-premium/docs/overview)
-for current rates.
-
-### Can I use a service account instead of user credentials?
-
-Yes, but the service account must have
-[domain-wide delegation](https://developers.google.com/identity/protocols/oauth2/service-account#delegatingauthority)
-configured in the Admin Console with the required scopes. Set
-`GOOGLE_APPLICATION_CREDENTIALS` to point to the key file.
-
-### Why do I see "Retrying in 15s..." on first use?
-
-Newly enabled APIs take a few minutes to propagate. The server retries
-automatically. This is normal on first run and should resolve within a minute or
-two.
-
-### How do I enable experimental features?
-
-Some tools (e.g., deletion of DLP rules and detectors) are gated behind feature
-flags and disabled by default. Enable them with `EXPERIMENT_` prefixed
-environment variables:
-
-```bash
-EXPERIMENT_DELETE_TOOL_ENABLED=true npm start
-```
-
-See `lib/util/feature_flags.js` for the full list of available flags.
+For license requirements, Workspace edition, service-account auth,
+experimental features, and other recurring questions, see
+[`docs/faq.md`](docs/faq.md).
 
 ## Reporting Bugs
 
@@ -617,7 +307,7 @@ If something isn't working:
 
 1. In Gemini CLI, run `/bug` to capture session diagnostics. Attach the
    generated file to your issue.
-2. Run `npm run presubmit` and include the output — this helps determine whether
+2. Run `npm run presubmit` and include the output; this helps determine whether
    the issue is environmental or a code bug.
 3. Describe what you expected vs. what actually happened, including the exact
    error message.
@@ -629,7 +319,7 @@ file for details on how to contribute to this project.
 
 ## Legal
 
-- **License**: [Apache License 2.0](LICENSE)
-- **Terms of Service**: [Terms of Service](https://policies.google.com/terms)
-- **Privacy Policy**: [Privacy Policy](https://policies.google.com/privacy)
-- **Security**: [Security Policy](SECURITY.md)
+- **License:** [Apache License 2.0](LICENSE)
+- **Terms of Service:** [Terms of Service](https://policies.google.com/terms)
+- **Privacy Policy:** [Privacy Policy](https://policies.google.com/privacy)
+- **Security:** [Security Policy](SECURITY.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,34 @@
+<!--
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# docs
+
+Reference documentation for operating and extending the Chrome Enterprise
+Premium MCP server. The root [`README.md`](../README.md) covers installation
+and connecting an MCP client; these docs cover what you need after the server
+is running.
+
+- [`configuration.md`](./configuration.md): environment variables, stdio vs.
+  HTTP modes, OAuth setup.
+- [`troubleshooting.md`](./troubleshooting.md): auth, permissions, Node.js,
+  and MCP client integration issues with fixes.
+- [`architecture.md`](./architecture.md): code layout, client abstraction,
+  retry behavior, CEL validation.
+- [`faq.md`](./faq.md): license requirements, service accounts, experimental
+  features, and other recurring questions.
+
+For contributing changes, see [`../CONTRIBUTING.md`](../CONTRIBUTING.md). For
+the test infrastructure, see [`../test/README.md`](../test/README.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,62 @@
+<!--
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Architecture
+
+```text
+/
+├── lib/
+│   ├── api/              # Google Cloud and Workspace API clients
+│   │   ├── interfaces/   # Abstract client contracts
+│   │   └── real_*.js     # Production implementations
+│   ├── util/             # Auth, retry, CEL validation, logging, flags
+│   └── constants.js      # Centralized configuration
+├── prompts/              # MCP prompt definitions
+│   ├── definitions/      # Individual prompt implementations
+│   └── index.js
+├── tools/
+│   ├── definitions/      # Individual tool implementations
+│   ├── utils/            # Tool-specific utilities
+│   └── index.js          # Tool registration entry point
+├── test/                 # Unit, integration, and eval tests
+└── mcp-server.js         # Server entry point
+```
+
+## Key design patterns
+
+- **Client abstraction.** Each Google API has an interface
+  (`lib/api/interfaces/`) and a real implementation (`lib/api/real_*.js`).
+  Tools program against the interface. There is no separate fake client class:
+  we instantiate the same `Real*Client` with a `rootUrl` override and a stub
+  OAuth token to redirect it at the in-process fake server. See
+  [`lib/api/README.md`](../lib/api/README.md) for the full pattern.
+- **Structured tool output.** Tools return structured JSON with both
+  machine-readable data and human-readable summaries.
+- **Retry with backoff.** API calls retry on `PERMISSION_DENIED` (gRPC code 7)
+  to handle eventual consistency after enabling APIs.
+- **CEL validation.** DLP rule conditions are validated offline against the
+  Chrome CEL grammar before submission.
+
+## Test backends
+
+Tests and evals run against two backends, controlled by `CEP_BACKEND`:
+
+- **Fake** (default for presubmit). An in-process Express server,
+  `test/helpers/fake-api-server.js`, that mimics all five Google APIs. The
+  real client classes are redirected at it via `rootUrl + fakeAuth`. No
+  network calls, no credentials needed.
+- **Real** (postsubmit). Calls the live Google APIs using your ADC
+  credentials. Requires authentication and API enablement.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,87 @@
+<!--
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Configuration
+
+The server is configured via environment variables. How you set them depends
+on which transport mode you are using.
+
+## MCP client (stdio mode)
+
+Add variables to the `env` block of your client's settings file. The client
+injects them into the server's environment on startup.
+
+```json
+{
+  "mcpServers": {
+    "cep": {
+      "command": "npx",
+      "args": ["-y", "@google/chrome-enterprise-premium-mcp@latest"],
+      "env": {
+        "GCP_STDIO": "true",
+        "GOOGLE_CLOUD_QUOTA_PROJECT": "your-project-id"
+      }
+    }
+  }
+}
+```
+
+## Standalone (HTTP mode)
+
+You can pass variables inline or load them from a `.env` file in your working
+directory. See [`.env.example`](../.env.example) for the full set of options.
+
+```bash
+PORT=8080 GCP_STDIO=false npx -y @google/chrome-enterprise-premium-mcp@latest
+```
+
+## Key variables
+
+| Variable                     | Description                                          | Default |
+| :--------------------------- | :--------------------------------------------------- | :------ |
+| `GCP_STDIO`                  | `true` for Stdio (local); `false` for HTTP (remote). | `true`  |
+| `PORT`                       | Network port when `GCP_STDIO=false`.                 | `0`     |
+| `GOOGLE_CLOUD_QUOTA_PROJECT` | GCP project ID for API quotas.                       | -       |
+| `OAUTH_ENABLED`              | Set `true` to require OAuth (HTTP mode only).        | `false` |
+| `LOG_LEVEL`                  | Verbosity (`error`, `warn`, `info`, `debug`).        | `info`  |
+
+> [!NOTE]
+> When `GCP_STDIO=false` and `PORT` is unset or `0`, the server binds to a
+> random available port. The actual port is logged at startup, e.g.
+> `Chrome Enterprise Premium MCP server listening on port X`.
+
+## HTTP mode with OAuth
+
+The server supports HTTP transport with optional OAuth, useful for shared or
+remote deployments where multiple users connect to a single server instance.
+In this mode the MCP client (e.g., Gemini CLI) authenticates the end user via
+OAuth and passes their access token as a Bearer header. The server validates
+the token and uses it for Google API calls; ADC is not involved.
+
+```bash
+GCP_STDIO=false npx -y @google/chrome-enterprise-premium-mcp@latest
+```
+
+The server exposes `.well-known/oauth-protected-resource` and
+`.well-known/oauth-authorization-server` endpoints so clients can auto-discover
+the OAuth flow. See [`.env.example`](../.env.example) for the full set of
+OAuth variables.
+
+> **OAuth client status.** Today, OAuth requires you to bring your own
+> internal OAuth client. We are working on a Google-managed OAuth client
+> specifically for Chrome Enterprise Premium, but it is not yet available. If
+> you want the fastest path to a working setup, use ADC (the Quick Start in
+> the root README); OAuth is for production multi-user deployments.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,59 @@
+<!--
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# FAQ
+
+## Do I need a Chrome Enterprise Premium license?
+
+Yes. DLP rules, content detectors, Chrome connectors, and threat protection
+are CEP features. They require an active Chrome Enterprise Premium license
+[assigned to the relevant users](https://docs.cloud.google.com/chrome-enterprise-premium/docs/overview).
+Without it, most tools will return permission errors. A 60-day free trial is
+available from the Admin Console or Cloud Console.
+
+## Which Google Workspace edition do I need?
+
+Chrome Enterprise Premium is a paid add-on available with any Google
+Workspace edition. Chrome Enterprise Core (free) provides policy management
+for over 300 policies but does not include DLP, threat protection, or
+Context-Aware Access. See
+[Chrome Enterprise Premium pricing](https://docs.cloud.google.com/chrome-enterprise-premium/docs/overview)
+for current rates.
+
+## Can I use a service account instead of user credentials?
+
+Yes, but the service account must have
+[domain-wide delegation](https://developers.google.com/identity/protocols/oauth2/service-account#delegatingauthority)
+configured in the Admin Console with the required scopes. Set
+`GOOGLE_APPLICATION_CREDENTIALS` to point to the key file.
+
+## Why do I see "Retrying in 15s..." on first use?
+
+Newly enabled APIs take a few minutes to propagate. The server retries
+automatically. Normal on first run; should resolve within a minute or two.
+
+## How do I enable experimental features?
+
+Some tools (e.g., deletion of DLP rules and detectors) are gated behind
+feature flags and disabled by default. Enable them with `EXPERIMENT_`-prefixed
+environment variables:
+
+```bash
+EXPERIMENT_DELETE_TOOL_ENABLED=true npm start
+```
+
+See [`lib/util/feature_flags.js`](../lib/util/feature_flags.js) for the full
+list.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,143 @@
+<!--
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Troubleshooting
+
+## Authentication
+
+### "Could not load the default credentials"
+
+ADC is not configured. Run the login command from the
+[Quick Start](../README.md#1-authenticate-with-google-cloud). Verify
+credentials exist afterward:
+
+```bash
+cat ~/.config/gcloud/application_default_credentials.json
+```
+
+If the file does not exist, login did not complete (check for a browser popup
+you may have missed).
+
+### "Request had insufficient authentication scopes"
+
+We created credentials without the required scopes, usually because
+`gcloud auth application-default login` was run without `--scopes`. The
+default scope (`cloud-platform`) does not cover Workspace APIs like Admin SDK
+or Chrome Management. Delete and re-create credentials:
+
+```bash
+rm ~/.config/gcloud/application_default_credentials.json
+```
+
+Then re-run the full login command from the
+[Quick Start](../README.md#1-authenticate-with-google-cloud). You cannot add
+scopes to existing ADC credentials.
+
+### "API requires a quota project, which is not set by default"
+
+Google needs to know which project's API quotas and enablement to use. This
+error appears on the first API call, not at login:
+
+```bash
+gcloud auth application-default set-quota-project YOUR_PROJECT_ID
+```
+
+If you are unsure which project to use, run `gcloud projects list` and pick
+the one linked to your Workspace domain.
+
+### "invalid_grant" or "Token has been revoked"
+
+Cached credentials are stale. Common causes: password change, admin revoked
+access, MFA re-enrollment, or token expired after seven days of inactivity.
+Delete `~/.config/gcloud/application_default_credentials.json` and
+re-authenticate.
+
+### `gcloud` is installed but `gcloud auth` fails with "command not found"
+
+Your shell can find `gcloud` but not the auth component. Run
+`gcloud components install` or reinstall the Cloud SDK. On macOS with
+Homebrew, `brew install google-cloud-sdk` sometimes does not add auth
+components; use the
+[official installer](https://cloud.google.com/sdk/docs/install) instead.
+
+## Permissions
+
+### "The caller does not have permission" (403)
+
+This is almost always one of three things:
+
+1. **API not enabled.** Run the `gcloud services enable` command from the
+   [Quick Start](../README.md#2-enable-required-apis). Most common cause on
+   first setup.
+2. **Missing Workspace admin role.** Chrome and Admin SDK APIs require a
+   Google Workspace admin role (Super Admin or delegated) configured in the
+   [Admin Console](https://admin.google.com/) > Account > Admin roles. GCP
+   IAM roles alone are not sufficient for Workspace APIs.
+3. **Missing GCP IAM role.** The user needs roles on the GCP project itself
+   (e.g., `roles/browser.admin`, `roles/serviceusage.serviceUsageAdmin`).
+
+### "PERMISSION_DENIED" followed by retries
+
+Normal on first run. The server retries `PERMISSION_DENIED` (gRPC code 7) up
+to seven times with exponential backoff; the first retry waits 15 seconds.
+This handles propagation delay after enabling APIs. If retries exhaust, the
+permission issue is real; check the three items above.
+
+## Node.js
+
+### "Cannot find module" or "ERR_MODULE_NOT_FOUND"
+
+Dependencies are missing. Run `npm install` from the project root.
+
+### "ExperimentalWarning: ... is an experimental feature"
+
+Harmless. Some Node.js features used by dependencies emit warnings on older
+Node versions. Upgrade to Node 20+ to suppress, or ignore them; they do not
+affect functionality.
+
+### Wrong Node version
+
+The server requires Node >= 18. Check with `node --version`. If you use
+[nvm](https://github.com/nvm-sh/nvm), make sure you have run `nvm use 18` (or
+higher) in the project directory. MCP clients launch `node` as a subprocess —
+they use whatever `node` is on the system PATH, which may differ from your
+shell's `nvm`-managed version.
+
+## MCP client integration
+
+### Tools do not appear in the client
+
+1. **Restart the client** after editing its config file; most clients do not
+   hot-reload MCP config.
+2. **Run the client's MCP-reload command.** In Gemini CLI, type `/mcp` and
+   reload. Some clients pick up new tool registrations only after an explicit
+   reload, even after a restart.
+3. **Use absolute paths.** The `args` path in your config must be absolute.
+   Relative paths resolve from the client's working directory, which is
+   unpredictable.
+4. **Check `node` visibility.** GUI apps (Claude Desktop, VS Code) may not
+   inherit your shell PATH. Try the full path to node:
+   `"command": "/usr/local/bin/node"` (find yours with `which node`).
+5. **Test manually.** Run
+   `npx -y @google/chrome-enterprise-premium-mcp@latest` in a terminal. You
+   should see
+   `[mcp] Chrome Enterprise Premium MCP server stdio transport connected` on
+   stderr. If you see errors, fix those first.
+
+### Server starts but immediately exits
+
+Check stderr output. Common causes: missing `.env` values the server expects,
+or a port conflict if you accidentally ran in HTTP mode (`GCP_STDIO=false`).

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,29 @@
+<!--
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# lib
+
+Shared infrastructure for the MCP server.
+
+- [`api/`](./api/): Google Cloud and Workspace API clients. Each domain has
+  an interface and a real implementation; integration tests redirect the real
+  clients at an in-process fake.
+- [`util/`](./util/): auth, retry/backoff, logging, CEL validation, feature
+  flags, DLP constants, and other cross-cutting utilities.
+- [`knowledge/`](./knowledge/): markdown knowledge-base articles bundled with
+  the server and exposed via the `cep:expert` and search tools.
+- `constants.js`: centralized OAuth scopes, API versions, and tag strings used
+  across the codebase.

--- a/lib/api/README.md
+++ b/lib/api/README.md
@@ -16,23 +16,35 @@ limitations under the License.
 
 # lib/api
 
-Google Cloud and Workspace API clients. Each API is wrapped behind a client
-abstraction so tools depend on interfaces and tests can swap in fakes without
-network calls.
+Google Cloud and Workspace API clients. Each API has an interface and a real
+implementation. Tools depend on the interface so we can run integration tests
+against an in-process fake without changing client code.
 
-## Client triad pattern
+## Client pattern
 
-Every API has three files:
+Every API has two files:
 
-- `interfaces/foo_client.js` — Abstract base class. Methods throw
-  `Error('Not implemented')`. Defines the contract that tools program against.
-- `real_foo_client.js` — Production implementation. Authenticates via ADC or a
-  passed-through OAuth token, calls the real Google API.
-- `fake_foo_client.js` — Test double. Returns canned responses and tracks calls.
-  Used by the fake API server in `test/helpers/fake-api-server.js`.
+- `interfaces/foo_client.js`: abstract base class. Methods throw
+  `Error('Not implemented')`. Tools program against the interface.
+- `real_foo_client.js`: production implementation. Authenticates via ADC or a
+  passed-through OAuth token, calls the live Google API.
 
-The server wires real or fake clients in `mcp-server.js` based on whether
-`GOOGLE_API_ROOT_URL` is set.
+There is no separate `fake_*_client.js` class. For tests, we instantiate the
+same `Real*Client` and redirect it at the fake API server in
+`test/helpers/fake-api-server.js`. The factory in
+`test/helpers/integration/tools/client_factory.js` does the wiring:
+
+```js
+// Real backend (production / postsubmit): no args, uses ADC.
+new RealAdminSdkClient()
+
+// Fake backend (presubmit): same class, redirected via rootUrl + a fake
+// OAuth client so getAuthClient() is never called.
+new RealAdminSdkClient({ rootUrl, auth: fakeAuth })
+```
+
+`mcp-server.js` uses the same trick: when `GOOGLE_API_ROOT_URL` is set, it
+passes `rootUrl` into each Real client.
 
 ## API domains
 
@@ -46,16 +58,28 @@ The server wires real or fake clients in `mcp-server.js` based on whether
 
 ## Legacy standalone wrappers
 
-The bare files (`admin_sdk.js`, `chromemanagement.js`, `chromepolicy.js`,
-`cloudidentity.js`) are earlier standalone implementations that predate the
-client abstraction. They are not imported anywhere and will be removed in a
-future cleanup.
+The bare files `admin_sdk.js`, `chromemanagement.js`, and `cloudidentity.js`
+are earlier standalone implementations that predate the client abstraction.
+Nothing imports them; they will be removed in a future cleanup.
+
+`chromepolicy.js` is in the same category but still has one live export:
+`ConnectorPolicyFilter` is imported by `tools/definitions/get_connector_policy.js`
+and `tools/definitions/diagnose_environment.js`. Move that constant out of
+`chromepolicy.js` (e.g., into `lib/constants.js` or the real client) before
+deleting the file.
 
 ## Adding a new API client
 
 1. Create `interfaces/new_client.js` with abstract methods.
-2. Create `real_new_client.js` implementing the interface with `googleapis` or
-   `@google-cloud/*`.
-3. Create `fake_new_client.js` returning canned data.
-4. Wire both into `mcp-server.js` (in the real/fake client blocks).
-5. Add the fake to `test/helpers/integration/tools/client_factory.js`.
+2. Create `real_new_client.js` that implements the interface using `googleapis`
+   or `@google-cloud/*`. Take an optional `apiOptions` argument and pass it
+   through to your client constructor so `rootUrl` and `auth` overrides work.
+3. Wire the new client into `mcp-server.js` (both the
+   `GOOGLE_API_ROOT_URL`-set and unset branches construct the same Real
+   clients).
+4. Add the new client to `getApiClients()` in
+   `test/helpers/integration/tools/client_factory.js`. Mirror the existing
+   pattern: instantiate with no args for the `real` branch, and with
+   `{ rootUrl, auth: fakeAuth }` for the `fake` branch.
+5. Add HTTP handlers for the new API to `test/helpers/fake-api-server.js` so
+   the fake backend can serve the requests your client will make.

--- a/test/evals/README.md
+++ b/test/evals/README.md
@@ -265,30 +265,7 @@ Examples: "What's my customer ID?", "Show me all content detectors"
 
 ## Running evals
 
-```bash
-# Run all evals
-node test/evals/run.js
-
-# Run a single eval
-node test/evals/run.js --id m01
-
-# Run a category
-node test/evals/run.js --category mutation
-
-# Run by tags
-node test/evals/run.js --tags dlp,create
-
-# Multiple judge runs for consistency measurement
-node test/evals/run.js --runs 3
-
-# CI mode: JSON output + exit code
-node test/evals/run.js --output eval-results.json
-
-# Verbose: show full agent responses
-node test/evals/run.js --id k01 --verbose
-```
-
-### npm scripts
+The four npm scripts cover the common workflows:
 
 ```bash
 npm run eval              # all evals
@@ -296,6 +273,18 @@ npm run eval:knowledge    # knowledge category only
 npm run eval:agentic      # all non-knowledge categories
 npm run eval:full         # 3 runs per eval, JSON output
 ```
+
+For one-off filtering, invoke the runner directly:
+
+```bash
+node test/evals/run.js --id m01           # single eval
+node test/evals/run.js --tags dlp,create  # by tag
+node test/evals/run.js --output out.json  # CI: JSON + exit code
+```
+
+The runner accepts more flags (`--runs`, `--concurrency`, `--delay`,
+`--verbose`, `--no-judge`, `--dry-run`); see the usage block at the top of
+[`run.js`](./run.js).
 
 ### Environment variables
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -25,39 +25,39 @@ Every tool file exports a `registerXxxTool(server, options, sessionState)`
 function that calls `server.registerTool(name, schema, handler)`. The handler is
 wrapped with `guardedToolCall` from `utils/wrapper.js`, which provides:
 
-- **Automatic customer ID resolution** — if the tool needs a `customerId` and
-  one isn't provided, the wrapper calls `get_customer_id` and caches the result
-  in session state.
-- **Org unit normalization** — strips `id:` prefixes from org unit IDs.
-- **System prompt injection** — on the first tool call of a session, injects
+- **Automatic customer ID resolution:** if the tool needs a `customerId` and
+  one isn't provided, the wrapper calls `get_customer_id` and caches the
+  result in session state.
+- **Org unit normalization:** strips `id:` prefixes from org unit IDs.
+- **System prompt injection:** on the first tool call of a session, injects
   `prompts/system-prompt.md` and `lib/knowledge/0-agent-capabilities.md` into
   the response.
-- **Error handling** — catches and formats errors consistently.
-- **History tracking** — records each tool call in session state for
+- **Error handling:** catches and formats errors consistently.
+- **History tracking:** records each tool call in session state for
   diagnostics.
 
 ## Response format
 
 Tools return `formatToolResponse({ summary, data, structuredContent })`:
 
-- `summary` — Human-readable markdown shown to the user.
-- `data` — Fenced JSON block appended to the summary for structured detail.
-- `structuredContent` — Machine-readable JSON in the MCP `structuredContent`
+- `summary`: human-readable markdown shown to the user.
+- `data`: fenced JSON block appended to the summary for structured detail.
+- `structuredContent`: machine-readable JSON in the MCP `structuredContent`
   field.
 
 ## Tool groups
 
-| Group      | Tools                                                                                                       | API domain                     |
-| :--------- | :---------------------------------------------------------------------------------------------------------- | :----------------------------- |
-| Discovery  | get_customer_id, list_org_units, count_browser_versions, list_customer_profiles                             | Admin SDK, Chrome Management   |
-| Licensing  | check_cep_subscription, check_user_cep_license                                                              | Admin SDK (Licensing)          |
-| DLP        | list_dlp_rules, create_chrome_dlp_rule, delete_agent_dlp_rule, create_default_dlp_rules                     | Cloud Identity                 |
-| Detectors  | list_detectors, create_regex_detector, create_url_list_detector, create_word_list_detector, delete_detector | Cloud Identity                 |
-| Connectors | get_connector_policy, enable_chrome_enterprise_connectors                                                   | Chrome Policy                  |
-| Extensions | check_seb_extension_status, install_seb_extension                                                           | Chrome Policy                  |
-| Security   | get_chrome_activity_log, check_and_enable_cep_api                                                           | Admin SDK, Service Usage       |
-| Knowledge  | search_content, get_document, list_documents                                                                | Local knowledge base           |
-| Feedback   | cep_feedback                                                                                                | Local (writes diagnostic file) |
+| Group       | Tools                                                                                                       | API domain                   |
+| :---------- | :---------------------------------------------------------------------------------------------------------- | :--------------------------- |
+| Discovery   | get_customer_id, list_org_units, count_browser_versions, list_customer_profiles                             | Admin SDK, Chrome Management |
+| Licensing   | check_cep_subscription, check_user_cep_license                                                              | Admin SDK (Licensing)        |
+| DLP         | list_dlp_rules, get_dlp_rule, create_chrome_dlp_rule, delete_agent_dlp_rule, create_default_dlp_rules       | Cloud Identity               |
+| Detectors   | list_detectors, create_regex_detector, create_url_list_detector, create_word_list_detector, delete_detector | Cloud Identity               |
+| Connectors  | get_connector_policy, enable_chrome_enterprise_connectors                                                   | Chrome Policy                |
+| Extensions  | check_seb_extension_status, install_seb_extension                                                           | Chrome Policy                |
+| Security    | get_chrome_activity_log, check_and_enable_cep_api                                                           | Admin SDK, Service Usage     |
+| Diagnostics | diagnose_environment                                                                                        | Multi-API health check       |
+| Knowledge   | search_content, get_document, list_documents                                                                | Local knowledge base         |
 
 ## Feature-gated tools
 
@@ -66,9 +66,9 @@ Delete tools (`delete_agent_dlp_rule`, `delete_detector`) only register when
 
 ## Utilities (`utils/`)
 
-- `wrapper.js` — `guardedToolCall` and `formatToolResponse` (described above).
-- `org-unit.js` — Root org unit resolution with session caching.
-- `detector.js` — Shared helper for the three create-detector tools.
+- `wrapper.js`: `guardedToolCall` and `formatToolResponse` (described above).
+- `org-unit.js`: root org unit resolution with session caching.
+- `detector.js`: shared helper for the three create-detector tools.
 
 ## Shared schemas (`definitions/shared.js`)
 


### PR DESCRIPTION
## Summary

Bundled doc audit and restructuring. Independent of #7 and #8 (no overlap).

### Restructure
- Split the operations half of the root README into a new `docs/` directory: `configuration.md`, `troubleshooting.md`, `architecture.md`, `faq.md`, plus a `README.md` index.
- Trim root `README.md` from **635 → 325 lines**. The Quick Start (clone, install, auth, client config snippets, verify) stays fully intact in root, since that is the conversion path for viewers landing on the repo from the launch video.
- Add `lib/README.md` (was missing) as a five-line index of `lib/api/`, `lib/util/`, `lib/knowledge/`, and `lib/constants.js`.

### Stale claims fixed
- **`lib/api/README.md`**: removed the `fake_*_client.js` pattern it described — those files never existed. The actual pattern: instantiate the same `Real*Client` with `{ rootUrl, auth: fakeAuth }` to redirect at the in-process Express fake server (`test/helpers/fake-api-server.js`). Cross-checked against `mcp-server.js` and `test/helpers/integration/tools/client_factory.js`.
- **`lib/api/README.md` legacy-wrappers section**: previously claimed `chromepolicy.js` was unused. It actually still exports `ConnectorPolicyFilter`, which `tools/definitions/get_connector_policy.js` and `tools/definitions/diagnose_environment.js` import. Updated to call this out and note the prerequisite for deletion.
- **`tools/README.md` Tool Groups table**: removed the `cep_feedback` row (no such tool exists in the codebase), added `get_dlp_rule` to the DLP row, and added a Diagnostics row for `diagnose_environment` (which existed but was unlisted).
- **Root `README.md` Development**: corrected misleading "after merge, postsubmit adds a real-API run" to reflect that postsubmit runs the full presubmit suite *plus* the real-API integration pass.

### Content additions surfaced by the launch video
- `docs/configuration.md`: paragraph on the OAuth roadmap — today, OAuth requires a BYO client; a Google-managed OAuth client for CEP is coming.
- `docs/troubleshooting.md`: the `/mcp` reload tip when CEP tools do not show up after a client restart.

### Smaller fixes
- Trimmed eval-command duplication in `test/evals/README.md:266–298` to lead with the four npm scripts and reference the runner's `--help` block.
- Style pass on edited files: close-set em-dashes (`word—word`), colons inside boldface for `**Term:**` definition-list patterns, and semicolons where a single em-dash was joining two complete clauses.

## Out of scope (not in this PR)
- Stripping eval aliases (`eval:agentic`, `eval:full`, `eval:knowledge`) — both READMEs reference each one; kept all four.
- Per-tool documentation under `tools/` — `tools/README.md` covers the registration pattern; tool-specific docs are not needed.
- Knowledge-base content review (`lib/knowledge/*.md`) — those are domain content, not project docs.
- A separate `docs/development.md` — `CONTRIBUTING.md` and `test/README.md` already serve that role.
- Sweeping the existing Quick Start's prose style — left as-is to keep the diff focused.

## Test plan

- [x] `npx prettier --check .` passes on the full tree.
- [x] `npm run presubmit` passes locally (verified via husky pre-commit hook).
- [x] Every link in the new root `README.md` and new `docs/*.md` files resolves to an existing file.
- [x] All `lib/api/*` claims cross-checked against `mcp-server.js`, `client_factory.js`, and the actual file listing in `lib/api/`.
- [x] All `tools/README.md` table entries cross-checked against `tools/definitions/` directory contents and `tools/index.js` registrations.
- [ ] CI green on this PR.