### PR TITLE
docs: document CI workflow and read-only presubmit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,11 +27,11 @@ This project follows
 
 If you encounter an issue, please file a GitHub issue with the following:
 
-1. **Generate a diagnostic report** — in your Gemini CLI session, use the `/bug`
-   command. This creates a diagnostic file with session logs and environment
-   details. Attach it to the issue.
+1. **Generate a diagnostic report.** In your Gemini CLI session, use the
+   `/bug` command. This creates a diagnostic file with session logs and
+   environment details. Attach it to the issue.
 
-2. **Run presubmit** — run `npm run presubmit` and include the output. This
+2. **Run presubmit.** Run `npm run presubmit` and include the output. This
    helps determine whether the issue is environmental or a code bug.
 
 3. **Describe what you expected** vs. what actually happened, including the
@@ -77,7 +77,20 @@ npm run test:integration:real # Integration tests against real Google APIs
 ### Linting and formatting
 
 ```bash
-npm run lint          # Check for errors
-npm run lint -- --fix # Auto-fix
-npm run format        # Prettier
+npm run lint          # Check for errors (read-only)
+npm run lint -- --fix # Auto-fix lint
+npm run format        # Auto-fix formatting (Prettier)
 ```
+
+`npm run presubmit` runs `prettier --check` and `eslint` in read-only mode;
+it will fail rather than auto-fix. The husky pre-commit hook fixes staged
+files via lint-staged on commit, so a clean working tree usually passes.
+
+### Continuous integration
+
+Pull requests trigger four parallel jobs on GitHub Actions: `lint`,
+`test-unit`, `test-integration-fake`, and `test-smoke`. Each maps to one of
+the `npm run` scripts above. Jobs run hermetically (no ADC), so any test
+that inadvertently reaches `getAuthClient()` fails fast with a named error
+instead of timing out on metadata-server discovery. The workflow is at
+[`.github/workflows/node.js.yml`](.github/workflows/node.js.yml).

--- a/README.md
+++ b/README.md
@@ -270,6 +270,16 @@ integration tests, and a smoke test against the in-process fake API server;
 no credentials needed. After merge, `npm run postsubmit` re-runs the full
 presubmit suite plus a real-API integration pass.
 
+Presubmit is **read-only**. If formatting or lint fails, run
+`npm run format` and `npm run lint:fix` to fix, then re-run. The husky
+pre-commit hook auto-fixes staged files via lint-staged, so commits from a
+clean working tree usually pass without manual fixup.
+
+GitHub Actions runs the same checks on every pull request as four parallel
+jobs (`lint`, `test-unit`, `test-integration-fake`, `test-smoke`); each
+failure shows up as a separate PR check. The workflow is at
+[`.github/workflows/node.js.yml`](.github/workflows/node.js.yml).
+
 ```bash
 npm run presubmit               # Required before every PR
 npm run postsubmit              # After merge (real API credentials)


### PR DESCRIPTION
## Merge order

**Do not merge until all of the following have landed in `main`:**

| PR | What it adds | Why this PR depends on it |
| :- | :----------- | :------------------------ |
| #7 | `.github/workflows/node.js.yml` (CI) | This PR's wording references that workflow file. |
| #8 | Read-only `presubmit` script | This PR's wording says "presubmit is read-only". Until #8 merges, presubmit still auto-formats and the wording is wrong. |
| #9 | New `docs/` directory + restructured root README | This PR is stacked on `docs/audit-and-restructure` (#9's branch). |

**Recommended sequence:** #7 → #8 → #9 → this PR.

If #9 is squash-merged, this PR will need a manual rebase (`git rebase --onto main docs/audit-and-restructure docs/ci-and-readonly-presubmit`) before merging. Merge-commit or rebase-and-merge of #9 lets GitHub auto-update this PR's base.

## Summary

We update the docs to match the state of `main` after #7 and #8 land:

- In the root `README.md` Development section, we note the read-only presubmit, point devs at `npm run format` / `npm run lint:fix` for fixing failures, mention the husky pre-commit hook, and describe the four parallel CI jobs.
- In `CONTRIBUTING.md`, we add a Continuous Integration subsection covering the same four jobs and the hermetic auth env, and we make the read-only nature of presubmit explicit in the Linting section.
- We rewrite the Reporting bugs list intros to use colons inside boldface (style consistency with #9).

## Out of scope

- Changes to `.github/workflows/node.js.yml` (handled by #7).
- Changes to `npm run` scripts (handled by #8).
- New cosmetic artifacts (badges, banners, TOCs).

## Test plan

- [x] `npm run presubmit` exits 0 locally on this branch.
- [x] `prettier --check .` exits 0 on the diff.
- [ ] After #7 + #8 + #9 merge, confirm the file references in CONTRIBUTING.md still resolve and the Development section wording matches the read-only behavior.
- [ ] CI green on this PR (only meaningful once #7 lands).