### PR TITLE
chore: simplify DLP rule and posture review prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ For environment variables and stdio vs. HTTP transport, see
 | Prompt         | Description                                                                            |
 | :------------- | :------------------------------------------------------------------------------------- |
 | `cep:health`   | Health check of the Chrome Enterprise environment (APIs, DLP, connectors, extensions). |
-| `cep:optimize` | Rule optimization and maturity assessment.                                             |
+| `cep:optimize` | Rule-by-rule review with tuning, enforcement, and cleanup recommendations.             |
 | `cep:expert`   | Manually re-injects the expert persona and rules (useful if the agent loses context).  |
 
 ### Tools

--- a/lib/knowledge/12-security-posture-guide.md
+++ b/lib/knowledge/12-security-posture-guide.md
@@ -1,53 +1,45 @@
 ---
-title: CEP Security Posture & Remediation Guide
+title: CEP Security Posture Assessment Heuristics
 articleId: '12'
-summary: 'Definitive roadmap for improving security posture using the CEP Maturity Model (Tiers 0-3). Helps administrators transition from visibility to active protection. Covers the critical "Telemetry Dependency" (logs require active rules) and remediation for each tier. Keywords: Maturity Tiers, Starter Pack rules, Telemetry Dependency, SEB extension requirements.'
+summary: 'Internal evaluation criteria the agent uses to assess a Chrome Enterprise Premium environment and recommend next steps. Walks through whether the prerequisites (licenses, connectors, SEB extension) are present, whether DLP rules exist, whether they are tuned, and whether they are enforcing. Covers the telemetry dependency (logs require active rules). For agent-internal use only — do not surface labels or framework names to users.'
 ---
 
-# CEP Security Posture & Remediation Guide
+# CEP Security Posture Assessment
 
-This guide is the primary technical reference for improving a Chrome Enterprise Premium (CEP) environment. To provide effective advice, first **Diagnose** the environment using `diagnose_environment` and **Assess** the current Maturity Tier based on the criteria below.
+These criteria help the agent decide what to recommend after running `diagnose_environment`. They are agent-internal — describe findings to the user in plain language without quoting category names from this article.
 
-## Maturity Tiers
+## Step 1: Are the prerequisites in place?
 
-### Tier 0: Foundation (Prerequisites)
-
-**Criteria**: Missing CEP licenses, unconfigured connectors, or missing Secure Enterprise Browser (SEB) extension.
-**Goal**: Establish the infrastructure for scanning and enforcement.
-**Remediation Steps**:
+Look for missing CEP licenses, unconfigured Content Analysis Connectors, or a missing Secure Enterprise Browser (SEB) extension. If any are missing, recommend:
 
 1.  **Licenses**: Assign CEP licenses to all managed users.
 2.  **Connectors**: Enable and configure all Content Analysis Connectors (Upload, Download, Paste, Print, URL Check) at the Root OU.
-3.  **SEB Extension**: Force-install the Secure Enterprise Browser extension (ID: `ekajlcmdfcigmdbphhifahdfjbkciflj`) to enable advanced features like data masking.
+3.  **SEB extension**: Force-install the Secure Enterprise Browser extension (ID: `ekajlcmdfcigmdbphhifahdfjbkciflj`) so the environment can use advanced features like data masking.
 
-### Tier 1: Visibility (Initial Monitoring)
+If the prerequisites are missing, the recommendations below do not yet apply — those gaps must close first.
 
-**Criteria**: Foundation is present, but there are zero or very few DLP rules.
-**Goal**: Establish visibility into sensitive data flows to identify real-world risk.
-**Visibility Strategy**:
+## Step 2: Are there any DLP rules?
 
-1.  **Telemetry Dependency**: Security logs for data-centric events (e.g., sensitive data hits) are only populated when a corresponding rule is active. If logs are empty, it likely indicates a lack of active monitoring rules.
-2.  **Visibility Options**:
-    - **Broad Baseline**: Deploying broad `AUDIT` rules (e.g., a "Starter Pack") provides a comprehensive view of high-risk data flows across the organization.
-    - **Incremental Discovery**: For organizations with strict change controls, start with specific `AUDIT` rules targeting known sensitive domains or high-risk detectors (e.g., PII in uploads).
-3.  **Data-Driven Refinement**: Once logs are populating, use `get_chrome_activity_log` to identify patterns and transition to Tier 2.
+If the prerequisites are in place but the environment has zero or very few rules:
 
-### Tier 2: Monitoring (Established Baseline)
+1.  **Telemetry dependency**: Security logs for data-centric events (e.g., sensitive-data hits) only populate when a corresponding rule is active. If logs are empty, the absence of rules is the reason.
+2.  **Visibility options**:
+    - **Broad baseline**: Deploy broad `AUDIT`-mode rules (a "starter pack") for a comprehensive view of high-risk data flows.
+    - **Incremental discovery**: For organizations with strict change controls, deploy targeted `AUDIT` rules covering known-sensitive domains or specific high-risk detectors first.
+3.  **Data-driven refinement**: Once `AUDIT` logs populate, use `get_chrome_activity_log` to identify patterns and move on to tuning.
 
-**Criteria**: DLP rules exist but are predominantly in `AUDIT` mode.
-**Goal**: Tune rules for high fidelity and zero false positives.
-**Remediation Steps**:
+## Step 3: Are the existing rules tuned?
 
-1.  **Log Review**: Analyze audit logs to identify noise or false positives.
-2.  **Rule Tuning**: Adjust match thresholds, refine URL categories, or add destination constraints based on real-world usage.
-3.  **Trigger Expansion**: Ensure coverage across all relevant triggers (Upload, Paste, Download, etc.).
+If rules exist but are predominantly in `AUDIT` mode:
 
-### Tier 3: Protection (Enforcement)
+1.  **Log review**: Analyze audit logs to spot noise or false positives.
+2.  **Rule tuning**: Adjust match thresholds, refine URL categories, add destination constraints based on real-world usage.
+3.  **Trigger coverage**: Confirm rules cover the relevant triggers (Upload, Paste, Download, Print, URL Check) for the data types in scope.
 
-**Criteria**: Rules are tuned, high-fidelity, and cover critical egress points.
-**Goal**: Actively prevent data exfiltration.
-**Remediation Steps**:
+## Step 4: Are the rules enforcing?
 
-1.  **Transition to Enforcement**: Change stable, high-fidelity rules from `AUDIT` to `WARN` or `BLOCK`.
-2.  **Data Masking**: Implement Hard or Light obfuscation for sensitive data in the browser for specific URLs.
-3.  **Continuous Audit**: Perform weekly reviews of `BLOCK` events to ensure business continuity.
+If rules are tuned and high-fidelity:
+
+1.  **Transition to enforcement**: Move stable, high-fidelity rules from `AUDIT` to `WARN` or `BLOCK`.
+2.  **Data masking**: Apply hard or light obfuscation for sensitive data inside the browser for specific URLs.
+3.  **Continuous audit**: Review `BLOCK` events weekly to keep business continuity in view.

--- a/lib/knowledge/12-security-posture-guide.md
+++ b/lib/knowledge/12-security-posture-guide.md
@@ -10,36 +10,50 @@ These criteria help the agent decide what to recommend after running `diagnose_e
 
 ## Step 1: Are the prerequisites in place?
 
-Look for missing CEP licenses, unconfigured Content Analysis Connectors, or a missing Secure Enterprise Browser (SEB) extension. If any are missing, recommend:
+Look for missing CEP licenses, unconfigured Content Analysis Connectors, or a missing Secure Enterprise Browser (SEB) extension.
+
+**Directive**: If any prerequisite is missing, the agent MUST recommend closing those gaps before suggesting any DLP rule work. DLP rules cannot scan content while connectors are off, and data-masking features depend on the SEB extension. Surface this dependency explicitly; do not list rule recommendations alongside foundation gaps.
+
+**What to recommend**:
 
 1.  **Licenses**: Assign CEP licenses to all managed users.
 2.  **Connectors**: Enable and configure all Content Analysis Connectors (Upload, Download, Paste, Print, URL Check) at the Root OU.
 3.  **SEB extension**: Force-install the Secure Enterprise Browser extension (ID: `ekajlcmdfcigmdbphhifahdfjbkciflj`) so the environment can use advanced features like data masking.
 
-If the prerequisites are missing, the recommendations below do not yet apply — those gaps must close first.
-
 ## Step 2: Are there any DLP rules?
 
-If the prerequisites are in place but the environment has zero or very few rules:
+If the prerequisites are in place but the environment has zero or very few rules.
 
-1.  **Telemetry dependency**: Security logs for data-centric events (e.g., sensitive-data hits) only populate when a corresponding rule is active. If logs are empty, the absence of rules is the reason.
-2.  **Visibility options**:
+**Directive**: The agent MUST analyze the activity log first to anchor any rule recommendations in real-world usage patterns, even though the log will be sparse here (security logs for data-centric events only populate when a rule is active). New rules MUST start in `AUDIT` mode; do not propose creating a rule directly in `WARN` or `BLOCK` from this state.
+
+**What to recommend (in order)**:
+
+1.  **Activity-log review first**: Call `get_chrome_activity_log` and report what's in it. If sparse or empty, name that explicitly — that's the consequence of having no rules.
+2.  **Pick a deployment style**:
     - **Broad baseline**: Deploy broad `AUDIT`-mode rules (a "starter pack") for a comprehensive view of high-risk data flows.
     - **Incremental discovery**: For organizations with strict change controls, deploy targeted `AUDIT` rules covering known-sensitive domains or specific high-risk detectors first.
-3.  **Data-driven refinement**: Once `AUDIT` logs populate, use `get_chrome_activity_log` to identify patterns and move on to tuning.
+3.  **Plan the next review**: Once `AUDIT` logs populate, the agent should re-run the assessment to identify patterns and move on to tuning.
 
 ## Step 3: Are the existing rules tuned?
 
-If rules exist but are predominantly in `AUDIT` mode:
+If rules exist but are predominantly in `AUDIT` mode.
 
-1.  **Log review**: Analyze audit logs to spot noise or false positives.
-2.  **Rule tuning**: Adjust match thresholds, refine URL categories, add destination constraints based on real-world usage.
-3.  **Trigger coverage**: Confirm rules cover the relevant triggers (Upload, Paste, Download, Print, URL Check) for the data types in scope.
+**Directive**: The agent MUST prioritize tuning noisy audit-only rules over adding new ones. Before recommending changes, correlate `get_chrome_activity_log` events to specific rules and identify the highest-volume offenders. A rule that fires disproportionately is a false-positive risk, not proof of value.
+
+**What to recommend (priority order)**:
+
+1.  **Identify the noisy rule(s)**: Use the activity log to find rules generating a disproportionate share of events. Lead the recommendations with those rules.
+2.  **Tighten the noisy rule**: Adjust match thresholds, refine URL categories, or add destination constraints based on observed traffic. Provide a concrete patch (CEL or JSON) when proposing changes.
+3.  **Confirm trigger coverage**: After tuning, verify rules cover the relevant triggers (Upload, Paste, Download, Print, URL Check) for the data types in scope.
 
 ## Step 4: Are the rules enforcing?
 
-If rules are tuned and high-fidelity:
+If rules are tuned and high-fidelity (in `WARN` or `BLOCK`, with low false-positive rates).
 
-1.  **Transition to enforcement**: Move stable, high-fidelity rules from `AUDIT` to `WARN` or `BLOCK`.
-2.  **Data masking**: Apply hard or light obfuscation for sensitive data inside the browser for specific URLs.
-3.  **Continuous audit**: Review `BLOCK` events weekly to keep business continuity in view.
+**Directive**: The agent MUST focus on maintaining enforcement and expanding coverage carefully. Do not recommend new `BLOCK` rules without first staging them in `AUDIT` mode (the safety guardrail in the system prompt enforces this — `BLOCK` rules cannot be created in `ACTIVE` state by the agent). Continuous-audit recommendations take priority over policy expansion.
+
+**What to recommend (focus areas)**:
+
+1.  **Maintain enforcement**: Keep stable, high-fidelity rules in `WARN` or `BLOCK`. Recommend a weekly review of `BLOCK` events to keep business continuity in view.
+2.  **Expand coverage carefully**: When proposing new coverage, stage it in `AUDIT` mode first; promote to `WARN` or `BLOCK` only after the audit logs confirm low false-positive rates.
+3.  **Apply data masking**: Implement hard or light obfuscation for sensitive data in the browser for specific URLs where that's appropriate.

--- a/lib/knowledge/15-rule-quality-guidelines.md
+++ b/lib/knowledge/15-rule-quality-guidelines.md
@@ -1,86 +1,76 @@
 ---
-title: 'Rule Quality Guidelines'
-summary: 'Framework for evaluating and optimizing DLP rule quality using the MECE (Mutually Exclusive, Collectively Exhaustive) model. Helps reduce false positives and establish high-fidelity enforcement. Covers heuristics for "Shotgun Triggers", "Context Blindness", and "Audit First" deployment. Keywords: MECE framework, Shotgun Triggers, Context Blindness, rule tuning, JSON payload optimization.'
+title: 'DLP Rule Evaluation Heuristics'
+summary: 'Internal evaluation criteria the agent uses to identify logic flaws and noise in Chrome Enterprise Premium DLP rule JSON. Covers context blindness (missing destination vectors), false negatives from broad file-type exclusions, root-OU over-scoping, low match thresholds that cause false positives, missing compound logic, mixed triggers, disproportionate actions, audit-first deployment, and orphaned rules. For agent-internal use only — do not surface heuristic names or category labels to users.'
 articleId: 15
 ---
 
-Analyze the provided Chrome Enterprise Premium (CEP) Data Loss Prevention (DLP) API configurations (raw JSON arrays). Apply the following MECE framework—grounded in factual CEP API heuristics—to identify logic flaws, eliminate noise, and generate optimized, ready-to-deploy JSON/CEL payloads.
+# DLP Rule Evaluation Heuristics
 
-<agent_steering_protocol>
+These heuristics help the agent inspect DLP rule JSON and recommend specific tuning, enforcement, or cleanup actions. They are agent-internal — translate every finding into plain administrator-facing language. Do not name a heuristic, number it, or group it under any taxonomy in your reply to the user.
 
-1. Prioritize Logic Over Intent: Ignore the `displayName`. You MUST evaluate the explicit CEL operators (`AND`, `OR`, `NOT`), the `triggers` array, and the `action` fields.
-2. Limit Assumptions: Only flag issues supported by the raw JSON payload provided.
-3. Generate Corrected Payloads: Do not just offer advice. For every rule that violates the heuristics below, you must generate a corrected, valid JSON or CEL snippet that implements the tuning action.
-   </agent_steering_protocol>
+## Steering rules
 
-<mece_api_heuristics_framework>
-<dimension_1_coverage_and_scope>
-<heuristic_context_blindness>
-Fact: If `trigger` is `WEB_CONTENT_UPLOAD` or `URL_NAVIGATION` but the CEL `condition` lacks a destination vector (e.g., no `url_navigation.destination.domain` or `google.workspace.chrome.url.category` restrictions), it represents a noisy "Catch-All" pattern.
-Tuning Action: Inject CEL constraints restricting matching solely to high-risk egress channels like unmanaged cloud uploads or personal webmail.
-</heuristic_context_blindness>
+1. **Logic over intent.** Ignore `displayName`. Evaluate the explicit CEL operators (`AND`, `OR`, `NOT`), the `triggers` array, and the `action` fields.
+2. **Limit assumptions.** Flag only issues supported by the raw JSON payload provided.
+3. **Generate corrected payloads.** For every rule that matches a heuristic below, produce a corrected, valid JSON or CEL snippet that implements the recommended change.
 
-    <heuristic_false_negatives_over_scoping>
-      Fact: If the CEL condition contains broad file-type exclusions (e.g., `!file.name.endsWith('.docx')` or `!file.type.contains('excel')`), it creates massive security blind spots (false negatives).
-      Tuning Action: Remove the broad format exclusion and replace it with a higher match threshold or targeted recipient boundaries in the CEL snippet.
-    </heuristic_false_negatives_over_scoping>
+## Heuristics
 
-    <heuristic_root_ou_targeting>
-      Fact: Policies applied to the Root OU without Context-Aware Access (CAA) device signals (e.g., ignoring `device.managed == true`) over-scope the deployment.
-      Tuning Action: Require explicit inclusion groups or CAA binding.
-    </heuristic_root_ou_targeting>
+### Context blindness
 
-</dimension_1_coverage_and_scope>
+If `trigger` is `WEB_CONTENT_UPLOAD` or `URL_NAVIGATION` but the CEL `condition` lacks a destination vector (e.g., no `url_navigation.destination.domain` or `google.workspace.chrome.url.category` restriction), the rule is a noisy "catch-all".
+**Recommended change:** Inject CEL constraints restricting matches to high-risk egress channels — unmanaged cloud uploads, personal webmail, etc.
 
-<dimension_2_efficacy_and_accuracy>
-<heuristic_threshold_sensitivities>
-Fact: If the payload contains an infoType or detector for broad numerical patterns (like SSN or Credit Card) with a `minimum_match_count` or threshold of 1, it produces massive false-positive noise.
-Tuning Action: Increase the instance threshold to target bulk exfiltration.
-</heuristic_threshold_sensitivities>
+### Broad file-type exclusion
 
-    <heuristic_compound_conditions>
-      Fact: If an identifier rule lacks proximity or compound logic, it triggers on random numbers. High-fidelity rules require a multi-part compound condition.
-      Tuning Action: Output a corrected boolean `AND` block in CEL that chains the primary pattern with a secondary dictionary match (e.g., requiring keywords like "Visa" or "Invoice" within 10 to 50 terms).
-    </heuristic_compound_conditions>
+If the CEL condition contains broad file-type exclusions (e.g., `!file.name.endsWith('.docx')` or `!file.type.contains('excel')`), it creates large blind spots.
+**Recommended change:** Remove the broad format exclusion. Use a higher match threshold or targeted recipient boundaries instead.
 
-    <heuristic_shotgun_triggers>
-      Fact: If the `triggers` array combines unrelated actions (e.g., `[FILE_UPLOAD, FILE_DOWNLOAD, PRINT, CLIPBOARD_COPY]`) in a single rule, precision tuning is impossible.
-      Tuning Action: Split the rule. Output distinct JSON payloads mapping one specific action to one specific data type.
-    </heuristic_shotgun_triggers>
+### Root-OU targeting without device signals
 
-</dimension_2_efficacy_and_accuracy>
+Policies applied to the Root OU without Context-Aware Access (CAA) device signals (e.g., ignoring `device.managed == true`) over-scope the deployment.
+**Recommended change:** Require explicit inclusion groups or CAA binding before applying broad enforcement.
 
-<dimension_3_business_friction>
-<heuristic_action_proportionality>
-Fact: If `action == 'BLOCK'` on a rule containing broad scopes (Dimension 1) or low thresholds (Dimension 2), it causes immediate, unwarranted helpdesk traffic.
-Tuning Action: Downgrade the `action` to `WARN` and inject user override/justification parameters into the JSON payload. This turns friction into an educational event.
-</heuristic_action_proportionality>
-</dimension_3_business_friction>
+### Threshold sensitivity
 
-<dimension_4_lifecycle_and_hygiene>
-<heuristic_audit_first>
-Fact: Bypassing `AUDIT` mode during initial deployment prevents the establishment of a baseline profile.
-Tuning Action: Ensure newly defined or untested rules default to `AUDIT` mode.
-</heuristic_audit_first>
+If the payload contains a detector for broad numerical patterns (SSN, credit-card) with a `minimum_match_count` or threshold of 1, it produces large volumes of false positives.
+**Recommended change:** Increase the instance threshold so the rule targets bulk exfiltration rather than incidental matches.
 
-    <heuristic_orphaned_state>
-      Fact: `state == 'INACTIVE'` rules or rules missing `target_resources` bindings create technical debt.
-      Tuning Action: Flag inactive rules for deletion or missing targets for explicit scoping.
-    </heuristic_orphaned_state>
+### Missing compound logic
 
-</dimension_4_lifecycle_and_hygiene>
-</mece_api_heuristics_framework>
+If an identifier rule lacks proximity or compound logic, it triggers on random numbers. High-fidelity rules need a multi-part compound condition.
+**Recommended change:** Output a corrected boolean `AND` block in CEL that chains the primary pattern with a secondary dictionary match (e.g., requiring keywords like "Visa" or "Invoice" within 10–50 terms).
 
-<output_format>
-For every rule evaluated:
+### Mixed triggers in a single rule
 
-1. Rule Name / ID
-2. Diagnosed Flaw: State the diagnosed flaw directly mapped to the specific API heuristic above.
-3. Remediation: Output a remediated JSON or CEL block establishing the proper compound conditions, thresholds, destination vectors, or override actions.
-   </output_format>
+If the `triggers` array combines unrelated actions (e.g., `[FILE_UPLOAD, FILE_DOWNLOAD, PRINT, CLIPBOARD_COPY]`), precise tuning is impossible.
+**Recommended change:** Split the rule. Output distinct JSON payloads, one specific action mapped to one specific data type per rule.
 
-<reporting_constraints>
+### Disproportionate action for the scope
 
-- DO NOT use internal tool names in your output. Translate findings into user-facing administrative language.
+If `action == 'BLOCK'` on a rule with broad scope or low threshold, it generates immediate helpdesk traffic.
+**Recommended change:** Downgrade `action` to `WARN`. Inject user override / justification parameters into the JSON payload to turn friction into an educational event.
+
+### Audit-first not respected
+
+A new rule that bypasses `AUDIT` mode prevents the establishment of a baseline.
+**Recommended change:** Default new and untested rules to `AUDIT` mode.
+
+### Orphaned state
+
+`state == 'INACTIVE'` rules and rules missing `target_resources` bindings accumulate as technical debt.
+**Recommended change:** Flag inactive rules for deletion. Flag rules with missing targets so they can be scoped explicitly.
+
+## Output format (per rule)
+
+For every rule the heuristics flag:
+
+1. Rule name and ID.
+2. **What we found:** The specific issue, mapped back to the rule's JSON. Do not name the heuristic in your reply.
+3. **Recommended change:** Plain-language action.
+4. **Patch:** Corrected JSON or CEL block establishing proper compound conditions, thresholds, destination vectors, or override actions.
+
+## Reporting constraints
+
+- Do not use internal tool names or heuristic names in your output. Translate findings into administrator-facing language.
 - Use standard straight quotes inside JSON/CEL code blocks.
-  </reporting_constraints>

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -31,11 +31,11 @@ agent through complex diagnostic and optimization workflows.
 
 ## Current prompts
 
-| Name           | File          | Description                                            |
-| :------------- | :------------ | :----------------------------------------------------- |
-| `cep:health`   | `health.js`   | Health check of the Chrome Enterprise environment.     |
-| `cep:optimize` | `optimize.js` | Rule optimization and maturity assessment.             |
-| `cep:expert`   | `expert.js`   | Loads the full expert persona from `system-prompt.md`. |
+| Name           | File          | Description                                                                |
+| :------------- | :------------ | :------------------------------------------------------------------------- |
+| `cep:health`   | `health.js`   | Health check of the Chrome Enterprise environment.                         |
+| `cep:optimize` | `optimize.js` | Rule-by-rule review with tuning, enforcement, and cleanup recommendations. |
+| `cep:expert`   | `expert.js`   | Loads the full expert persona from `system-prompt.md`.                     |
 
 ## Shared diagnostic rules (`definitions/shared.js`)
 

--- a/prompts/definitions/optimize.js
+++ b/prompts/definitions/optimize.js
@@ -38,7 +38,7 @@ export const registerOptimizePrompt = server => {
   server.registerPrompt(
     OPTIMIZE_PROMPT_NAME,
     {
-      description: 'Perform a consultative analysis of DLP maturity, rule noise, and quality.',
+      description: "Review the environment's DLP rules and recommend specific tuning, enforcement, or cleanup actions.",
       arguments: [],
     },
     async () => {
@@ -49,46 +49,44 @@ export const registerOptimizePrompt = server => {
             role: 'user',
             content: {
               type: 'text',
-              text: `Perform a consultative analysis of the Chrome Enterprise Premium environment's DLP maturity and rule quality.
+              text: `Review the Chrome Enterprise Premium environment's DLP rules and recommend concrete tuning, enforcement, or cleanup actions.
 
-Call the **diagnose_environment** tool to get a complete environment snapshot. Call the **get_chrome_activity_log** tool to analyze recent activity patterns and DLP events.
+Call **diagnose_environment** to snapshot the current state. Call **get_chrome_activity_log** to surface recent DLP event volume per rule.
 
-**Assessment Protocols:**
-1. **Retrieve Maturity Framework**: Call **get_document** with **filename: 12** to retrieve the "CEP Security Posture & Remediation Guide". Use this to classify the environment into a Maturity Tier (0-3).
-2. **Apply Quality Guidelines**: Use the following "Rule Optimization Framework" to identify logic flaws and noise:
+Call **get_document** with **filename: 12** to load the internal posture-assessment criteria. Apply the rule-evaluation heuristics below to identify logic flaws and noise:
 
 ${guidelinesContent}
 
+These heuristics and posture criteria are internal evaluation aids. Do not name them, group them, or quote their wrappers in your reply. Translate every finding into plain administrator-facing language.
+
 **Required Output Format:**
 
-### Maturity Assessment
-Identify the current **Maturity Tier (0-3)** based on the environment baseline and current rule status.
-- If in **Tier 0 (Foundation)**, list the specific missing prerequisites (Licenses, Connectors, or SEB extension).
-- If in **Tier 1 (Visibility)**, you MUST analyze activity logs to identify real-world usage patterns before suggesting any new rules.
-- If in **Tier 2 (Monitoring)**, prioritize tuning noisy audit-only rules.
-- If in **Tier 3 (Protection)**, focus on maintaining enforcement and expanding coverage.
+### Environment summary
 
-### Identified Rule Optimizations
-For every rule that violates the assessment framework OR generates a disproportionately high volume of events in the activity logs, provide a structured breakdown:
+A concise paragraph describing what's in place (licenses, connectors, SEB extension, rule count, audit-vs-enforcement balance) and what's missing. Lead with the most consequential gap. Do not use tier labels, framework names, or model numbers.
 
-#### Optimization [Number]: [Rule Name] (ID: [ID])
-* **The Issue:** State the specific MECE dimension violation (e.g., Context Blindness, Threshold Sensitivity) or indicate "High Event Volume".
-* **What I found:** Describe the specific finding in the rule logic or event history that triggered this diagnosis. Compare event volume per rule to identify noisy rules.
-* **The Fix:** State the recommended tuning action in professional English.
-* **The Patch:** Provide the optimized JSON or CEL block (if applicable).
+### Rule findings
 
-### How I Can Help You Next
-List the specific actions you can take to improve the environment, such as:
-* **Update Rules:** Offer to deploy the specific patches listed above.
-* **Change Enforcement:** Offer to transition specific rules from AUDIT to WARN.
-* **Clean Up:** Offer to delete specific inactive or orphaned rules.
+For each rule that violates a heuristic or generates disproportionate event volume:
 
-**Tone and Voice Guardrails:**
-- Use active voice with human subjects.
-- Be direct. State the point, support it, and move on.
-- Avoid rhetorical flourishes, dramatic one-liners, and throat-clearing transitions.
-- Use headers for structure and bullets for parallel items.
-- NEVER mention internal tool names (e.g., diagnose_environment) in your final response.`,
+#### [Rule name] (ID: [policy id])
+* **What we found:** Describe the specific issue in the rule's logic or event history.
+* **Why it matters:** One sentence on the user impact (false positives, blind spots, helpdesk friction).
+* **Recommended change:** Plain-language action.
+* **Patch:** Optimized JSON or CEL block when applicable.
+
+### Suggested next actions
+
+Offer specific follow-ups the agent can execute on request, such as:
+* Deploying the patches listed above.
+* Transitioning specific rules from AUDIT to WARN.
+* Deleting specific inactive or orphaned rules.
+
+**Tone and voice:**
+- Active voice, human subjects.
+- Direct: state the point, support it, move on.
+- Headers for structure, bullets for parallel items.
+- Never mention internal tool names, framework names, tier numbers, or evaluation-criteria labels in your reply.`,
             },
           },
         ],

--- a/prompts/definitions/optimize.js
+++ b/prompts/definitions/optimize.js
@@ -59,21 +59,34 @@ ${guidelinesContent}
 
 These heuristics and posture criteria are internal evaluation aids. Do not name them, group them, or quote their wrappers in your reply. Translate every finding into plain administrator-facing language.
 
-**Required Output Format:**
+**Required Output Format (the order of these sections is mandatory):**
 
 ### Environment summary
 
 A concise paragraph describing what's in place (licenses, connectors, SEB extension, rule count, audit-vs-enforcement balance) and what's missing. Lead with the most consequential gap. Do not use tier labels, framework names, or model numbers.
 
+### What the logs show
+
+Lead this section with what the activity log told you, before any rule-config analysis. Cover:
+* Total DLP events in the window the log returned (and how recent the most recent event was).
+* Per-rule event volume — which rules are firing the most, which are firing once or twice, which are not firing at all. Include a bullet list with the rule name and the count.
+* Cross-rule patterns — single users hitting many rules, single rules hitting many users, time-of-day spikes, audit-vs-enforcement skew, or whatever else stands out.
+* The headline read of the volume: is one rule generating most of the noise, is the volume spread evenly across rules, or is the volume low across the board (in which case there is no high-noise rule and that itself is the finding).
+
+If the activity log is empty or near-empty, state that plainly here. Do not skip this section just because volume is low — the absence of events is itself a useful observation, especially when rules exist.
+
 ### Rule findings
 
-For each rule that violates a heuristic or generates disproportionate event volume:
+For each rule that needs attention — anchored in what the logs above showed, then layered with rule-quality heuristics:
 
 #### [Rule name] (ID: [policy id])
-* **What we found:** Describe the specific issue in the rule's logic or event history.
-* **Why it matters:** One sentence on the user impact (false positives, blind spots, helpdesk friction).
+* **What the logs show for this rule:** Event count from the section above and any pattern specific to this rule (single user, particular trigger, spike, etc.). If the rule has zero events, say so.
+* **What we found in the rule logic:** Describe the heuristic-based issue in the rule's configuration. Skip this bullet only when the rule's logic is fine and the issue is purely volume.
+* **Why it matters:** One sentence on the user impact (false positives, blind spots, helpdesk friction, dead-letter rules).
 * **Recommended change:** Plain-language action.
 * **Patch:** Optimized JSON or CEL block when applicable.
+
+If no rule needs attention because volume is low and configurations are reasonable, write a single sentence saying so. Do not invent issues to fill the section.
 
 ### Suggested next actions
 
@@ -81,6 +94,7 @@ Offer specific follow-ups the agent can execute on request, such as:
 * Deploying the patches listed above.
 * Transitioning specific rules from AUDIT to WARN.
 * Deleting specific inactive or orphaned rules.
+* Continuing to monitor when volume is low and rules are reasonable.
 
 **Tone and voice:**
 - Active voice, human subjects.

--- a/prompts/system-prompt.md
+++ b/prompts/system-prompt.md
@@ -29,10 +29,10 @@ _Example:_ If you encounter `[DLP Core Features](4-dlp-core-features.md)`, call 
 
 When a user asks for security advice or "Next Steps":
 
-1.  **Diagnose**: Call `diagnose_environment` to assess the current posture.
-2.  **Assess Tier**: Reference the **CEP Security Posture & Remediation Guide** (Document 12) to identify the user's Maturity Tier.
-3.  **Telemetry Awareness**: Be aware that `get_chrome_activity_log` only records sensitive data events if a corresponding rule is active. For environments in **Tier 1 (Visibility)**, explain this dependency and suggest starting with `AUDIT` mode rules to establish the necessary telemetry for future analysis.
-4.  **Audit-First Recommendation**: Always recommend that new rules start in `AUDIT` mode to establish a baseline before moving to enforcement.
+1.  **Diagnose**: Call `diagnose_environment` to capture the current state.
+2.  **Apply internal criteria**: Call `get_document` with `filename: 12` to load the posture-assessment heuristics. Use them to decide what's missing, what needs tuning, and what's ready to enforce. The heuristics are internal — do not surface their labels, tier numbers, or framework names in your reply.
+3.  **Telemetry dependency**: `get_chrome_activity_log` only records sensitive-data events when a corresponding rule is active. If the environment has no active rules, recommend starting with `AUDIT`-mode rules so the logs populate for later analysis.
+4.  **Audit first**: New rules should start in `AUDIT` mode to establish a baseline before enforcement.
 
 ## Capabilities and limitations
 
@@ -44,3 +44,4 @@ You have a defined set of capabilities (diagnostics, configuration, remediation)
 - **Never mention internal tool or function names.** Users must not see identifiers like `search_content`, `list_dlp_rules`, `get_connector_policy`, `check_cep_subscription`, or any other underscore-delimited function name, and this holds even when the user asks directly ("what tools do you have?", "what APIs can you use?"). Describe actions in plain language — "I checked your DLP rules," not "I called list_dlp_rules" — and summarize capabilities in English ("I can check your DLP rules, verify license status...") rather than listing function names.
 - **Don't expose other internal identifiers.** Resource names and IDs (like `policies/abc123`) are fine — users need those. But don't surface API trigger identifiers (like `google.workspace.chrome.*`), policy schema names, or raw enum values (like `SERVICE_PROVIDER_CHROME_ENTERPRISE_PREMIUM`). Use user-facing terms instead.
 - **DLP safety guardrails**: You cannot create an active DLP rule with a "block" action. Block rules are created in an inactive state and must be manually enabled by an admin. You can only delete DLP rules that were created by this agent (identified by the robot emoji prefix in the rule name). If asked to delete other rules, you MUST decline and provide the exact link to the Admin Console: `https://admin.google.com/ac/dp/rules`.
+- **Don't invent product taxonomies.** The internal heuristics and posture-assessment criteria you load from the knowledge base are evaluation aids for your reasoning, not Google product concepts. Do not name them, number them, group them by "tier", "model", "framework", or "dimension" in your reply, and do not present them to users as documented CEP features. Translate findings into plain administrator-facing language with concrete CEP nouns (licenses, connectors, SEB extension, rule modes, AUDIT/WARN/BLOCK).

--- a/test/evals/cases/prompts/optimize.md
+++ b/test/evals/cases/prompts/optimize.md
@@ -4,7 +4,7 @@ id: pr08
 category: prompt
 tags:
   - prompt
-  - maturity
+  - rule-state
 scenario: no-dlp-rules
 prompt_name: 'cep:optimize'
 expected_tools:
@@ -18,11 +18,11 @@ priority: P2
 
 ## Golden Response
 
-Agent should assess DLP maturity and find zero DLP rules configured. This represents the earliest possible maturity stage -- no DLP enforcement at all. Agent should recommend starting with audit-mode rules to gain visibility before enabling blocking rules.
+Agent should report that the environment has no DLP rules in place and that no enforcement is active. Agent should recommend starting with audit-mode rules to gain visibility before turning on warn or block actions.
 
 ## Judge Instructions
 
-The agent MUST identify that there are no DLP rules and assess maturity as very low / nonexistent / early stage. If the agent reports any existing DLP rules, grade as FAIL (the scenario removes them all). Recommending a phased rollout (audit first, then warn, then block) shows strong understanding.
+The agent MUST identify that there are no DLP rules and explain that the environment has no DLP coverage. If the agent reports any existing DLP rules, grade as FAIL (the scenario removes them all). Recommending a phased rollout (audit first, then warn, then block) shows strong understanding. The agent should NOT label this state with internal taxonomy like "Tier 0", "early stage", or "low maturity" — describe it in plain language. Using such labels is a soft FAIL.
 
 --- CASE ---
 
@@ -30,7 +30,7 @@ id: pr09
 category: prompt
 tags:
   - prompt
-  - maturity
+  - rule-state
 scenario: audit-only-rules
 prompt_name: 'cep:optimize'
 expected_tools:
@@ -44,11 +44,11 @@ priority: P2
 
 ## Golden Response
 
-Agent should assess DLP maturity and find 4 DLP rules, all configured with audit-only actions. No blocking, warning, or watermarking is active. This represents an early monitoring stage -- the organization is logging DLP events to gain visibility before moving to enforcement. Agent should recommend progressing to warn actions for high-confidence rules.
+Agent should report that all 4 DLP rules are in audit-only mode — the environment is logging events but not enforcing. Agent should recommend progressing high-confidence rules from audit to warn so the policies start having user-visible effect.
 
 ## Judge Instructions
 
-The agent MUST identify that all rules are audit-only and assess maturity as early or monitoring stage. If the agent assesses maturity as advanced despite no enforcement actions, grade as FAIL. Recommending progression to warn/block demonstrates understanding of the DLP maturity model.
+The agent MUST identify that all rules are audit-only and recommend progression to warn or block for high-confidence rules. If the agent says rules are already enforcing, grade as FAIL. The agent should NOT use internal taxonomy ("Tier 1", "early monitoring stage", "maturity model") — describe the state in plain language. Using such labels is a soft FAIL.
 
 --- CASE ---
 
@@ -56,7 +56,7 @@ id: pr10
 category: prompt
 tags:
   - prompt
-  - maturity
+  - rule-state
 scenario: healthy
 prompt_name: 'cep:optimize'
 expected_tools:
@@ -70,11 +70,11 @@ priority: P2
 
 ## Golden Response
 
-Agent should assess DLP maturity and find 4 active DLP rules across multiple OUs covering block, watermark, audit, and warn actions. Activity logs show DLP events being triggered. This represents an advanced maturity stage with a layered approach. Agent may recommend further refinements but should acknowledge the strong foundation.
+Agent should report 4 active DLP rules across multiple OUs covering a mix of block, watermark, audit, and warn actions, with activity logs showing events being generated. Agent may recommend further refinements but should acknowledge that the deployment is solid.
 
 ## Judge Instructions
 
-The agent MUST identify multiple active DLP rules with different action types and assess maturity as intermediate or advanced. Identifying that the organization uses a mix of block, warn, audit, and watermark actions demonstrates understanding of DLP maturity. If the agent says there are no rules or assesses maturity as early/nonexistent, grade as FAIL.
+The agent MUST identify that multiple rules with different action types are active and producing events. If the agent says there are no rules or that nothing is enforcing, grade as FAIL. The agent should NOT use internal taxonomy ("Tier 3", "advanced maturity"). Plain descriptions like "rules in mixed enforcement modes are firing" are correct. Using internal labels is a soft FAIL.
 
 --- CASE ---
 
@@ -82,7 +82,7 @@ id: pr11
 category: prompt
 tags:
   - prompt
-  - maturity
+  - rule-state
 scenario: overly-broad-block-rule
 prompt_name: 'cep:optimize'
 expected_tools:
@@ -96,11 +96,11 @@ priority: P2
 
 ## Golden Response
 
-Agent should assess DLP maturity and find that while multiple rules exist, one rule ("Block all sensitive content") has overly broad triggers (all 5 event types) and matches all content. This suggests the organization has rules but they are not well-tuned. Maturity is intermediate but with significant room for improvement in rule specificity.
+Agent should report that multiple rules exist but one ("Block all sensitive content") has overly broad triggers (all 5 event types) and a match-all condition. The deployment has coverage but the rule quality needs work — the broad rule is a noise and false-positive risk that should be narrowed.
 
 ## Judge Instructions
 
-The agent MUST identify the overly broad block rule as a maturity concern. Simply counting rules and reporting "advanced" without analyzing rule quality is a FAIL. The agent should note that broad catch-all rules indicate the DLP configuration needs refinement.
+The agent MUST identify the overly broad block rule and explain why its scope is a problem. Simply counting rules and saying everything looks good is FAIL. The agent should note that broad catch-all rules need refinement. Internal taxonomy ("intermediate maturity", "Tier 2") is a soft FAIL — describe the issue with the specific rule in plain language.
 
 --- CASE ---
 
@@ -122,11 +122,11 @@ priority: P2
 
 ## Golden Response
 
-Agent should analyze DLP rules and activity logs to assess noise levels. The activity log shows 3 events: one block, one warn, one audit, each from a different rule. With a small number of events across multiple rules, there is no obvious high-noise rule. Agent should report current noise levels and recommend continued monitoring as the deployment matures.
+Agent should analyze DLP rules and activity logs to assess noise levels. The activity log shows 3 events: one block, one warn, one audit, each from a different rule. With a small number of events spread across multiple rules, there is no obvious high-noise rule. Agent should report current noise levels and recommend continued monitoring.
 
 ## Judge Instructions
 
-The agent MUST examine both DLP rules and activity logs. If the agent fails to fetch the activity log entirely, grade as FAIL. If the agent fetches the log and provides an optimization assessment (even if it focuses more on rule configuration than citing specific low event counts), it is acceptable and should PASS.
+The agent MUST examine both DLP rules and activity logs. If the agent fails to fetch the activity log entirely, grade as FAIL. If the agent fetches the log and provides an optimization assessment (even if it focuses more on rule configuration than specific low event counts), it is acceptable and should PASS.
 
 --- CASE ---
 
@@ -148,7 +148,7 @@ priority: P2
 
 ## Golden Response
 
-Agent should analyze DLP rules and activity logs and identify that the "Audit pastes to generative AI sites" rule is generating significantly more events than other rules (24 events vs 1 from the block rule). Multiple users across multiple days are triggering it. Agent should flag this as a high-noise rule and recommend either tightening the rule's conditions, switching to a more targeted URL list, or accepting the volume if monitoring GenAI usage is a priority.
+Agent should identify that the "Audit pastes to generative AI sites" rule is generating significantly more events than other rules (24 events vs 1 from the block rule). Multiple users across multiple days are triggering it. Agent should flag this as a high-noise rule and recommend either tightening the rule's conditions, switching to a more targeted URL list, or accepting the volume if monitoring GenAI usage is a priority.
 
 ## Judge Instructions
 

--- a/test/evals/cases/prompts/optimize.md
+++ b/test/evals/cases/prompts/optimize.md
@@ -22,7 +22,7 @@ Agent should report that the environment has no DLP rules in place and that no e
 
 ## Judge Instructions
 
-The agent MUST identify that there are no DLP rules and explain that the environment has no DLP coverage. If the agent reports any existing DLP rules, grade as FAIL (the scenario removes them all). Recommending a phased rollout (audit first, then warn, then block) shows strong understanding. The agent should NOT label this state with internal taxonomy like "Tier 0", "early stage", or "low maturity" — describe it in plain language. Using such labels is a soft FAIL.
+The agent MUST identify that there are no DLP rules and explain that the environment has no DLP coverage. If the agent reports any existing DLP rules, grade as FAIL (the scenario removes them all). Recommending a phased rollout (audit first, then warn, then block) shows strong understanding. If the agent labels this state with internal taxonomy in the user-facing reply (e.g., "Tier 0", "early stage", "low maturity", "MECE", "Maturity Model"), grade as FAIL even if the rest of the analysis is correct.
 
 --- CASE ---
 
@@ -48,7 +48,7 @@ Agent should report that all 4 DLP rules are in audit-only mode — the environm
 
 ## Judge Instructions
 
-The agent MUST identify that all rules are audit-only and recommend progression to warn or block for high-confidence rules. If the agent says rules are already enforcing, grade as FAIL. The agent should NOT use internal taxonomy ("Tier 1", "early monitoring stage", "maturity model") — describe the state in plain language. Using such labels is a soft FAIL.
+The agent MUST identify that all rules are audit-only and recommend progression to warn or block for high-confidence rules. If the agent says rules are already enforcing, grade as FAIL. If the agent uses internal taxonomy in the user-facing reply (e.g., "Tier 1", "early monitoring stage", "maturity model", "MECE"), grade as FAIL even if the rest of the analysis is correct.
 
 --- CASE ---
 
@@ -74,7 +74,7 @@ Agent should report 4 active DLP rules across multiple OUs covering a mix of blo
 
 ## Judge Instructions
 
-The agent MUST identify that multiple rules with different action types are active and producing events. If the agent says there are no rules or that nothing is enforcing, grade as FAIL. The agent should NOT use internal taxonomy ("Tier 3", "advanced maturity"). Plain descriptions like "rules in mixed enforcement modes are firing" are correct. Using internal labels is a soft FAIL.
+The agent MUST identify that multiple rules with different action types are active and producing events. If the agent says there are no rules or that nothing is enforcing, grade as FAIL. If the agent uses internal taxonomy in the user-facing reply (e.g., "Tier 3", "advanced maturity", "MECE"), grade as FAIL even if the rest of the analysis is correct. Plain descriptions like "rules in mixed enforcement modes are firing" are the expected style.
 
 --- CASE ---
 
@@ -100,7 +100,7 @@ Agent should report that multiple rules exist but one ("Block all sensitive cont
 
 ## Judge Instructions
 
-The agent MUST identify the overly broad block rule and explain why its scope is a problem. Simply counting rules and saying everything looks good is FAIL. The agent should note that broad catch-all rules need refinement. Internal taxonomy ("intermediate maturity", "Tier 2") is a soft FAIL — describe the issue with the specific rule in plain language.
+The agent MUST identify the overly broad block rule and explain why its scope is a problem. Simply counting rules and saying everything looks good is FAIL. The agent should note that broad catch-all rules need refinement. If the agent uses internal taxonomy in the user-facing reply (e.g., "intermediate maturity", "Tier 2", "MECE"), grade as FAIL even if the rest of the analysis is correct.
 
 --- CASE ---
 

--- a/test/evals/scenarios/no-dlp-rules.js
+++ b/test/evals/scenarios/no-dlp-rules.js
@@ -17,7 +17,7 @@ limitations under the License.
 /**
  * @file Scenario: all DLP rules removed (zero enforcement).
  *
- * Used by: pr05 (prompt maturity).
+ * Used by: pr05 (prompt rule-state).
  */
 
 /** @param {object} state - Cloned base state. */

--- a/test/evals/scenarios/overly-broad-block-rule.js
+++ b/test/evals/scenarios/overly-broad-block-rule.js
@@ -17,7 +17,7 @@ limitations under the License.
 /**
  * @file Scenario: block rule has overly broad triggers and condition.
  *
- * Used by: pr11 (prompt maturity), pr14 (prompt noise).
+ * Used by: pr11 (prompt rule-state), pr14 (prompt noise).
  */
 
 /** @param {object} state - Cloned base state. */

--- a/test/local/prompts.test.js
+++ b/test/local/prompts.test.js
@@ -71,9 +71,17 @@ describe('MCP Prompts', () => {
     const result = await client.getPrompt({ name: 'cep:optimize' })
 
     assert.ok(result.messages)
-    assert.ok(result.messages[0].content.text.includes('Maturity Assessment'))
-    assert.ok(result.messages[0].content.text.includes('get_document'))
-    assert.ok(result.messages[0].content.text.includes('filename: 12'))
+    const text = result.messages[0].content.text
+    assert.ok(text.includes('Environment summary'))
+    assert.ok(text.includes('Rule findings'))
+    assert.ok(text.includes('get_document'))
+    assert.ok(text.includes('filename: 12'))
+    // Guardrails: the user-facing prompt template must not surface the old
+    // internal taxonomy. The agent leaked these labels to admins as if they
+    // were documented CEP product concepts; they aren't.
+    assert.doesNotMatch(text, /Maturity Tier/)
+    assert.doesNotMatch(text, /\bMECE\b/)
+    assert.doesNotMatch(text, /Tier [0-3]/)
   })
 
   test('When cep:expert prompt is requested, then it returns its content', async () => {

--- a/test/local/prompts.test.js
+++ b/test/local/prompts.test.js
@@ -73,9 +73,13 @@ describe('MCP Prompts', () => {
     assert.ok(result.messages)
     const text = result.messages[0].content.text
     assert.ok(text.includes('Environment summary'))
+    assert.ok(text.includes('What the logs show'))
     assert.ok(text.includes('Rule findings'))
     assert.ok(text.includes('get_document'))
     assert.ok(text.includes('filename: 12'))
+    // The "What the logs show" section must come before "Rule findings" so the
+    // agent grounds rule-config analysis in observed event volume.
+    assert.ok(text.indexOf('What the logs show') < text.indexOf('Rule findings'))
     // Guardrails: the user-facing prompt template must not surface the old
     // internal taxonomy. The agent leaked these labels to admins as if they
     // were documented CEP product concepts; they aren't.


### PR DESCRIPTION
## Summary

The `/cep:optimize` prompt and its supporting knowledge articles asked the agent to classify environments into a four-tier maturity model and to evaluate rules against a four-dimension framework. The agent surfaced those labels to administrators as if they were documented Chrome Enterprise Premium concepts.

This PR rewrites the optimize prompt and the two supporting articles to present the same evaluation logic in plain language, treating the heuristics as internal reasoning aids rather than user-facing taxonomy.

## Changes

- **`prompts/definitions/optimize.js`** — Output template now leads with an `Environment summary` paragraph and a `Rule findings` section per rule (`What we found / Why it matters / Recommended change / Patch`), followed by `Suggested next actions`. Removes the prior "Maturity Assessment" section and the per-rule "MECE dimension violation" line.
- **`prompts/system-prompt.md`** — Security guidance workflow drops the explicit "assess Tier" step. Adds a constraint forbidding the agent from naming internal frameworks, tier numbers, or model labels in replies; findings must use plain CEP nouns (licenses, connectors, SEB extension, AUDIT/WARN/BLOCK).
- **`lib/knowledge/12-security-posture-guide.md`** — Title changes to "CEP Security Posture Assessment Heuristics". Rewrites the body around four ordered questions (prerequisites in place? rules exist? rules tuned? rules enforcing?) with the same remediation steps under each.
- **`lib/knowledge/15-rule-quality-guidelines.md`** — Title changes to "DLP Rule Evaluation Heuristics". Drops the `<mece_api_heuristics_framework>` and `<dimension_N>` wrappers; presents the eight evaluation heuristics as a flat list. Frontmatter `summary` rewritten to reflect the new framing.
- **`test/local/prompts.test.js`** — Assertions updated for the new template; adds regression checks that the prompt template never contains "Maturity Tier", "MECE", or "Tier 0–3".
- **`test/evals/cases/prompts/optimize.md`** — Golden responses and judge instructions for `pr08`–`pr14` rewritten in plain language. Each judge instruction now treats internal-taxonomy leakage in the agent's reply as a soft FAIL.
- **`test/evals/scenarios/{no-dlp-rules,overly-broad-block-rule}.js`** — Comments updated to match the renamed eval tag.
- **`README.md`, `prompts/README.md`** — `cep:optimize` description updated to match the new prompt focus.

## Test plan

- [x] `npm run lint` passes.
- [x] `npm run test:unit` passes (321/321).
- [x] `npm run test:smoke` passes.
- [x] `node test/evals/run.js --category prompt --dry-run` passes (19/19 cases load).
- [x] `npm run eval` against a fake backend with a live Gemini judge — verify the agent's actual replies under the new system prompt no longer surface "Tier" / "MECE" / "framework" labels and the LLM judge grades them PASS.
- [x] Spot-check `/cep:optimize` and `/cep:health` interactively against the fake API server. Confirm output uses plain language ("the environment has 4 audit-only rules" rather than "Tier 1 (Visibility)") and that the agent does not cite "Maturity Tier" or "MECE Framework".