### PR TITLE
fix(prompts): cep:health leads with the top finding

### DIFF
--- a/prompts/definitions/health.js
+++ b/prompts/definitions/health.js
@@ -55,11 +55,13 @@ Call the **diagnose_environment** tool to get a complete environment snapshot in
 - **SEB Extension**: Whether the Secure Enterprise Browser extension is force-installed on the root OU
 - **Browser Versions**: Distribution of Chrome versions across managed devices
 
-The response includes a pre-computed **issues[]** array with severity ratings. Use this as your starting point, but also examine the raw data to provide context. For example:
-- If a connector is missing, explain what content goes unscanned without it
-- If DLP rules are audit-only, explain that users are not blocked or warned
-- If the SEB extension is missing, explain which features (like data masking) depend on it
-- If there are no issues, confirm the environment is healthy and summarize the key metrics
+The response includes a pre-computed **issues[]** array with severity ratings. Use this as your starting point, but also examine the raw data to identify **dependencies between controls** before reporting. The most useful health check leads with the upstream gap, not a list of leaf failures. Look for:
+- **Connectors and DLP rules.** DLP rules cannot scan content unless the matching Content Analysis Connector is enabled. If connectors are missing while DLP rules exist, the rules are inert — surface this as the top finding rather than listing the connector gaps and the rule list separately.
+- **Detectors and DLP rules.** Active DLP rules can reference custom detectors. If a referenced detector doesn't exist, the rule silently produces no matches. Flag this dependency explicitly.
+- **Subscription and everything else.** If the CEP subscription is inactive or has zero licenses assigned, no other control matters until that's fixed.
+- **SEB extension and browser-side features.** Data masking and other in-browser enforcement only work where the Secure Enterprise Browser extension is force-installed.
+- **Audit-only rules.** Rules in audit mode don't block or warn users; they only log events. Note this when summarizing rule status.
+- **Healthy environment.** When nothing is broken, confirm the environment is healthy and summarize the key metrics — don't manufacture a problem.
 
 ${SHARED_DIAGNOSTIC_RULES}
 `,

--- a/prompts/definitions/shared.js
+++ b/prompts/definitions/shared.js
@@ -24,8 +24,20 @@ limitations under the License.
  */
 export const SHARED_DIAGNOSTIC_RULES = `3. Summarize your findings using the following structural rules:
 
+**Top Finding (Lead With the Headline)**
+Begin your response with a single bold sentence — preceded by **Top finding:** — that states the most consequential thing the administrator needs to know. Pick the upstream dependency, not a leaf observation. Examples of what counts as a top finding:
+*   The Content Analysis Connectors are missing, so the DLP rules cannot scan any content (rules are present but inert).
+*   Active DLP rules reference detectors that no longer exist, so those rules silently produce no matches.
+*   The CEP subscription is inactive or has zero licenses assigned, so no CEP feature can apply.
+*   The Secure Enterprise Browser extension is missing, so data-masking and other browser-side enforcement features cannot run even when DLP rules are configured.
+*   The environment is healthy: subscription active, connectors enabled, DLP rules in place, and SEB deployed (only when nothing is wrong).
+
+When upstream gaps make downstream controls non-functional, name that explicitly: do not list each gap as if it were independent.
+
+After the top finding, add a short paragraph (one or two sentences) connecting the headline to its downstream effect — what the administrator loses or can't rely on while the upstream gap exists.
+
 **Visual Status Mapping (The Summary Table)**
-Begin your response with a Markdown table that provides a clear status for every metric.
+Below the headline, render a Markdown table that provides a clear status for every metric.
 *   Columns: \`Security Control\`, \`Status\`, \`Findings\`
 *   Use emojis for quick scanning: ✅ (Configured/Active), ❌ (Inactive/Missing), ⚠️ (Unknown/Unverified).
 *   Keep the "Findings" text brief and direct.


### PR DESCRIPTION
Closes #14.

## Summary

When `cep:health` runs against an environment with upstream gaps that make downstream controls inert (missing Content Analysis Connectors leave DLP rules with nothing to scan; missing custom detectors silently neuter rules that reference them), the agent lists each gap as an isolated row in the status table. The administrator has to reconstruct the dependency themselves, and the eval cases `pr16` and `pr17` fail because the judge expects the agent to call out the upstream-vs-leaf relationship explicitly.

We restructure the `cep:health` output so the agent leads with the headline:

1. **Top finding:** a single bold sentence naming the most consequential dependency.
2. A short paragraph connecting the headline to its downstream effect.
3. The existing status table.
4. The existing severity-grouped issue list.

## Changes

- `prompts/definitions/shared.js`: we add a "Top Finding (Lead With the Headline)" block at the start of `SHARED_DIAGNOSTIC_RULES` with examples of upstream-vs-leaf framings and a healthy-environment exception.
- `prompts/definitions/health.js`: we tighten the analysis guidance with the dependency pairs the agent should look for — connectors↔rules, detectors↔rules, subscription↔everything, SEB↔browser-side features, audit-only mode↔no enforcement — and add a note that when nothing is broken the agent should confirm health rather than manufacture a problem.

## Test plan

- [x] `npm run lint` passes.
- [x] `npm run test:unit` passes (321/321; existing prompt assertions only check for the presence of `diagnose_environment` and similar tool references, so they still hold).
- [ ] Live eval run (`npm run eval -- --category prompt` with a Gemini key): verify `pr16` and `pr17` (the two cases that failed because the agent listed isolated gaps) now PASS.
- [ ] Spot-check `/cep:health` interactively against the fake API server in a scenario with missing connectors but rules present: confirm the agent leads with "DLP rules cannot scan content because the connectors are off" rather than tabulating each gap separately.