### PR TITLE
fix(prompts): cep:optimize leads with what the logs show

### DIFF
--- a/prompts/definitions/optimize.js
+++ b/prompts/definitions/optimize.js
@@ -59,21 +59,34 @@ ${guidelinesContent}
 
 These heuristics and posture criteria are internal evaluation aids. Do not name them, group them, or quote their wrappers in your reply. Translate every finding into plain administrator-facing language.
 
-**Required Output Format:**
+**Required Output Format (the order of these sections is mandatory):**
 
 ### Environment summary
 
 A concise paragraph describing what's in place (licenses, connectors, SEB extension, rule count, audit-vs-enforcement balance) and what's missing. Lead with the most consequential gap. Do not use tier labels, framework names, or model numbers.
 
+### What the logs show
+
+Lead this section with what the activity log told you, before any rule-config analysis. Cover:
+* Total DLP events in the window the log returned (and how recent the most recent event was).
+* Per-rule event volume — which rules are firing the most, which are firing once or twice, which are not firing at all. Include a bullet list with the rule name and the count.
+* Cross-rule patterns — single users hitting many rules, single rules hitting many users, time-of-day spikes, audit-vs-enforcement skew, or whatever else stands out.
+* The headline read of the volume: is one rule generating most of the noise, is the volume spread evenly across rules, or is the volume low across the board (in which case there is no high-noise rule and that itself is the finding).
+
+If the activity log is empty or near-empty, state that plainly here. Do not skip this section just because volume is low — the absence of events is itself a useful observation, especially when rules exist.
+
 ### Rule findings
 
-For each rule that violates a heuristic or generates disproportionate event volume:
+For each rule that needs attention — anchored in what the logs above showed, then layered with rule-quality heuristics:
 
 #### [Rule name] (ID: [policy id])
-* **What we found:** Describe the specific issue in the rule's logic or event history.
-* **Why it matters:** One sentence on the user impact (false positives, blind spots, helpdesk friction).
+* **What the logs show for this rule:** Event count from the section above and any pattern specific to this rule (single user, particular trigger, spike, etc.). If the rule has zero events, say so.
+* **What we found in the rule logic:** Describe the heuristic-based issue in the rule's configuration. Skip this bullet only when the rule's logic is fine and the issue is purely volume.
+* **Why it matters:** One sentence on the user impact (false positives, blind spots, helpdesk friction, dead-letter rules).
 * **Recommended change:** Plain-language action.
 * **Patch:** Optimized JSON or CEL block when applicable.
+
+If no rule needs attention because volume is low and configurations are reasonable, write a single sentence saying so. Do not invent issues to fill the section.
 
 ### Suggested next actions
 
@@ -81,6 +94,7 @@ Offer specific follow-ups the agent can execute on request, such as:
 * Deploying the patches listed above.
 * Transitioning specific rules from AUDIT to WARN.
 * Deleting specific inactive or orphaned rules.
+* Continuing to monitor when volume is low and rules are reasonable.
 
 **Tone and voice:**
 - Active voice, human subjects.

--- a/test/local/prompts.test.js
+++ b/test/local/prompts.test.js
@@ -73,9 +73,13 @@ describe('MCP Prompts', () => {
     assert.ok(result.messages)
     const text = result.messages[0].content.text
     assert.ok(text.includes('Environment summary'))
+    assert.ok(text.includes('What the logs show'))
     assert.ok(text.includes('Rule findings'))
     assert.ok(text.includes('get_document'))
     assert.ok(text.includes('filename: 12'))
+    // The "What the logs show" section must come before "Rule findings" so the
+    // agent grounds rule-config analysis in observed event volume.
+    assert.ok(text.indexOf('What the logs show') < text.indexOf('Rule findings'))
     // Guardrails: the user-facing prompt template must not surface the old
     // internal taxonomy. The agent leaked these labels to admins as if they
     // were documented CEP product concepts; they aren't.


### PR DESCRIPTION
Closes #15. **Stacks on top of #13** — base is set to \`fix/internal-eval-criteria\` so the diff is clean against #13's optimize-prompt rewrite. Will re-target to \`main\` automatically once #13 merges.

## Summary

The `cep:optimize` prompt asks the agent to call both `diagnose_environment` and `get_chrome_activity_log` but doesn't enforce any ordering on the output. In low-volume scenarios the agent jumps to rule-config heuristics from `lib/knowledge/15-rule-quality-guidelines.md` and never reports what the activity log actually contained — even though the log is what the administrator needs to start with.

Eval case `pr12` (the `healthy` scenario in `test/evals/cases/prompts/optimize.md`) failed in the post-#13 live eval run for exactly this reason. Judge feedback:

> The agent failed to analyze the actual activity logs to identify the low-volume, multi-rule event pattern requested by the golden reference, choosing instead to generate hypothetical optimizations based on broad policy configurations.

## Changes

- `prompts/definitions/optimize.js` — Inserts a new mandatory `What the logs show` section between `Environment summary` and `Rule findings`. The section covers per-rule event volume, cross-rule patterns, and a headline read of the volume. The per-rule template now leads each rule with `What the logs show for this rule:` so the heuristic-based analysis follows observed events rather than overriding them. Adds an explicit "do not invent issues to fill the section" guardrail for healthy environments.
- `test/local/prompts.test.js` — Adds an ordering assertion verifying `What the logs show` appears before `Rule findings` in the rendered prompt template.

## Test plan

- [x] `npm run lint` passes.
- [x] `npm run test:unit` passes (321/321; new ordering assertion validates).
- [ ] Live eval run (`npm run eval -- --category prompt` with a Gemini key) — verify `pr12` (healthy / noise scenario) and `pr13` (high-noise rule) PASS, and `pr08`–`pr11`, `pr14` continue to PASS.
- [ ] Spot-check `/cep:optimize` against the fake API server in the `healthy` scenario — confirm the agent reports per-rule event counts before recommending config changes.