### PR TITLE
chore(tools): remove stale TODO about real-vs-fake create response

### DIFF
--- a/tools/definitions/create_chrome_dlp_rule.js
+++ b/tools/definitions/create_chrome_dlp_rule.js
@@ -258,11 +258,6 @@ To ensure technical accuracy and verify trigger compatibility, you should retrie
 
           const result = await cloudIdentityClient.createDlpRule(customerId, orgUnitId, ruleConfig, authToken)
 
-          // TODO: Mismatch between real API and fake API responses.
-          // The real API may return the policy directly or an unwrapped Operation,
-          // while the fake API returns `{ done: true, response: ... }`.
-          // We extract `response` here because it works with the fake, but this
-          // may break with the real API if it doesn't wrap the policy this way.
           const createdPolicy = result.response
 
           return safeFormatResponse({


### PR DESCRIPTION
Closes #21.

Verified against the real Cloud Identity v1beta1 \`policies.create\` on a test domain: the API returns \`{done: true, response: <Policy>}\` synchronously, identical to the fake server. The \`result.response\` unwrap is correct as written; the surrounding warning comment is out of date.

Probe response (truncated):
\`\`\`json
{
  "done": true,
  "response": {
    "@type": "type.googleapis.com/google.apps.cloudidentity.policies.v1main.Policy",
    "name": "policies/akajj264aop7bpwicq",
    "setting": { ... }
  }
}
\`\`\`

No behavior change. Comment-only.