### PR TITLE
fix(tools): let list_customer_profiles surface auth errors

### DIFF
--- a/test/local/chromemanagement.test.js
+++ b/test/local/chromemanagement.test.js
@@ -137,7 +137,7 @@ describe('Chrome Management API', () => {
       assert.ok(result.content[1].text.includes('```json'))
     })
 
-    test('When API call fails, then it returns an error message', async () => {
+    test('When API call fails, then it surfaces as isError so guardedToolCall can run auth remediation', async () => {
       const mockListCustomerProfiles = mock.fn(async () => {
         throw new Error('API Error')
       })
@@ -164,7 +164,8 @@ describe('Chrome Management API', () => {
         .arguments[2]
 
       const result = await handler({ customerId: 'C0123' }, {})
-      assert.deepStrictEqual(result.content[0].text, 'Error listing customer profiles: API Error')
+      assert.strictEqual(result.isError, true)
+      assert.match(result.content[0].text, /API Error/)
     })
   })
 })

--- a/test/unit/tools/list_customer_profiles.test.js
+++ b/test/unit/tools/list_customer_profiles.test.js
@@ -1,0 +1,137 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { registerCustomerProfileTool } from '../../../tools/definitions/list_customer_profiles.js'
+
+describe('list_customer_profiles tool handler', () => {
+  const getHandler = mockChromeManagementClient => {
+    let registeredHandler
+    const mockServer = {
+      registerTool(name, config, handler) {
+        if (name === 'list_customer_profiles') {
+          registeredHandler = handler
+        }
+      },
+    }
+    registerCustomerProfileTool(mockServer, { chromeManagementClient: mockChromeManagementClient }, {})
+    return registeredHandler
+  }
+
+  const mockContext = {
+    requestInfo: {
+      headers: {
+        authorization: 'Bearer token',
+      },
+    },
+  }
+
+  test('When no profiles are found, then it returns a graceful empty message', async () => {
+    const mockClient = {
+      listCustomerProfiles: async () => [],
+    }
+
+    const handler = getHandler(mockClient)
+    const result = await handler({ customerId: 'C012345' }, mockContext)
+
+    assert.match(result.content[0].text, /No profiles found/)
+    assert.deepStrictEqual(result.structuredContent.profiles, [])
+    assert.strictEqual(result.structuredContent.totalCount, 0)
+  })
+
+  test('When profiles are returned, then it formats them and includes a resource map', async () => {
+    const mockProfiles = [
+      {
+        name: 'customers/C012345/profiles/abc123',
+        displayName: 'Test User',
+        userEmail: 'user@example.com',
+        osPlatformType: 'LINUX',
+        osVersion: '22.04',
+        profileId: 'abc123',
+      },
+    ]
+
+    const mockClient = {
+      listCustomerProfiles: async () => mockProfiles,
+    }
+
+    const handler = getHandler(mockClient)
+    const result = await handler({ customerId: 'C012345' }, mockContext)
+    const text = result.content[0].text
+
+    assert.match(text, /## Browser Profiles \(1\)/)
+    assert.match(text, /\*\*Test User\*\*/)
+    assert.match(text, /Email: user@example.com/)
+    assert.match(text, /OS: LINUX 22\.04/)
+    assert.match(text, /"Test User" → `customers\/C012345\/profiles\/abc123`/)
+    assert.deepStrictEqual(result.structuredContent.profiles, mockProfiles)
+    assert.strictEqual(result.structuredContent.totalCount, 1)
+  })
+
+  test('When a profile has missing fields, then it falls back to safe defaults', async () => {
+    const mockProfiles = [
+      {
+        name: 'customers/C012345/profiles/xyz999',
+      },
+    ]
+
+    const mockClient = {
+      listCustomerProfiles: async () => mockProfiles,
+    }
+
+    const handler = getHandler(mockClient)
+    const result = await handler({ customerId: 'C012345' }, mockContext)
+    const text = result.content[0].text
+
+    assert.match(text, /Unnamed Profile/)
+    assert.match(text, /Email: Unknown/)
+    assert.match(text, /OS: Unknown/)
+  })
+
+  test('When the client throws an auth error, then isError is true and it is not swallowed', async () => {
+    const authError = new Error('API Error 401: Unauthorized')
+    authError.status = 401
+
+    const mockClient = {
+      listCustomerProfiles: async () => {
+        throw authError
+      },
+    }
+
+    const handler = getHandler(mockClient)
+    const result = await handler({ customerId: 'C012345' }, mockContext)
+
+    assert.strictEqual(result.isError, true)
+    // The auth remediation message (not the swallowed error shape) should appear
+    assert.ok(!result.structuredContent?.error, 'error flag must not be buried in structuredContent')
+  })
+
+  test('When the client throws a generic error, then isError is true and the message surfaces', async () => {
+    const mockClient = {
+      listCustomerProfiles: async () => {
+        throw new Error('Network timeout')
+      },
+    }
+
+    const handler = getHandler(mockClient)
+    const result = await handler({ customerId: 'C012345' }, mockContext)
+
+    assert.strictEqual(result.isError, true)
+    assert.match(result.content[0].text, /Network timeout/)
+    assert.ok(!result.structuredContent?.error, 'error flag must not be buried in structuredContent')
+  })
+})

--- a/tools/definitions/list_customer_profiles.js
+++ b/tools/definitions/list_customer_profiles.js
@@ -19,7 +19,7 @@ limitations under the License.
  */
 
 import { z } from 'zod'
-import { guardedToolCall, formatToolResponse } from '../utils/wrapper.js'
+import { guardedToolCall, formatToolResponse, safeFormatResponse } from '../utils/wrapper.js'
 import { commonOutputSchemas } from './shared.js'
 import { TAGS } from '../../lib/constants.js'
 import { logger } from '../../lib/util/logger.js'
@@ -64,55 +64,51 @@ These profiles represent managed browser instances and provide details like OS v
          */
         handler: async ({ customerId }, { _requestInfo, authToken }) => {
           logger.debug(`${TAGS.MCP} Calling 'list_customer_profiles' with customerId: ${customerId}`)
-          try {
-            const profiles = await chromeManagementClient.listCustomerProfiles(customerId, authToken)
+          const profiles = await chromeManagementClient.listCustomerProfiles(customerId, authToken)
 
-            if (!profiles || profiles.length === 0) {
-              logger.debug(`${TAGS.MCP} No profiles found.`)
-              const sc = { profiles: [], totalCount: 0 }
+          return safeFormatResponse({
+            rawData: profiles,
+            toolName: 'list_customer_profiles',
+            formatFn: data => {
+              if (!data || data.length === 0) {
+                logger.debug(`${TAGS.MCP} No profiles found.`)
+                const sc = { profiles: [], totalCount: 0 }
+                return formatToolResponse({
+                  summary: `No profiles found for customer ${customerId}.`,
+                  data: sc,
+                  structuredContent: sc,
+                })
+              }
+
+              const formattedProfiles = data
+                .map(profile => {
+                  const displayName = profile.displayName || 'Unnamed Profile'
+                  const id =
+                    profile.profileId || profile.profilePermanentId || profile.name?.split('/').pop() || 'Unknown'
+                  const email = profile.userEmail || 'Unknown'
+                  const os = profile.osPlatformType ? `${profile.osPlatformType} ${profile.osVersion || ''}` : 'Unknown'
+                  return `- **${displayName}** — Email: ${email}, OS: ${os}, Profile: \`${id}\``
+                })
+                .join('\n')
+
+              const resourceMap = data
+                .map(profile => {
+                  const displayName = profile.displayName || 'Unnamed Profile'
+                  return `- "${displayName}" → \`${profile.name}\``
+                })
+                .join('\n')
+
+              logger.debug(`${TAGS.MCP} Successfully listed customer profiles.`)
+              const text = `## Browser Profiles (${data.length})\n\n${formattedProfiles}\n\nResource names for API operations:\n${resourceMap}`
+
+              const sc = { profiles: data, totalCount: data.length }
               return formatToolResponse({
-                summary: `No profiles found for customer ${customerId}.`,
+                summary: text,
                 data: sc,
                 structuredContent: sc,
               })
-            }
-
-            const formattedProfiles = profiles
-              .map(profile => {
-                const displayName = profile.displayName || 'Unnamed Profile'
-                const id =
-                  profile.profileId || profile.profilePermanentId || profile.name?.split('/').pop() || 'Unknown'
-                const email = profile.userEmail || 'Unknown'
-                const os = profile.osPlatformType ? `${profile.osPlatformType} ${profile.osVersion || ''}` : 'Unknown'
-                return `- **${displayName}** — Email: ${email}, OS: ${os}, Profile: \`${id}\``
-              })
-              .join('\n')
-
-            const resourceMap = profiles
-              .map(profile => {
-                const displayName = profile.displayName || 'Unnamed Profile'
-                return `- "${displayName}" → \`${profile.name}\``
-              })
-              .join('\n')
-
-            logger.debug(`${TAGS.MCP} Successfully listed customer profiles.`)
-            const text = `## Browser Profiles (${profiles.length})\n\n${formattedProfiles}\n\nResource names for API operations:\n${resourceMap}`
-
-            const sc = { profiles, totalCount: profiles.length }
-            return formatToolResponse({
-              summary: text,
-              data: sc,
-              structuredContent: sc,
-            })
-          } catch (error) {
-            logger.error(`${TAGS.MCP} Error listing customer profiles: ${error.message}`)
-            const sc = { profiles: [], totalCount: 0, error: true, message: error.message }
-            return formatToolResponse({
-              summary: `Error listing customer profiles: ${error.message}`,
-              data: sc,
-              structuredContent: sc,
-            })
-          }
+            },
+          })
         },
       },
       options,


### PR DESCRIPTION
Closes #22.

The handler wrapped its entire body in try/catch and returned a success-shaped response with `error: true` buried in `data` — no `isError` flag. Auth errors never reached `guardedToolCall`'s remediation handler, so users got a generic `Error listing customer profiles` string instead of the standard re-auth instructions.

This change replaces the broad catch with `safeFormatResponse` (which handles formatter errors locally and lets underlying client errors propagate). Updates the existing chromemanagement test to assert the new `isError: true` surface, and adds unit tests for the empty/populated/error paths.

Verified locally: `npm run test:unit` 326/326 pass.