### PR TITLE
chore(test): scrub real names from eval fixtures

### DIFF
--- a/test/evals/cases/tools/get_chrome_activity_log.md
+++ b/test/evals/cases/tools/get_chrome_activity_log.md
@@ -17,7 +17,7 @@ Have there been any recent data transfer violations or unscanned files?
 
 ## Golden Response
 
-Yes, there was a CONTENT_UNSCANNED event — a file download by tim@cep-netnew.cc
+Yes, there was a CONTENT_UNSCANNED event — a file download by alex@cep-netnew.cc
 was not scanned by the DLP engine. This typically means the file was
 password-protected, too large, or the download connector wasn't configured to
 scan it.

--- a/test/evals/fixtures/customer-default.json
+++ b/test/evals/fixtures/customer-default.json
@@ -3,7 +3,7 @@
   "id": "C01b1e65b",
   "customerDomain": "cep-netnew.cc",
   "postalAddress": {
-    "contactName": "Tim Feeley",
+    "contactName": "Test Admin",
     "organizationName": "CEP Netnew",
     "countryCode": "US"
   },

--- a/test/evals/fixtures/dlp-activities.json
+++ b/test/evals/fixtures/dlp-activities.json
@@ -4,7 +4,7 @@
     {
       "kind": "admin#reports#activity",
       "id": { "time": "2026-04-09T14:22:00Z", "applicationName": "chrome", "customerId": "C01b1e65b" },
-      "actor": { "email": "tim@cep-netnew.cc" },
+      "actor": { "email": "alex@cep-netnew.cc" },
       "events": [
         {
           "type": "CONTENT_UNSCANNED_TYPE",


### PR DESCRIPTION
Replace `Tim Feeley` contact name in `customer-default.json` with `Test Admin`, and the actor email `tim@cep-netnew.cc` in `dlp-activities.json` and the `get_chrome_activity_log` golden response with `alex@cep-netnew.cc` (matching the alice/bob/carol synthetic-name pattern already used in `dlp-activities-multi.json`).

The `cep-netnew.cc` test domain is retained because it's clearly synthetic and is referenced throughout the eval suite.

Verified locally: `npm run test:unit` 321/321 pass.