### PR TITLE
fix(server): wrap /sse handler in try/catch

### DIFF
--- a/mcp-server.js
+++ b/mcp-server.js
@@ -354,13 +354,20 @@ async function main() {
 
       app.get('/sse', async (_req, res) => {
         logger.info(`${TAGS.MCP} /sse Received request`)
-        const server = await getServer(gcpInfo, sharedSessionState)
-        const transport = new SSEServerTransport('/messages', res)
-        sseTransports[transport.sessionId] = transport
-        res.on('close', () => {
-          delete sseTransports[transport.sessionId]
-        })
-        await server.connect(transport)
+        try {
+          const server = await getServer(gcpInfo, sharedSessionState)
+          const transport = new SSEServerTransport('/messages', res)
+          sseTransports[transport.sessionId] = transport
+          res.on('close', () => {
+            delete sseTransports[transport.sessionId]
+          })
+          await server.connect(transport)
+        } catch (error) {
+          logger.error(`${TAGS.MCP} Error handling SSE request:`, error)
+          if (!res.headersSent) {
+            res.status(500).send(error.message || 'Internal server error')
+          }
+        }
       })
 
       app.post('/messages', async (req, res) => {


### PR DESCRIPTION
Mirrors the /mcp handler's error-handling pattern. Without it, an exception inside getServer() or server.connect() left the SSE response open and unanswered, the transport never registered, and any subsequent /messages POST returned 'No transport found' indefinitely.

Closes #24.

Verified locally: unit tests pass; integration tests pass on the fake backend. Pre-existing port-binding failures in mcp-server.test.js (unrelated to this change) were observed but did not affect the changed code paths.