### PR TITLE
fix(evals): move m02 to create_chrome_dlp_rule, add real connector-enablement case

### DIFF
--- a/test/evals/cases/tools/create_chrome_dlp_rule.md
+++ b/test/evals/cases/tools/create_chrome_dlp_rule.md
@@ -24,3 +24,30 @@ Agent should identify the root OU, then create a DLP rule with warn action for f
 Verify the agent actually performed the action (tool was called), not just
 described how to do it. Resource IDs (policy names, OU IDs) are fine to show.
 Prefer plain-language confirmation over raw API output.
+
+--- CASE ---
+
+id: m02
+category: mutation
+tags:
+  - mutation
+expected_tools:
+  - list_org_units
+  - create_chrome_dlp_rule
+forbidden_patterns: []
+required_patterns: []
+priority: P0
+
+## Prompt
+
+I want to silently monitor when users navigate to social media sites. Set up an audit-only DLP rule on the root OU.
+
+## Golden Response
+
+Agent should identify root OU, then create a DLP rule with audit action for URL navigation trigger targeting social media categories. Should confirm creation and explain that audit mode logs events without notifying users.
+
+## Judge Instructions
+
+Verify the agent actually performed the action (tool was called), not just
+described how to do it. Resource IDs (policy names, OU IDs) are fine to show.
+Prefer plain-language confirmation over raw API output.

--- a/test/evals/cases/tools/enable_chrome_enterprise_connectors.md
+++ b/test/evals/cases/tools/enable_chrome_enterprise_connectors.md
@@ -1,26 +1,28 @@
 --- CASE ---
 
-id: m02
+id: enable_chrome_enterprise_connectors__when_no_connector_exists__agent_enables_with_appropriate_defaults
 category: mutation
 tags:
   - mutation
+  - connectors
+scenario: upload-connector-missing
 expected_tools:
   - list_org_units
-  - create_chrome_dlp_rule
+  - enable_chrome_enterprise_connectors
 forbidden_patterns: []
 required_patterns: []
 priority: P0
 
 ## Prompt
 
-I want to silently monitor when users navigate to social media sites. Set up an audit-only DLP rule on the root OU.
+Enable the file-upload connector for the root organizational unit using sensible defaults.
 
 ## Golden Response
 
-Agent should identify root OU, then create a DLP rule with audit action for URL navigation trigger targeting social media categories. Should confirm creation and explain that audit mode logs events without notifying users.
+The agent identified the root organizational unit, then called the connector enablement tool to configure the file-upload connector. It confirmed the connector is now active and briefly described what it does — scanning files users attempt to upload for policy violations — so the admin understands the change that was applied.
 
 ## Judge Instructions
 
 Verify the agent actually performed the action (tool was called), not just
-described how to do it. Resource IDs (policy names, OU IDs) are fine to show.
-Prefer plain-language confirmation over raw API output.
+described how to do it. Resource IDs (OU IDs, connector policy names) are fine
+to show. Prefer plain-language confirmation over raw API output.


### PR DESCRIPTION
The enable_chrome_enterprise_connectors.md case file was actually a DLP-rule creation case (id m02). Move m02 into create_chrome_dlp_rule.md where it belongs, and replace enable_chrome_enterprise_connectors.md with a real eval case (descriptive ID, mutation category, scenario: upload-connector-missing, expected_tools: [list_org_units, enable_chrome_enterprise_connectors]).

Closes #29.

Verified locally: unit tests pass; integration tests pass on the fake backend. Pre-existing port-binding failures in mcp-server.test.js (unrelated to this change) were observed but did not affect the changed code paths.