### PR TITLE
fix(wrapper): propagate customerId auto-resolve errors

### DIFF
--- a/test/local/customer_id_caching.test.js
+++ b/test/local/customer_id_caching.test.js
@@ -84,4 +84,31 @@ describe('Customer ID Caching and Auto-Resolution', () => {
     assert.strictEqual(mockListOrgUnits.mock.calls[0].arguments[0].customerId, 'C_EXPLICIT')
     assert.strictEqual(sessionState.customerId, 'C_EXPLICIT')
   })
+
+  test('When getCustomerId throws during auto-resolve, then the tool returns isError true without running with undefined customerId', async () => {
+    const authError = new Error('UNAUTHENTICATED: credentials are invalid')
+    authError.status = 401
+    const mockGetCustomerId = mock.fn(async () => {
+      throw authError
+    })
+    const mockHandler = mock.fn(async () => ({ content: [{ type: 'text', text: 'ok' }] }))
+    const adminSdkClientInstance = { getCustomerId: mockGetCustomerId }
+
+    const sessionState = { customerId: null }
+    const tool = guardedToolCall(
+      { handler: mockHandler },
+      { apiClients: { adminSdk: adminSdkClientInstance } },
+      sessionState,
+    )
+
+    const result = await tool({}, {})
+
+    assert.strictEqual(result.isError, true, 'Tool should return isError: true when auto-resolve fails')
+    assert.strictEqual(
+      mockHandler.mock.callCount(),
+      0,
+      'Underlying handler should not be called when auto-resolve fails',
+    )
+    assert.ok(result.content[0].text.length > 0, 'Error response should contain a message')
+  })
 })

--- a/tools/utils/wrapper.js
+++ b/tools/utils/wrapper.js
@@ -213,6 +213,7 @@ export function guardedToolCall(
             }
           } catch (error) {
             logger.error(`${TAGS.MCP} Failed to auto-resolve customerId:`, error)
+            throw error
           }
         }
       }


### PR DESCRIPTION
The auto-resolve catch block only logged and let execution continue with undefined customerId — API clients then fell back to my_customer and produced a confusing 403 unrelated to the real (auth) problem. Re-throw the error so guardedToolCall's outer handler can surface the auth-remediation message.

Closes #25.

Verified locally: unit tests pass; integration tests pass on the fake backend. Pre-existing port-binding failures in mcp-server.test.js (unrelated to this change) were observed but did not affect the changed code paths.