### PR TITLE
refactor(server): collapse duplicate getServer branches

### DIFF
--- a/mcp-server.js
+++ b/mcp-server.js
@@ -188,27 +188,20 @@ async function getServer(gcpInfo, sharedSessionState) {
   })
 
   const apiOptions = {}
-  let apiClients = {}
 
   if (process.env.GOOGLE_API_ROOT_URL) {
     apiOptions.rootUrl = process.env.GOOGLE_API_ROOT_URL
     logger.info(`${TAGS.MCP} TEST MODE: Real API clients redirected to ${apiOptions.rootUrl}`)
-    apiClients = {
-      adminSdk: new RealAdminSdkClient(apiOptions),
-      cloudIdentity: new RealCloudIdentityClient(apiOptions),
-      chromePolicy: new RealChromePolicyClient(apiOptions),
-      chromeManagement: new RealChromeManagementClient(apiOptions),
-      serviceUsage: new RealServiceUsageClient(apiOptions),
-    }
   } else {
     logger.info(`${TAGS.MCP} Using REAL API clients.`)
-    apiClients = {
-      adminSdk: new RealAdminSdkClient(apiOptions),
-      cloudIdentity: new RealCloudIdentityClient(apiOptions),
-      chromePolicy: new RealChromePolicyClient(apiOptions),
-      chromeManagement: new RealChromeManagementClient(apiOptions),
-      serviceUsage: new RealServiceUsageClient(apiOptions),
-    }
+  }
+
+  const apiClients = {
+    adminSdk: new RealAdminSdkClient(apiOptions),
+    cloudIdentity: new RealCloudIdentityClient(apiOptions),
+    chromePolicy: new RealChromePolicyClient(apiOptions),
+    chromeManagement: new RealChromeManagementClient(apiOptions),
+    serviceUsage: new RealServiceUsageClient(apiOptions),
   }
 
   const toolOptions = {


### PR DESCRIPTION
The if (process.env.GOOGLE_API_ROOT_URL) and else branches in getServer() were textually identical — both constructed the same five RealXxxClient instances. The only differentiator (apiOptions.rootUrl) is set on the shared apiOptions before the branch. Hoists the construction out of the conditional.

Closes #59.