### PR TITLE
fix(evals): skip tool check in --dry-run instead of asserting expected==expected

### DIFF
--- a/test/evals/README.md
+++ b/test/evals/README.md
@@ -134,7 +134,9 @@ audit mode is silent"), use the judge instead.
 
 **Expected tool validation** checks that every tool listed in `expected_tools`
 was actually called by the agent. This catches a common failure mode: the agent
-_describes_ what it would do instead of actually doing it.
+_describes_ what it would do instead of actually doing it. Tool checks are
+skipped in `--dry-run` mode, since no agent runs and there are no actual tool
+calls to validate.
 
 ### Layer 2: LLM-as-judge (Gemini)
 

--- a/test/evals/run.js
+++ b/test/evals/run.js
@@ -47,7 +47,7 @@ import { fileURLToPath } from 'node:url'
 import fs from 'node:fs/promises'
 
 import { loadAllEvals, loadGlobalConfig } from './lib/loader.js'
-import { runChecks } from './lib/assertions.js'
+import { runChecks, checkForbidden, checkRequired } from './lib/assertions.js'
 import { createJudge } from './lib/judge.js'
 import { createEvalAgent } from './lib/agent.js'
 import { printConsole, writeResults } from './lib/reporter.js'
@@ -126,7 +126,14 @@ async function main() {
   if (dryRun) {
     console.log(`Dry run: validating ${evals.length} eval(s) against their golden responses...\n`)
     const results = evals.map(evalCase => {
-      const deterministic = runChecks(evalCase.goldenResponse, evalCase.expectedTools, evalCase)
+      const forbidden = checkForbidden(evalCase.goldenResponse, evalCase.forbiddenPatterns)
+      const required = checkRequired(evalCase.goldenResponse, evalCase.requiredPatterns)
+      const failures = [...forbidden.failures, ...required.failures]
+      const deterministic = {
+        passed: failures.length === 0,
+        failures,
+        toolsSkipped: true,
+      }
       return {
         id: evalCase.id,
         category: evalCase.category,
@@ -134,7 +141,7 @@ async function main() {
         passed: deterministic.passed,
         deterministic,
         judge: { passed: true, reasoning: 'skipped (dry run)' },
-        toolCalls: evalCase.expectedTools.map(name => ({ name, args: {} })),
+        toolCalls: [],
         responseText: evalCase.goldenResponse,
         durationMs: 0,
       }


### PR DESCRIPTION
Dry-run set actualTools = expectedTools, so checkTools(expected, expected) always returned true. Dry-run now runs only forbidden/required pattern checks against the golden response (the parts that actually validate the case), and the README notes the limitation.

Closes #49.