### PR TITLE
fix(evals): reject cases that set both fixtures and scenario

### DIFF
--- a/test/evals/lib/loader.js
+++ b/test/evals/lib/loader.js
@@ -114,7 +114,7 @@ export function loadEvalsFromFile(filepath, globalConfig) {
     const evalId = String(frontmatter.id)
     if (frontmatter.scenario && frontmatter.fixtures && frontmatter.fixtures.length > 0) {
       throw new Error(
-        `Eval case ${evalId} sets both \`fixtures:\` and \`scenario:\` — these are mutually exclusive (scenario replaces state, fixtures merge into state). Pick one.`
+        `Eval case ${evalId} sets both \`fixtures:\` and \`scenario:\` — these are mutually exclusive (scenario replaces state, fixtures merge into state). Pick one.`,
       )
     }
 

--- a/test/evals/lib/loader.js
+++ b/test/evals/lib/loader.js
@@ -111,8 +111,15 @@ export function loadEvalsFromFile(filepath, globalConfig) {
       ? perEvalForbidden
       : [...globalConfig.forbiddenPatterns, ...perEvalForbidden]
 
+    const evalId = String(frontmatter.id)
+    if (frontmatter.scenario && frontmatter.fixtures && frontmatter.fixtures.length > 0) {
+      throw new Error(
+        `Eval case ${evalId} sets both \`fixtures:\` and \`scenario:\` — these are mutually exclusive (scenario replaces state, fixtures merge into state). Pick one.`
+      )
+    }
+
     evals.push({
-      id: String(frontmatter.id),
+      id: evalId,
       category: frontmatter.category || path.basename(path.dirname(filepath)),
       priority: (frontmatter.priority || 'P2').toUpperCase(),
       tags: frontmatter.tags || [],

--- a/test/local/eval-loader.test.js
+++ b/test/local/eval-loader.test.js
@@ -16,6 +16,8 @@ limitations under the License.
 
 import { describe, test } from 'node:test'
 import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { loadGlobalConfig, loadEvalsFromFile, loadAllEvals } from '../evals/lib/loader.js'
@@ -125,6 +127,35 @@ describe('Eval Loader', () => {
       for (let i = 1; i < evals.length; i++) {
         const cmp = evals[i - 1].id.localeCompare(evals[i].id, undefined, { numeric: true })
         assert.ok(cmp <= 0, `${evals[i - 1].id} should come before ${evals[i].id}`)
+      }
+    })
+  })
+
+  describe('mutual exclusion of fixtures and scenario', () => {
+    test('When a case sets both fixtures and scenario, then loading throws a clear error', () => {
+      const config = loadGlobalConfig(evalsDir)
+      const content = [
+        'id: mutex-test',
+        'scenario: some-scenario',
+        'fixtures:',
+        '  - some-fixture.json',
+        '',
+        '## Prompt',
+        '',
+        'test prompt',
+      ].join('\n')
+      const tmpFile = path.join(os.tmpdir(), `eval-mutex-test-${Date.now()}.md`)
+      fs.writeFileSync(tmpFile, content, 'utf8')
+      try {
+        assert.throws(
+          () => loadEvalsFromFile(tmpFile, config),
+          err =>
+            err.message.includes('mutex-test') &&
+            err.message.includes('fixtures:') &&
+            err.message.includes('scenario:'),
+        )
+      } finally {
+        fs.unlinkSync(tmpFile)
       }
     })
   })


### PR DESCRIPTION
The eval runner sequence was resetState() -> mergeFixture() -> setState(applyScenario()) — the third call replaced the entire state, silently discarding fixtures if scenario was also set. Throws a clear error at case-load time if both fields are present. Adds a unit test.

Closes #48.