### PR TITLE
fix(test): use 'value' key in fake RealtimeUrlCheck to match other connectors and the real API

### DIFF
--- a/test/helpers/fake-api-server.js
+++ b/test/helpers/fake-api-server.js
@@ -178,7 +178,7 @@ function getInitialState() {
           ],
           'chrome.users.RealtimeUrlCheck': [
             {
-              policyValue: {
+              value: {
                 policySchema: 'chrome.users.RealtimeUrlCheck',
                 value: {
                   realtimeUrlCheckEnabled: 'ENTERPRISE_REAL_TIME_URL_CHECK_MODE_ENUM_ENABLED',


### PR DESCRIPTION
Every other connector entry in the fake server uses { value: { policySchema, value: {...} } } but RealtimeUrlCheck used policyValue. Tools read policy.value.value.realtimeUrlCheckEnabled, so against this fake the tool always reported the connector as disabled. Single-key rename in the fake.

Closes #50.