### PR TITLE
fix(server): handle SIGTERM for graceful Cloud Run shutdown

### DIFF
--- a/mcp-server.js
+++ b/mcp-server.js
@@ -399,10 +399,13 @@ async function main() {
   }
 }
 
-process.on('SIGINT', async () => {
+const shutdown = async () => {
   logger.error(`${TAGS.MCP} Shutting down server...`)
   // eslint-disable-next-line n/no-process-exit
   process.exit(0)
-})
+}
+
+process.on('SIGINT', shutdown)
+process.on('SIGTERM', shutdown)
 
 main()


### PR DESCRIPTION
Only SIGINT was handled. Cloud Run sends SIGTERM for graceful shutdown — without a handler the process died immediately, dropping in-flight SSE connections. Refactors the inline SIGINT handler into a named shutdown function and registers both SIGINT and SIGTERM against it.

Closes #57.