### PR TITLE
fix(tools): drop chained .describe() on orgUnitId in SEB tools

### DIFF
--- a/tools/definitions/check_seb_extension_status.js
+++ b/tools/definitions/check_seb_extension_status.js
@@ -47,7 +47,6 @@ The SEB extension is REQUIRED for advanced Chrome Enterprise Premium features li
         customerId: z.string().optional().describe('The Chrome customer ID (e.g. C012345).'),
         orgUnitId: z
           .string()
-          .describe('The ID of the organizational unit.')
           .describe('The ID of the organizational unit to check.'),
       },
       outputSchema: z

--- a/tools/definitions/check_seb_extension_status.js
+++ b/tools/definitions/check_seb_extension_status.js
@@ -45,9 +45,7 @@ export function registerCheckSebExtensionStatusTool(server, options, sessionStat
 The SEB extension is REQUIRED for advanced Chrome Enterprise Premium features like data masking. If not installed, use 'install_seb_extension' to fix it.`,
       inputSchema: {
         customerId: z.string().optional().describe('The Chrome customer ID (e.g. C012345).'),
-        orgUnitId: z
-          .string()
-          .describe('The ID of the organizational unit to check.'),
+        orgUnitId: z.string().describe('The ID of the organizational unit to check.'),
       },
       outputSchema: z
         .object({

--- a/tools/definitions/install_seb_extension.js
+++ b/tools/definitions/install_seb_extension.js
@@ -47,7 +47,6 @@ The SEB extension is REQUIRED for advanced Chrome Enterprise Premium features li
         customerId: z.string().optional().describe('The Chrome customer ID (e.g. C012345).'),
         orgUnitId: z
           .string()
-          .describe('The ID of the organizational unit.')
           .describe('The ID of the organizational unit where the extension will be force-installed.'),
       },
       outputSchema: z


### PR DESCRIPTION
check_seb_extension_status.js and install_seb_extension.js each had two .describe() calls on the orgUnitId Zod chain — only the second was visible (Zod returns a new schema per call). Edit artifact; removes the silent first call.

Closes #54.