### PR TITLE
fix(util): add 3s timeout to checkGCP metadata probe

### DIFF
--- a/lib/util/gcp.js
+++ b/lib/util/gcp.js
@@ -39,6 +39,7 @@ async function fetchMetadata(path) {
       'Metadata-Flavor': 'Google',
     },
     responseType: 'text',
+    timeout: 3000,
   })
 
   return response.data


### PR DESCRIPTION
checkGCP awaits an axios.get to http://metadata.google.internal with no timeout. On networks where 169.254.169.254 is routable but unreachable, the probe hangs until the OS TCP timeout (20-130s on Linux), blocking server startup. Adds a 3-second timeout to the axios call.

Closes #56.