### PR TITLE
fix(evals): default EXPERIMENT_DELETE_TOOL_ENABLED=true so m03 tests real agent behavior

### DIFF
--- a/test/evals/README.md
+++ b/test/evals/README.md
@@ -288,13 +288,14 @@ The runner accepts more flags (`--runs`, `--concurrency`, `--delay`,
 
 ### Environment variables
 
-| Variable         | Description                                                    | Default |
-| ---------------- | -------------------------------------------------------------- | ------- |
-| `GEMINI_API_KEY` | **Required.** Gemini API key for both the agent and the judge. | --      |
-| `CEP_BACKEND`    | `fake` (in-process mock) or `real` (live Google APIs).         | `fake`  |
-| `EVAL_CATEGORY`  | Alternative to `--category` flag.                              | --      |
-| `EVAL_IDS`       | Alternative to `--id` flag. Comma-separated.                   | --      |
-| `EVAL_TAGS`      | Alternative to `--tags` flag. Comma-separated.                 | --      |
+| Variable                        | Description                                                                                                                   | Default |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `GEMINI_API_KEY`                | **Required.** Gemini API key for both the agent and the judge.                                                                | --      |
+| `CEP_BACKEND`                   | `fake` (in-process mock) or `real` (live Google APIs).                                                                        | `fake`  |
+| `EVAL_CATEGORY`                 | Alternative to `--category` flag.                                                                                             | --      |
+| `EVAL_IDS`                      | Alternative to `--id` flag. Comma-separated.                                                                                  | --      |
+| `EVAL_TAGS`                     | Alternative to `--tags` flag. Comma-separated.                                                                                | --      |
+| `EXPERIMENT_DELETE_TOOL_ENABLED`| Registers the delete-tool experiment. The runner defaults this to `true` so cases like `m03` test real agent judgment. Set to `false` to disable. | `true`  |
 
 ### Output
 

--- a/test/evals/run.js
+++ b/test/evals/run.js
@@ -41,6 +41,11 @@ limitations under the License.
 import { config } from '@dotenvx/dotenvx'
 config({ quiet: true, ignore: ['MISSING_ENV_FILE'] })
 
+// Ensure the delete-tool experiment is on by default so evals that test the
+// agent's judgment (e.g. m03) exercise real production-with-experiment behavior.
+// The caller can still override by setting EXPERIMENT_DELETE_TOOL_ENABLED=false.
+process.env.EXPERIMENT_DELETE_TOOL_ENABLED ??= 'true'
+
 import { parseArgs } from 'node:util'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'


### PR DESCRIPTION
m03 expects the agent to refuse deletion. But delete_agent_dlp_rule only registers when EXPERIMENT_DELETE_TOOL_ENABLED is set — without the flag the tool isn't there and m03 'passes' for the wrong reason. Defaults the flag in the eval runner so m03 actually exercises agent judgment; user can still override.

Closes #51.