### PR TITLE
fix(tools): set skipAutoResolve on tools that don't take customerId

### DIFF
--- a/tools/definitions/check_and_enable_cep_api.js
+++ b/tools/definitions/check_and_enable_cep_api.js
@@ -161,6 +161,7 @@ This is a PREREQUISITE tool. Many other tools will fail if necessary APIs are di
             structuredContent: { apiStatuses },
           })
         },
+        skipAutoResolve: true,
       },
       options,
       sessionState,

--- a/tools/definitions/check_user_cep_license.js
+++ b/tools/definitions/check_user_cep_license.js
@@ -71,6 +71,7 @@ Use this to verify if an individual user (by email or unique ID) is licensed for
             })
           }
         },
+        skipAutoResolve: true,
       },
       options,
       sessionState,

--- a/tools/definitions/delete_agent_dlp_rule.js
+++ b/tools/definitions/delete_agent_dlp_rule.js
@@ -111,6 +111,7 @@ export function registerDeleteAgentDlpRuleTool(server, options, sessionState) {
             },
           })
         },
+        skipAutoResolve: true,
       },
       options,
       sessionState,

--- a/tools/definitions/delete_detector.js
+++ b/tools/definitions/delete_detector.js
@@ -90,6 +90,7 @@ Note: This will not automatically remove the detector from any DLP rules that re
             },
           })
         },
+        skipAutoResolve: true,
       },
       options,
       sessionState,

--- a/tools/definitions/get_dlp_rule.js
+++ b/tools/definitions/get_dlp_rule.js
@@ -103,6 +103,7 @@ export function registerGetDlpRuleTool(server, options, sessionState) {
             },
           })
         },
+        skipAutoResolve: true,
       },
       options,
       sessionState,

--- a/tools/definitions/list_detectors.js
+++ b/tools/definitions/list_detectors.js
@@ -113,6 +113,7 @@ Detectors are used within DLP rules to identify sensitive content. Use this to f
             },
           })
         },
+        skipAutoResolve: true,
       },
       options,
       sessionState,

--- a/tools/definitions/list_dlp_rules.js
+++ b/tools/definitions/list_dlp_rules.js
@@ -117,6 +117,7 @@ export function registerListDlpRulesTool(server, options, sessionState) {
             },
           })
         },
+        skipAutoResolve: true,
       },
       options,
       sessionState,


### PR DESCRIPTION
Seven tools register through guardedToolCall without skipAutoResolve: true even though they don't accept a customerId parameter. Each invocation either makes a wasted getCustomerId API call or logs 'MCP adminSdkClient not provided' as an error.

Adds skipAutoResolve: true to:
- check_user_cep_license
- check_and_enable_cep_api
- list_dlp_rules
- list_detectors
- get_dlp_rule
- delete_agent_dlp_rule
- delete_detector

Closes #52.