### PR TITLE
fix(util): derive ADC scope lists from SCOPES constant in both remediation paths

### DIFF
--- a/lib/util/auth-error.js
+++ b/lib/util/auth-error.js
@@ -22,7 +22,7 @@ limitations under the License.
  */
 
 import { execFileSync } from 'node:child_process'
-import { ERROR_MESSAGES } from '../constants.js'
+import { ERROR_MESSAGES, SCOPES } from '../constants.js'
 
 let cachedIsGcloudInstalled = null
 
@@ -135,7 +135,7 @@ export function getAuthErrorMessage(error) {
 
   if (isInsufficientScopes) {
     if (gcloudInstalled) {
-      instruction = `Your credentials have insufficient scopes. Please run:\ngcloud auth application-default login --scopes https://www.googleapis.com/auth/chrome.management.policy,https://www.googleapis.com/auth/chrome.management.reports.readonly,https://www.googleapis.com/auth/admin.reports.audit.readonly,https://www.googleapis.com/auth/admin.directory.orgunit.readonly,https://www.googleapis.com/auth/admin.directory.customer.readonly,https://www.googleapis.com/auth/cloud-identity.policies`
+      instruction = `Your credentials have insufficient scopes. Please run:\ngcloud auth application-default login --scopes ${Object.values(SCOPES).join(',')}`
     } else {
       instruction = `Your credentials have insufficient scopes and gcloud is not installed. Please install the Google Cloud SDK and then run the login command with required scopes.`
     }

--- a/tools/utils/wrapper.js
+++ b/tools/utils/wrapper.js
@@ -54,17 +54,7 @@ function getAuthRemediationMessage(status, isOAuth = false) {
 2. **Verify APIs are enabled:** Ensure \`admin.googleapis.com\`, \`chromemanagement.googleapis.com\`, \`chromepolicy.googleapis.com\`, and \`cloudidentity.googleapis.com\` are enabled in your Google Cloud project.`
   }
 
-  const scopesList = [
-    SCOPES.CHROME_MANAGEMENT_POLICY,
-    SCOPES.CHROME_MANAGEMENT_REPORTS_READONLY,
-    SCOPES.CHROME_MANAGEMENT_PROFILES_READONLY,
-    SCOPES.ADMIN_REPORTS_AUDIT_READONLY,
-    SCOPES.ADMIN_DIRECTORY_ORGUNIT_READONLY,
-    SCOPES.ADMIN_DIRECTORY_CUSTOMER_READONLY,
-    SCOPES.LICENSING,
-    SCOPES.CLOUD_IDENTITY_POLICIES,
-    SCOPES.CLOUD_PLATFORM,
-  ]
+  const scopesList = Object.values(SCOPES)
 
   const bashScopes = scopesList.map(s => `  "${s}"`).join('\n')
   const bashCommand = `SCOPES=(\n${bashScopes}\n)\ngcloud auth application-default login --scopes=$(IFS=,; echo "\${SCOPES[*]}")`


### PR DESCRIPTION
Three places listed required Google OAuth scopes for ADC and they had drifted: lib/util/auth-error.js had 6 scopes, tools/utils/wrapper.js had 9, and probeADC derived all 13 from the SCOPES constant. A user following the auth-error remediation command would still trip wrapper.js scope errors for the missing ones.

Replaces the hardcoded lists in auth-error.js and wrapper.js with derivation from Object.values(SCOPES), so all three paths stay in sync.

Closes #53.