### PR TITLE
fix(test): skip ADC probe in startup-log tests to eliminate flaky timing race

### DIFF
--- a/test/local/mcp-server.test.js
+++ b/test/local/mcp-server.test.js
@@ -95,10 +95,16 @@ describe('MCP Server in stdio mode', () => {
   })
 
   describe('MCP Server Startup Logs', () => {
+    // A dummy API root causes probeADC() to short-circuit immediately (it
+    // checks process.env.GOOGLE_API_ROOT_URL and returns early), which
+    // removes the 8-second network-probe window that was racing against the
+    // 12-second spawnSync timeout and causing intermittent failures (#47).
+    const NO_ADC_PROBE = 'http://localhost:1'
+
     test('When server starts with custom PORT, then it logs the correct port', () => {
       const serverPath = path.resolve(__dirname, '../../mcp-server.js')
       const result = spawnSync(process.execPath, [serverPath], {
-        env: { ...process.env, PORT: '4000', GCP_STDIO: 'false', CEP_LOG_LEVEL: 'info' },
+        env: { ...process.env, PORT: '4000', GCP_STDIO: 'false', CEP_LOG_LEVEL: 'info', GOOGLE_API_ROOT_URL: NO_ADC_PROBE },
         timeout: 12000,
       })
 
@@ -110,7 +116,7 @@ describe('MCP Server in stdio mode', () => {
     test('When server starts without PORT, then it assigns a random port', () => {
       const serverPath = path.resolve(__dirname, '../../mcp-server.js')
       const result = spawnSync(process.execPath, [serverPath], {
-        env: { ...process.env, GCP_STDIO: 'false', CEP_LOG_LEVEL: 'info' },
+        env: { ...process.env, GCP_STDIO: 'false', CEP_LOG_LEVEL: 'info', GOOGLE_API_ROOT_URL: NO_ADC_PROBE },
         timeout: 12000,
       })
 
@@ -128,14 +134,17 @@ describe('MCP Server in stdio mode', () => {
       })
       const port = server.address().port
 
-      const result = spawnSync(process.execPath, [serverPath], {
-        env: { ...process.env, PORT: port.toString(), GCP_STDIO: 'false', CEP_LOG_LEVEL: 'info' },
-        timeout: 12000,
-      })
+      let result
+      try {
+        result = spawnSync(process.execPath, [serverPath], {
+          env: { ...process.env, PORT: port.toString(), GCP_STDIO: 'false', CEP_LOG_LEVEL: 'info', GOOGLE_API_ROOT_URL: NO_ADC_PROBE },
+          timeout: 12000,
+        })
+      } finally {
+        server.close()
+      }
 
       const output = result.stderr.toString() + result.stdout.toString()
-      server.close()
-
       assert.match(output, /Fatal error: Port \d+ is already in use/)
     })
 

--- a/test/local/mcp-server.test.js
+++ b/test/local/mcp-server.test.js
@@ -104,7 +104,13 @@ describe('MCP Server in stdio mode', () => {
     test('When server starts with custom PORT, then it logs the correct port', () => {
       const serverPath = path.resolve(__dirname, '../../mcp-server.js')
       const result = spawnSync(process.execPath, [serverPath], {
-        env: { ...process.env, PORT: '4000', GCP_STDIO: 'false', CEP_LOG_LEVEL: 'info', GOOGLE_API_ROOT_URL: NO_ADC_PROBE },
+        env: {
+          ...process.env,
+          PORT: '4000',
+          GCP_STDIO: 'false',
+          CEP_LOG_LEVEL: 'info',
+          GOOGLE_API_ROOT_URL: NO_ADC_PROBE,
+        },
         timeout: 12000,
       })
 
@@ -137,7 +143,13 @@ describe('MCP Server in stdio mode', () => {
       let result
       try {
         result = spawnSync(process.execPath, [serverPath], {
-          env: { ...process.env, PORT: port.toString(), GCP_STDIO: 'false', CEP_LOG_LEVEL: 'info', GOOGLE_API_ROOT_URL: NO_ADC_PROBE },
+          env: {
+            ...process.env,
+            PORT: port.toString(),
+            GCP_STDIO: 'false',
+            CEP_LOG_LEVEL: 'info',
+            GOOGLE_API_ROOT_URL: NO_ADC_PROBE,
+          },
           timeout: 12000,
         })
       } finally {


### PR DESCRIPTION
Closes #47.

probeADC() in mcp-server.js makes real network calls and can take up to 8 seconds — nearly the entire 12-second spawnSync timeout used by the startup-log tests, leaving little margin for the banner to print before the child process is killed. In environments where ADC is slow or unreachable (CI, agent worktrees), the assertion racing the timeout produced intermittent failures.

Adds GOOGLE_API_ROOT_URL: 'http://localhost:1' to the env of the three affected tests, which trips the existing short-circuit in probeADC (mcp-server.js:105-107). Also moves server.close() into a try/finally in the port-collision test so a socket isn't leaked on assertion failure.

Verified: 3 consecutive clean runs of the full file.