### PR TITLE
fix(util): make gcloud quota-project probe async with per-call timeout

### DIFF
--- a/lib/util/auth-error.js
+++ b/lib/util/auth-error.js
@@ -21,99 +21,113 @@ limitations under the License.
  * quota project) and returns actionable remediation instructions.
  */
 
-import { execFileSync } from 'node:child_process'
+import { execFile } from 'node:child_process'
 import { ERROR_MESSAGES, SCOPES } from '../constants.js'
 
-let cachedIsGcloudInstalled = null
+const GCLOUD_CALL_TIMEOUT_MS = 1000
+const GCLOUD_TOTAL_BUDGET_MS = 5000
+
+let cachedIsGcloudInstalled = /** @type {boolean|null} */ (null)
+let gcloudCheckPromise = /** @type {Promise<boolean>|null} */ (null)
+
+/**
+ * Runs a gcloud command with a per-call timeout. Returns stdout or null on error/timeout.
+ * @param {string[]} args - Arguments to pass to gcloud.
+ * @returns {Promise<string|null>} The stdout output, or null if the call fails or times out.
+ */
+function runGcloud(args) {
+  return new Promise(resolve => {
+    const timer = setTimeout(() => resolve(null), GCLOUD_CALL_TIMEOUT_MS)
+    execFile('gcloud', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }, (err, stdout) => {
+      clearTimeout(timer)
+      resolve(err ? null : stdout)
+    })
+  })
+}
 
 /**
  * Checks if the Google Cloud SDK (gcloud) is installed on the system.
- * @returns {boolean} True if gcloud is installed, false otherwise.
+ * @returns {Promise<boolean>} True if gcloud is installed, false otherwise.
  */
 function isGcloudInstalled() {
   if (cachedIsGcloudInstalled !== null) {
-    return cachedIsGcloudInstalled
+    return Promise.resolve(cachedIsGcloudInstalled)
   }
-  try {
-    execFileSync('gcloud', ['--version'], { stdio: 'ignore' })
-    cachedIsGcloudInstalled = true
-  } catch {
-    cachedIsGcloudInstalled = false
+  if (!gcloudCheckPromise) {
+    gcloudCheckPromise = runGcloud(['--version']).then(result => {
+      cachedIsGcloudInstalled = result !== null
+      return cachedIsGcloudInstalled
+    })
   }
-  return cachedIsGcloudInstalled
+  return gcloudCheckPromise
 }
 
 /**
  * Attempts to suggest a suitable quota project ID using gcloud.
  * @param {string} errorMessage - The error message to parse for the API name.
- * @returns {string|null} A project ID if found, or null.
+ * @returns {Promise<string|null>} A project ID if found, or null.
  */
-function suggestQuotaProject(errorMessage) {
-  if (!isGcloudInstalled()) {
+async function suggestQuotaProject(errorMessage) {
+  if (!(await isGcloudInstalled())) {
     return null
   }
 
-  try {
-    // Try to get the current config project
-    const configProject = execFileSync('gcloud', ['config', 'get-value', 'project'], {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-    }).trim()
-    if (configProject && configProject !== '(unset)') {
-      return configProject
-    }
+  const budgetStart = Date.now()
 
-    // Identify the API from the error message
-    const apiMatch = errorMessage.match(/The ([a-z0-9.-]+) API requires/)
-    const apiName = apiMatch ? apiMatch[1] : null
-
-    // Get a list of active projects.
-    const projectsOutput = execFileSync(
-      'gcloud',
-      ['projects', 'list', '--filter=lifecycleState:ACTIVE', '--format=value(projectId)', '--limit=10'],
-      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
-    ).trim()
-
-    const candidates = projectsOutput.split('\n').filter(Boolean)
-
-    if (candidates.length === 0) {
-      return null
-    }
-
-    // If we know the API, check which project has it enabled
-    if (apiName) {
-      for (const projectId of candidates) {
-        try {
-          const serviceCheck = execFileSync(
-            'gcloud',
-            [
-              'services',
-              'list',
-              '--project',
-              projectId,
-              '--enabled',
-              `--filter=config.name:${apiName}`,
-              '--format=value(config.name)',
-            ],
-            { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
-          ).trim()
-
-          if (serviceCheck === apiName) {
-            return projectId // Found a project with the API enabled!
-          }
-        } catch {
-          // Ignore errors (e.g., insufficient permissions to list services)
-        }
-      }
-    }
-
-    // Fallback: Return the most recent project if no specific match found
-    return candidates[0]
-  } catch {
-    // Ignore errors during suggestion
+  const configOutput = await runGcloud(['config', 'get-value', 'project'])
+  const configProject = configOutput ? configOutput.trim() : ''
+  if (configProject && configProject !== '(unset)') {
+    return configProject
   }
 
-  return null
+  if (Date.now() - budgetStart >= GCLOUD_TOTAL_BUDGET_MS) {
+    return null
+  }
+
+  // Identify the API from the error message
+  const apiMatch = errorMessage.match(/The ([a-z0-9.-]+) API requires/)
+  const apiName = apiMatch ? apiMatch[1] : null
+
+  // Get a list of active projects.
+  const projectsOutput = await runGcloud([
+    'projects',
+    'list',
+    '--filter=lifecycleState:ACTIVE',
+    '--format=value(projectId)',
+    '--limit=10',
+  ])
+
+  const candidates = projectsOutput ? projectsOutput.trim().split('\n').filter(Boolean) : []
+
+  if (candidates.length === 0) {
+    return null
+  }
+
+  // If we know the API, check which project has it enabled
+  if (apiName) {
+    for (const projectId of candidates) {
+      if (Date.now() - budgetStart >= GCLOUD_TOTAL_BUDGET_MS) {
+        break
+      }
+
+      const serviceOutput = await runGcloud([
+        'services',
+        'list',
+        '--project',
+        projectId,
+        '--enabled',
+        `--filter=config.name:${apiName}`,
+        '--format=value(config.name)',
+      ])
+
+      if (serviceOutput && serviceOutput.trim() === apiName) {
+        return projectId
+      }
+    }
+  }
+
+  // Fallback: Return the most recent project if no specific match found
+  return candidates[0]
 }
 
 /**
@@ -124,8 +138,8 @@ function suggestQuotaProject(errorMessage) {
  * @param {Error} error - The original error object thrown during authentication.
  * @returns {string} A formatted error message with instructions.
  */
-export function getAuthErrorMessage(error) {
-  const gcloudInstalled = isGcloudInstalled()
+export async function getAuthErrorMessage(error) {
+  const gcloudInstalled = await isGcloudInstalled()
   const errorMessage = error.message || ''
   const isInsufficientScopes = errorMessage.toLowerCase().includes(ERROR_MESSAGES.INSUFFICIENT_SCOPES.toLowerCase())
   const isNoCredentials = errorMessage.toLowerCase().includes(ERROR_MESSAGES.NO_CREDENTIALS.toLowerCase())
@@ -146,7 +160,7 @@ export function getAuthErrorMessage(error) {
       instruction = `No credentials found and gcloud is not installed. Please install the Google Cloud SDK and then run gcloud auth application-default login.`
     }
   } else if (isQuotaProjectNotSet) {
-    const suggestedProject = suggestQuotaProject(errorMessage)
+    const suggestedProject = await suggestQuotaProject(errorMessage)
     if (suggestedProject) {
       instruction = `The API requires a quota project, which is not set by default. We found a potential quota project "${suggestedProject}".\n\nPlease run:\ngcloud auth application-default set-quota-project ${suggestedProject}`
     } else if (gcloudInstalled) {

--- a/lib/util/auth.js
+++ b/lib/util/auth.js
@@ -46,7 +46,7 @@ export async function getAuthClient(scopes, authToken) {
   try {
     return await auth.getClient()
   } catch (error) {
-    throw new Error(getAuthErrorMessage(error))
+    throw new Error(await getAuthErrorMessage(error))
   }
 }
 

--- a/lib/util/google-auth-provider.js
+++ b/lib/util/google-auth-provider.js
@@ -46,7 +46,7 @@ export class GoogleAuthProvider {
     try {
       return await auth.getClient()
     } catch (error) {
-      throw new Error(getAuthErrorMessage(error))
+      throw new Error(await getAuthErrorMessage(error))
     }
   }
 }

--- a/lib/util/helpers.js
+++ b/lib/util/helpers.js
@@ -75,11 +75,11 @@ export async function callWithRetry(fn, _description) {
     const errorMessage = error.message || ''
 
     if (errorMessage.toLowerCase().includes(ERROR_MESSAGES.INSUFFICIENT_SCOPES.toLowerCase())) {
-      throw new Error(getAuthErrorMessage(error))
+      throw new Error(await getAuthErrorMessage(error))
     }
 
     if (errorMessage.includes(ERROR_MESSAGES.QUOTA_PROJECT_NOT_SET)) {
-      throw new Error(getAuthErrorMessage(error))
+      throw new Error(await getAuthErrorMessage(error))
     }
 
     throw error

--- a/test/local/auth.test.js
+++ b/test/local/auth.test.js
@@ -95,103 +95,81 @@ describe('Auth', () => {
 
   describe('getAuthErrorMessage', () => {
     test('When a project with the required API enabled is found, then it is suggested', async () => {
-      const mockExecFileSync = mock.fn((cmd, args) => {
+      const mockExecFile = mock.fn((cmd, args, opts, cb) => {
+        let stdout = ''
         if (cmd === 'gcloud' && args.includes('--version')) {
-          return 'Google Cloud SDK'
-        }
-        if (cmd === 'gcloud' && args.includes('config') && args.includes('get-value')) {
-          return '(unset)\n'
-        }
-
-        // Return 3 projects
-        if (cmd === 'gcloud' && args.includes('projects') && args.includes('list') && args.includes('--limit=10')) {
-          return 'proj-1\nproj-2\nproj-3\n'
-        }
-
-        // Check for services list on specific projects
-        if (cmd === 'gcloud' && args.includes('services') && args.includes('list')) {
+          stdout = 'Google Cloud SDK'
+        } else if (cmd === 'gcloud' && args.includes('config') && args.includes('get-value')) {
+          stdout = '(unset)\n'
+        } else if (cmd === 'gcloud' && args.includes('projects') && args.includes('list') && args.includes('--limit=10')) {
+          stdout = 'proj-1\nproj-2\nproj-3\n'
+        } else if (cmd === 'gcloud' && args.includes('services') && args.includes('list')) {
           const projectIndex = args.indexOf('--project') + 1
           const projectId = args[projectIndex]
-
-          if (projectId === 'proj-1') {
-            return ''
-          } // Not enabled on proj-1
           if (projectId === 'proj-2') {
-            return 'admin.googleapis.com\n'
-          } // Enabled on proj-2
-          return ''
+            stdout = 'admin.googleapis.com\n'
+          }
         }
-
-        return ''
+        cb(null, stdout, '')
       })
 
       const { getAuthErrorMessage } = await esmock('../../lib/util/auth-error.js', {
         'node:child_process': {
-          execFileSync: mockExecFileSync,
+          execFile: mockExecFile,
         },
       })
 
       const error = new Error('The admin.googleapis.com API requires a quota project, which is not set by default.')
-      const message = getAuthErrorMessage(error)
+      const message = await getAuthErrorMessage(error)
 
       assert.match(message, /We found a potential quota project "proj-2"/)
       assert.match(message, /gcloud auth application-default set-quota-project proj-2/)
     })
 
     test('When no project has the API enabled, then it falls back to the most recent project', async () => {
-      const mockExecFileSync = mock.fn((cmd, args) => {
+      const mockExecFile = mock.fn((cmd, args, opts, cb) => {
+        let stdout = ''
         if (cmd === 'gcloud' && args.includes('--version')) {
-          return 'Google Cloud SDK'
+          stdout = 'Google Cloud SDK'
+        } else if (cmd === 'gcloud' && args.includes('config') && args.includes('get-value')) {
+          stdout = '(unset)\n'
+        } else if (cmd === 'gcloud' && args.includes('projects') && args.includes('list') && args.includes('--limit=10')) {
+          stdout = 'proj-1\nproj-2\n'
         }
-        if (cmd === 'gcloud' && args.includes('config') && args.includes('get-value')) {
-          return '(unset)\n'
-        }
-
-        if (cmd === 'gcloud' && args.includes('projects') && args.includes('list') && args.includes('--limit=10')) {
-          return 'proj-1\nproj-2\n'
-        }
-
-        if (cmd === 'gcloud' && args.includes('services') && args.includes('list')) {
-          return '' // Not enabled on any
-        }
-
-        return ''
+        cb(null, stdout, '')
       })
 
       const { getAuthErrorMessage } = await esmock('../../lib/util/auth-error.js', {
         'node:child_process': {
-          execFileSync: mockExecFileSync,
+          execFile: mockExecFile,
         },
       })
 
       const error = new Error('The admin.googleapis.com API requires a quota project, which is not set by default.')
-      const message = getAuthErrorMessage(error)
+      const message = await getAuthErrorMessage(error)
 
       assert.match(message, /We found a potential quota project "proj-1"/) // Fallback to first (most recent)
     })
 
     test('When no projects are found at all, then it falls back to a generic console URL message', async () => {
-      const mockExecFileSync = mock.fn((cmd, args) => {
+      const mockExecFile = mock.fn((cmd, args, opts, cb) => {
+        let stdout = ''
         if (cmd === 'gcloud' && args.includes('--version')) {
-          return 'Google Cloud SDK'
+          stdout = 'Google Cloud SDK'
+        } else if (cmd === 'gcloud' && args.includes('config') && args.includes('get-value')) {
+          stdout = '(unset)\n'
         }
-        if (cmd === 'gcloud' && args.includes('config') && args.includes('get-value')) {
-          return '(unset)\n'
-        }
-        if (cmd === 'gcloud' && args.includes('projects') && args.includes('list')) {
-          return ''
-        }
-        return ''
+        cb(null, stdout, '')
       })
 
       const { getAuthErrorMessage } = await esmock('../../lib/util/auth-error.js', {
         'node:child_process': {
-          execFileSync: mockExecFileSync,
+          execFile: mockExecFile,
         },
       })
 
       const error = new Error('The admin.googleapis.com API requires a quota project, which is not set by default.')
-      const message = getAuthErrorMessage(error)
+      const message = await getAuthErrorMessage(error)
 
       assert.match(message, /Google Cloud Console/)
       assert.match(message, /console\.cloud\.google\.com\/cloud-resource-manager/)
@@ -199,24 +177,24 @@ describe('Auth', () => {
     })
 
     test('When a project is already configured in gcloud, then it uses that project directly', async () => {
-      const mockExecFileSync = mock.fn((cmd, args) => {
+      const mockExecFile = mock.fn((cmd, args, opts, cb) => {
+        let stdout = ''
         if (cmd === 'gcloud' && args.includes('--version')) {
-          return 'Google Cloud SDK'
+          stdout = 'Google Cloud SDK'
+        } else if (cmd === 'gcloud' && args.includes('config') && args.includes('get-value')) {
+          stdout = 'configured-project\n'
         }
-        if (cmd === 'gcloud' && args.includes('config') && args.includes('get-value')) {
-          return 'configured-project\n'
-        }
-        return ''
+        cb(null, stdout, '')
       })
 
       const { getAuthErrorMessage } = await esmock('../../lib/util/auth-error.js', {
         'node:child_process': {
-          execFileSync: mockExecFileSync,
+          execFile: mockExecFile,
         },
       })
 
       const error = new Error('The admin.googleapis.com API requires a quota project, which is not set by default.')
-      const message = getAuthErrorMessage(error)
+      const message = await getAuthErrorMessage(error)
 
       assert.match(message, /We found a potential quota project "configured-project"/)
       assert.match(message, /gcloud auth application-default set-quota-project configured-project/)

--- a/test/local/auth.test.js
+++ b/test/local/auth.test.js
@@ -101,7 +101,12 @@ describe('Auth', () => {
           stdout = 'Google Cloud SDK'
         } else if (cmd === 'gcloud' && args.includes('config') && args.includes('get-value')) {
           stdout = '(unset)\n'
-        } else if (cmd === 'gcloud' && args.includes('projects') && args.includes('list') && args.includes('--limit=10')) {
+        } else if (
+          cmd === 'gcloud' &&
+          args.includes('projects') &&
+          args.includes('list') &&
+          args.includes('--limit=10')
+        ) {
           stdout = 'proj-1\nproj-2\nproj-3\n'
         } else if (cmd === 'gcloud' && args.includes('services') && args.includes('list')) {
           const projectIndex = args.indexOf('--project') + 1
@@ -133,7 +138,12 @@ describe('Auth', () => {
           stdout = 'Google Cloud SDK'
         } else if (cmd === 'gcloud' && args.includes('config') && args.includes('get-value')) {
           stdout = '(unset)\n'
-        } else if (cmd === 'gcloud' && args.includes('projects') && args.includes('list') && args.includes('--limit=10')) {
+        } else if (
+          cmd === 'gcloud' &&
+          args.includes('projects') &&
+          args.includes('list') &&
+          args.includes('--limit=10')
+        ) {
           stdout = 'proj-1\nproj-2\n'
         }
         cb(null, stdout, '')


### PR DESCRIPTION
Closes #55.

`suggestQuotaProject` in `lib/util/auth-error.js` issued up to 12 sequential `execFileSync('gcloud', ...)` calls on the event loop. The function is reachable from `getAuthErrorMessage` → `callWithRetry`, which runs in every API method's error handler. On a workstation with many GCP projects, the event loop was blocked for 10–50 seconds during error handling.

This PR converts the calls to async `execFile` with a 1s per-call timeout and a 5s total budget. On timeout or error the function continues with what it has collected. `getAuthErrorMessage` is now async; call sites in `helpers.js` are awaited. Existing `auth.test.js` mocks are updated to the callback-style `execFile`.