### PR TITLE
fix(evals): tighten P0-priority detection and Gemini options arg

### DIFF
--- a/test/evals/run.js
+++ b/test/evals/run.js
@@ -348,12 +348,12 @@ async function main() {
     writeResults(results, args.output)
 
     // Automatically generate AI failure summary for CI runs
-    if (args.priority && args.priority.includes('P0') && hasFailures) {
+    if (Array.isArray(args.priority) && args.priority.some(p => p === 'P0') && hasFailures) {
       console.log(`\nP0 tests failed. Generating AI summary for CI...`)
       try {
         const { GoogleGenerativeAI } = await import('@google/generative-ai')
         const genAI = new GoogleGenerativeAI(apiKey)
-        const model = genAI.getGenerativeModel({ model: 'gemini-3.1-flash-lite-preview' }, baseUrl ? { baseUrl } : {})
+        const model = genAI.getGenerativeModel({ model: 'gemini-3.1-flash-lite-preview' }, baseUrl ? { baseUrl } : undefined)
 
         const failedResults = results.filter(r => !r.passed)
         const failureDetails = failedResults

--- a/test/evals/run.js
+++ b/test/evals/run.js
@@ -353,7 +353,10 @@ async function main() {
       try {
         const { GoogleGenerativeAI } = await import('@google/generative-ai')
         const genAI = new GoogleGenerativeAI(apiKey)
-        const model = genAI.getGenerativeModel({ model: 'gemini-3.1-flash-lite-preview' }, baseUrl ? { baseUrl } : undefined)
+        const model = genAI.getGenerativeModel(
+          { model: 'gemini-3.1-flash-lite-preview' },
+          baseUrl ? { baseUrl } : undefined,
+        )
 
         const failedResults = results.filter(r => !r.passed)
         const failureDetails = failedResults


### PR DESCRIPTION
Two small correctness fixes in `test/evals/run.js`'s CI-only AI summary path.

## 1. P0-priority detection

The check that gates the AI failure summary used `args.priority && args.priority.includes('P0')`. `args.priority` is parsed from a comma-separated string into an array around line 117, so the `.includes` call was an Array#includes — correct in practice today, but it relies on the input always being an array. If the CLI ever passed `args.priority` as a string (e.g., `--priority=P0-critical`), the substring semantics of String#includes would silently match `'P0-critical'` as a P0 run.

Switch to `Array.isArray(args.priority) && args.priority.some(p => p === 'P0')` to make the exact-token intent explicit and reject non-array inputs cleanly.

## 2. Gemini options arg

The second argument to `getGenerativeModel` used a ternary `baseUrl ? { baseUrl } : {}`. Passing `{}` adds a no-op second argument; passing `undefined` lets the SDK fall through to its own defaults consistently with how it handles a missing arg in other call sites.

Switch the fallback to `undefined`.

## Notes

Both findings originally surfaced via the AI code-quality scanner — replaces #73 with a more descriptive title/body and a clean commit.