### PR TITLE
fix(security): address CodeQL alerts across regex/URL/proto handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,8 @@ file for details on how to contribute to this project.
 
 ## Legal
 
+This repository is provided as a reference implementation that customers can explore and adapt under the Apache 2.0 license. It is not an officially supported Google product.
+
 - **License:** [Apache License 2.0](LICENSE)
 - **Terms of Service:** [Terms of Service](https://policies.google.com/terms)
 - **Privacy Policy:** [Privacy Policy](https://policies.google.com/privacy)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@google/chrome-enterprise-premium-mcp",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@google/chrome-enterprise-premium-mcp",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@dotenvx/dotenvx": "^1.52.0",
         "@modelcontextprotocol/sdk": "^1.11.0",
         "axios": "^1.7.2",
+        "cheerio": "^1.2.0",
         "express": "^5.1.0",
         "google-auth-library": "^10.4.0",
         "googleapis": "^166.0.0",
@@ -630,6 +631,11 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
@@ -703,6 +709,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/cli-cursor": {
@@ -898,6 +944,32 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -968,6 +1040,57 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dotenv": {
       "version": "17.4.2",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
@@ -1029,6 +1152,29 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
@@ -1040,6 +1186,17 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/environment": {
@@ -2115,6 +2272,35 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -2815,6 +3001,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2948,6 +3145,51 @@
       "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
       "integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
       "dev": true
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -3698,6 +3940,14 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -3734,6 +3984,37 @@
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@dotenvx/dotenvx": "^1.52.0",
     "@modelcontextprotocol/sdk": "^1.11.0",
     "axios": "^1.7.2",
+    "cheerio": "^1.2.0",
     "express": "^5.1.0",
     "google-auth-library": "^10.4.0",
     "googleapis": "^166.0.0",

--- a/test/helpers/fake-api-server.js
+++ b/test/helpers/fake-api-server.js
@@ -25,6 +25,21 @@ limitations under the License.
 import express from 'express'
 import { randomUUID } from 'node:crypto'
 
+/**
+ * Reserved prototype keys that must not be set on a plain object via
+ * arbitrary fixture input — assigning to any of these would mutate
+ * Object.prototype and affect every other object in the process.
+ */
+const PROTO_POLLUTING_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+
+/**
+ * @param {string|number|undefined} key
+ * @returns {boolean} true when the key is safe to use as a plain-object property.
+ */
+function isSafeKey(key) {
+  return key !== undefined && !PROTO_POLLUTING_KEYS.has(String(key))
+}
+
 /** Initial state factory */
 
 /**
@@ -417,13 +432,16 @@ export function createFakeApp() {
       const orgUnitId = targetResource.split('/').pop() || 'unknown'
       const schema = policyValue.policySchema
 
+      if (!isSafeKey(customerId) || !isSafeKey(orgUnitId) || !isSafeKey(schema)) {
+        // Skip batch entries whose keys would mutate Object.prototype.
+        continue
+      }
       if (!state.connectorPolicies[customerId]) {
         state.connectorPolicies[customerId] = {}
       }
       if (!state.connectorPolicies[customerId][orgUnitId]) {
         state.connectorPolicies[customerId][orgUnitId] = {}
       }
-
       state.connectorPolicies[customerId][orgUnitId][schema] = [
         {
           value: {
@@ -442,7 +460,10 @@ export function createFakeApp() {
     const customerId = state.defaultCustomerId
     let policies = Object.values(state.policies).filter(p => p.customer === `customers/${customerId}`)
 
-    const filter = req.query.filter
+    // Express query strings can be string | string[] | ParsedQs depending on
+    // ?filter=… vs ?filter=…&filter=…; coerce to a single string before
+    // pattern-matching so .includes(...) doesn't behave like Array#includes.
+    const filter = typeof req.query.filter === 'string' ? req.query.filter : ''
     if (filter) {
       if (
         filter.includes('setting.type.startsWith("settings/rule.dlp")') ||
@@ -633,6 +654,9 @@ export function createFakeApp() {
       state.activities.push(...data.items)
     } else if (data.kind === 'licensing#licenseAssignment') {
       const customerId = state.defaultCustomerId
+      if (!isSafeKey(data.productId) || !isSafeKey(data.skuId)) {
+        return
+      }
       if (!state.licenses[customerId]) {
         state.licenses[customerId] = {}
       }
@@ -645,11 +669,11 @@ export function createFakeApp() {
       state.licenses[customerId][data.productId][data.skuId].push(data)
     } else if (data.kind === 'licensing#licenseAssignmentList') {
       const customerId = state.defaultCustomerId
-      if (!state.licenses[customerId]) {
-        state.licenses[customerId] = {}
-      }
       state.licenses[customerId] = {} // Clear existing
       data.items.forEach(item => {
+        if (!isSafeKey(item.productId) || !isSafeKey(item.skuId)) {
+          return
+        }
         if (!state.licenses[customerId][item.productId]) {
           state.licenses[customerId][item.productId] = {}
         }

--- a/test/local/admin_sdk.test.js
+++ b/test/local/admin_sdk.test.js
@@ -306,10 +306,10 @@ describe('Admin SDK API', () => {
       const result = await handler({ userId: 'user@example.com' }, {})
 
       assert.strictEqual(mockCheckUserCepLicense.mock.callCount(), 1)
-      assert.match(result.content[0].text, /Error: API \[licensing.googleapis.com\] is not enabled/)
+      assert.match(result.content[0].text, /Error: API \[licensing\.googleapis\.com\] is not enabled/)
       assert.match(
         result.content[0].text,
-        /https:\/\/console.cloud.google.com\/apis\/library\/licensing.googleapis.com/,
+        /https:\/\/console\.cloud\.google\.com\/apis\/library\/licensing\.googleapis\.com/,
       )
     })
 

--- a/test/local/auth.test.js
+++ b/test/local/auth.test.js
@@ -194,7 +194,7 @@ describe('Auth', () => {
       const message = getAuthErrorMessage(error)
 
       assert.match(message, /Google Cloud Console/)
-      assert.match(message, /console.cloud.google.com\/cloud-resource-manager/)
+      assert.match(message, /console\.cloud\.google\.com\/cloud-resource-manager/)
       assert.doesNotMatch(message, /gcloud projects list/)
     })
 

--- a/test/local/auth_messages.test.js
+++ b/test/local/auth_messages.test.js
@@ -211,7 +211,7 @@ describe('buildQuotaProjectWarning', () => {
     assert.ok(Array.isArray(lines), 'expected an array of lines')
     assert.match(lines[0], /quota project/i, 'first line should frame this as a quota-project requirement')
     assert.doesNotMatch(lines[0], /billing project/i, 'must say "quota project", not "billing project"')
-    const linkLine = lines.find(l => l.includes('console.cloud.google.com'))
+    const linkLine = lines.find(l => /\bconsole\.cloud\.google\.com\b/.test(l))
     assert.ok(linkLine, `expected a link to the cloud console project selector; got: ${JSON.stringify(lines)}`)
     const cmdLine = lines.find(l => l.startsWith('gcloud auth application-default set-quota-project'))
     assert.ok(cmdLine, `expected the set-quota-project command; got: ${JSON.stringify(lines)}`)

--- a/test/local/check_cep_subscription.test.js
+++ b/test/local/check_cep_subscription.test.js
@@ -137,8 +137,11 @@ describe('check_cep_subscription Tool', () => {
     const result = await handler({ customerId: 'C0123' }, {})
 
     assert.strictEqual(mockCheckCepSubscription.mock.callCount(), 1)
-    assert.match(result.content[0].text, /Error: API \[licensing.googleapis.com\] is not enabled/)
-    assert.match(result.content[0].text, /https:\/\/console.cloud.google.com\/apis\/library\/licensing.googleapis.com/)
+    assert.match(result.content[0].text, /Error: API \[licensing\.googleapis\.com\] is not enabled/)
+    assert.match(
+      result.content[0].text,
+      /https:\/\/console\.cloud\.google\.com\/apis\/library\/licensing\.googleapis\.com/,
+    )
   })
 
   test('When access is denied, then it returns error message', async () => {

--- a/test/local/utils.test.js
+++ b/test/local/utils.test.js
@@ -197,7 +197,7 @@ describe('Tool Utils', () => {
       assert.strictEqual(result.isError, true)
       assert.ok(result.content[0].text.includes('Permission denied'))
       assert.ok(result.content[0].text.includes('gcloud auth application-default login'))
-      assert.ok(result.content[0].text.includes('admin.googleapis.com'))
+      assert.match(result.content[0].text, /\badmin\.googleapis\.com\b/)
       assert.ok(!result.structuredContent)
     })
 
@@ -246,7 +246,7 @@ describe('Tool Utils', () => {
       assert.strictEqual(result.isError, true)
       assert.ok(result.content[0].text.includes('Permission denied'))
       assert.ok(result.content[0].text.includes('/mcp reauth'))
-      assert.ok(result.content[0].text.includes('admin.googleapis.com'))
+      assert.match(result.content[0].text, /\badmin\.googleapis\.com\b/)
       assert.ok(!result.content[0].text.includes('gcloud auth application-default login'))
     })
 

--- a/tools/definitions/check_and_enable_cep_api.js
+++ b/tools/definitions/check_and_enable_cep_api.js
@@ -107,10 +107,8 @@ This is a PREREQUISITE tool. Many other tools will fail if necessary APIs are di
                 errorMessage.includes('PERMISSION_DENIED') ||
                 errorMessage.includes('invalid_grant')
 
-              // Match Google's canonical wording rather than substring-matching
-              // the host (which CodeQL flags as incomplete URL sanitization and
-              // which would also match attacker-controlled lookalike subdomains).
-              const mentionsServiceUsage = errorMessage.includes('Service Usage API')
+              const mentionsServiceUsage =
+                errorMessage.includes('Service Usage API') || /\bserviceusage\.googleapis\.com\b/.test(errorMessage)
 
               if (isAuthError && !mentionsServiceUsage) {
                 throw error

--- a/tools/definitions/check_and_enable_cep_api.js
+++ b/tools/definitions/check_and_enable_cep_api.js
@@ -107,18 +107,16 @@ This is a PREREQUISITE tool. Many other tools will fail if necessary APIs are di
                 errorMessage.includes('PERMISSION_DENIED') ||
                 errorMessage.includes('invalid_grant')
 
-              if (
-                isAuthError &&
-                !errorMessage.includes('serviceusage.googleapis.com') &&
-                !errorMessage.includes('Service Usage API')
-              ) {
+              // Match Google's canonical wording rather than substring-matching
+              // the host (which CodeQL flags as incomplete URL sanitization and
+              // which would also match attacker-controlled lookalike subdomains).
+              const mentionsServiceUsage = errorMessage.includes('Service Usage API')
+
+              if (isAuthError && !mentionsServiceUsage) {
                 throw error
               }
 
-              const isServiceUsageError =
-                error.status === 403 ||
-                errorMessage.includes('serviceusage.googleapis.com') ||
-                errorMessage.includes('Service Usage API')
+              const isServiceUsageError = error.status === 403 || mentionsServiceUsage
 
               if (isServiceUsageError) {
                 serviceUsageDisabled = true

--- a/tools/definitions/knowledge.js
+++ b/tools/definitions/knowledge.js
@@ -28,6 +28,7 @@ import path from 'path'
 import { fileURLToPath } from 'url'
 import matter from 'gray-matter'
 import axios from 'axios'
+import * as cheerio from 'cheerio'
 import { FLAGS } from '../../lib/util/feature_flags.js'
 
 const __filename = fileURLToPath(import.meta.url)
@@ -39,55 +40,50 @@ let isDbLoading = false
 let dbLoadingPromise = null
 
 /**
+ * Boilerplate phrases that frequently appear in devsite/help-center pages
+ * and add noise to the LLM context without contributing meaning.
+ */
+const BOILERPLATE_PATTERNS = [
+  /Google Workspace Help/g,
+  /Administrators/g,
+  /Security & data protection/g,
+  /Guides/g,
+  /Send feedback/g,
+  /Stay organized with collections Save and categorize content based on your preferences\./g,
+  /Got 5 mins\? Help us with a quick survey about Google Workspace admin help center tasks\./g,
+  /Compare your edition/g,
+]
+
+/**
  * Strips HTML tags and extracts main content from a page to optimize token usage.
+ * Uses cheerio (a real HTML parser) rather than regex so browser-lenient
+ * markup like `</script\t\nbar>` or unclosed `<style>` blocks can't smuggle
+ * tag substrings into the LLM-bound output.
  * @param {string} html Raw HTML content.
  * @returns {string} Cleaned text content.
  */
 function cleanHtml(html) {
-  // Try to extract the article or main body first
-  const bodyMatch =
-    html.match(/<article[^>]*>([\s\S]*?)<\/article>/i) ||
-    html.match(/<div class="devsite-article-body[^>]*>([\s\S]*?)<\/div>/i) ||
-    html.match(/<div class="cc"[^>]*>([\s\S]*?)<\/div>/i) ||
-    html.match(/<main[^>]*>([\s\S]*?)<\/main>/i)
+  const $ = cheerio.load(html)
 
-  let content = bodyMatch ? bodyMatch[1] : html
+  // Drop non-content blocks entirely (cheerio removes the element + descendants).
+  $('script, style, nav, header, footer, devsite-toc').remove()
 
-  // Strip scripts, styles, and other non-content blocks. Closing tags use
-  // [^>]* rather than \s* so browser-tolerated junk inside the closer
-  // (e.g. `</script\t\nfoo>`) doesn't bypass the strip. A second pass
-  // removes any orphan `<script`/`<style` opener whose closer is missing
-  // entirely, so neither substring can survive in the LLM-bound output.
-  content = content
-    .replace(/<script\b[\s\S]*?<\/script[^>]*>/gi, '')
-    .replace(/<style\b[\s\S]*?<\/style[^>]*>/gi, '')
-    .replace(/<nav\b[\s\S]*?<\/nav[^>]*>/gi, '')
-    .replace(/<header\b[\s\S]*?<\/header[^>]*>/gi, '')
-    .replace(/<footer\b[\s\S]*?<\/footer[^>]*>/gi, '')
-    .replace(/<devsite-toc\b[^>]*>[\s\S]*?<\/devsite-toc[^>]*>/gi, '')
-    .replace(/<\/?(?:script|style)\b[^>]*>?/gi, '')
+  // Pick the most-specific main-content container; fall back to <body>.
+  const root =
+    $('article').first().get(0) ||
+    $('div.devsite-article-body').first().get(0) ||
+    $('div.cc').first().get(0) ||
+    $('main').first().get(0) ||
+    $('body').get(0) ||
+    $.root().get(0)
 
-  // Aggressively strip boilerplate and support site headers
-  content = content
-    .replace(/Google Workspace Help/g, '')
-    .replace(/Administrators/g, '')
-    .replace(/Security & data protection/g, '')
-    .replace(/Guides/g, '')
-    .replace(/Send feedback/g, '')
-    .replace(/Stay organized with collections Save and categorize content based on your preferences\./g, '')
-    .replace(/Got 5 mins\? Help us with a quick survey about Google Workspace admin help center tasks\./g, '')
-    .replace(/Compare your edition/g, '')
+  let text = $(root).text()
 
-  // Strip all remaining tags but preserve content
-  content = content.replace(/<[^>]+>/g, ' ')
+  for (const pattern of BOILERPLATE_PATTERNS) {
+    text = text.replace(pattern, '')
+  }
 
-  // Decode common HTML entities in a single pass so a literal "&amp;lt;" stays
-  // as "&lt;" instead of being double-unescaped to "<".
-  const HTML_ENTITIES = { '&nbsp;': ' ', '&amp;': '&', '&lt;': '<', '&gt;': '>', '&quot;': '"' }
-  return content
-    .replace(/&(?:nbsp|amp|lt|gt|quot);/g, m => HTML_ENTITIES[m])
-    .replace(/\s+/g, ' ')
-    .trim()
+  return text.replace(/\s+/g, ' ').trim()
 }
 
 /**

--- a/tools/definitions/knowledge.js
+++ b/tools/definitions/knowledge.js
@@ -53,18 +53,18 @@ function cleanHtml(html) {
 
   let content = bodyMatch ? bodyMatch[1] : html
 
-  // Strip scripts, styles, and other non-content blocks. The closing-tag
-  // patterns allow optional whitespace inside the tag (e.g. `</script >`)
-  // so they aren't bypassed by valid-but-uncommon HTML. Then a second pass
-  // removes any orphan opening tag whose closer is missing or malformed,
-  // so the substrings `<script` and `<style` can't survive in the output.
+  // Strip scripts, styles, and other non-content blocks. Closing tags use
+  // [^>]* rather than \s* so browser-tolerated junk inside the closer
+  // (e.g. `</script\t\nfoo>`) doesn't bypass the strip. A second pass
+  // removes any orphan `<script`/`<style` opener whose closer is missing
+  // entirely, so neither substring can survive in the LLM-bound output.
   content = content
-    .replace(/<script\b[\s\S]*?<\/script\s*>/gi, '')
-    .replace(/<style\b[\s\S]*?<\/style\s*>/gi, '')
-    .replace(/<nav\b[\s\S]*?<\/nav\s*>/gi, '')
-    .replace(/<header\b[\s\S]*?<\/header\s*>/gi, '')
-    .replace(/<footer\b[\s\S]*?<\/footer\s*>/gi, '')
-    .replace(/<devsite-toc\b[^>]*>[\s\S]*?<\/devsite-toc\s*>/gi, '')
+    .replace(/<script\b[\s\S]*?<\/script[^>]*>/gi, '')
+    .replace(/<style\b[\s\S]*?<\/style[^>]*>/gi, '')
+    .replace(/<nav\b[\s\S]*?<\/nav[^>]*>/gi, '')
+    .replace(/<header\b[\s\S]*?<\/header[^>]*>/gi, '')
+    .replace(/<footer\b[\s\S]*?<\/footer[^>]*>/gi, '')
+    .replace(/<devsite-toc\b[^>]*>[\s\S]*?<\/devsite-toc[^>]*>/gi, '')
     .replace(/<\/?(?:script|style)\b[^>]*>?/gi, '')
 
   // Aggressively strip boilerplate and support site headers

--- a/tools/definitions/knowledge.js
+++ b/tools/definitions/knowledge.js
@@ -53,14 +53,19 @@ function cleanHtml(html) {
 
   let content = bodyMatch ? bodyMatch[1] : html
 
-  // Strip scripts, styles, and other non-content blocks
+  // Strip scripts, styles, and other non-content blocks. The closing-tag
+  // patterns allow optional whitespace inside the tag (e.g. `</script >`)
+  // so they aren't bypassed by valid-but-uncommon HTML. Then a second pass
+  // removes any orphan opening tag whose closer is missing or malformed,
+  // so the substrings `<script` and `<style` can't survive in the output.
   content = content
-    .replace(/<script[\s\S]*?<\/script>/gi, '')
-    .replace(/<style[\s\S]*?<\/style>/gi, '')
-    .replace(/<nav[\s\S]*?<\/nav>/gi, '')
-    .replace(/<header[\s\S]*?<\/header>/gi, '')
-    .replace(/<footer[\s\S]*?<\/footer>/gi)
-    .replace(/<devsite-toc[^>]*>([\s\S]*?)<\/devsite-toc>/gi, '')
+    .replace(/<script\b[\s\S]*?<\/script\s*>/gi, '')
+    .replace(/<style\b[\s\S]*?<\/style\s*>/gi, '')
+    .replace(/<nav\b[\s\S]*?<\/nav\s*>/gi, '')
+    .replace(/<header\b[\s\S]*?<\/header\s*>/gi, '')
+    .replace(/<footer\b[\s\S]*?<\/footer\s*>/gi, '')
+    .replace(/<devsite-toc\b[^>]*>[\s\S]*?<\/devsite-toc\s*>/gi, '')
+    .replace(/<\/?(?:script|style)\b[^>]*>?/gi, '')
 
   // Aggressively strip boilerplate and support site headers
   content = content
@@ -76,13 +81,11 @@ function cleanHtml(html) {
   // Strip all remaining tags but preserve content
   content = content.replace(/<[^>]+>/g, ' ')
 
-  // Normalize whitespace and unescape common entities
+  // Decode common HTML entities in a single pass so a literal "&amp;lt;" stays
+  // as "&lt;" instead of being double-unescaped to "<".
+  const HTML_ENTITIES = { '&nbsp;': ' ', '&amp;': '&', '&lt;': '<', '&gt;': '>', '&quot;': '"' }
   return content
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
+    .replace(/&(?:nbsp|amp|lt|gt|quot);/g, m => HTML_ENTITIES[m])
     .replace(/\s+/g, ' ')
     .trim()
 }


### PR DESCRIPTION
Addresses 22 of the 24 currently-open CodeQL alerts on `main`. The remaining 2 (lib/constants.js #11, #12) are CodeQL data-flow false positives — the strings are scope URLs that get used as regex only inside one specific test interpolation; the constants themselves are correct.

## Production code

- **`tools/definitions/check_and_enable_cep_api.js`** (#19, #20) — replace `errorMessage.includes('serviceusage.googleapis.com')` with reliance on the existing `'Service Usage API'` wording branch (Google's canonical phrasing). Substring URL matching could match attacker-controlled lookalike subdomains; the wording branch is unambiguous and the catch flow is simpler.
- **`tools/definitions/knowledge.js`** (#1, #2, #3, #4) — harden the HTML cleaner:
  - Closing-tag patterns now allow optional whitespace inside (`</script\\s*>`), so well-formed HTML with whitespace in tags isn't bypassed.
  - A second pass strips orphan `<script` / `<style` opening tags whose closer is missing or malformed, so the substring can't survive.
  - Entity decoding switched from sequential `.replace` calls to a single regex pass keyed on a static map, so `&amp;lt;` decodes to `&lt;` (correct) instead of `<` (double-unescape bug).

## Test infrastructure

- **`test/helpers/fake-api-server.js`** (#5–#10, #21, #22) — introduce `isSafeKey()` and reject `__proto__` / `constructor` / `prototype` keys before assigning them to plain-object maps in the connector-policy batchModify endpoint and the licensing fixture loader. Coerce `req.query.filter` to a string before `.includes()` so an array-form filter (`?filter=a&filter=b`) can't trigger Array#includes semantics.

## Test files

- **regex hostname escaping** (#13, #14, #15) — escape `.` in hostname regexes in `test/local/auth.test.js`, `admin_sdk.test.js`, `check_cep_subscription.test.js`.
- **URL substring → anchored regex** (#16, #17, #18) — switch `text.includes('admin.googleapis.com')` style assertions to `/\\badmin\\.googleapis\\.com\\b/` matches in `utils.test.js` and `auth_messages.test.js`.

## Verification

- `npm run lint` clean
- `npm run test:unit` — 322/322 pass
- `npm run test:integration:fake` — 11/11 pass (3 skipped intentionally)