### PR TITLE
fix(api): drop dead initial detectorType assignment

### DIFF
--- a/lib/api/real_cloud_identity_client.js
+++ b/lib/api/real_cloud_identity_client.js
@@ -210,7 +210,7 @@ export class RealCloudIdentityClient extends CloudIdentityClient {
     )
     const client = await this.getPolicyClient(authToken)
     try {
-      let detectorType = CLOUD_IDENTITY_SETTING_TYPES.DETECTOR
+      let detectorType
       if (detectorConfig.url_list) {
         detectorType = CLOUD_IDENTITY_SETTING_TYPES.DETECTOR_URL_LIST
       } else if (detectorConfig.word_list) {


### PR DESCRIPTION
Surfaced by the AI code-quality scanner as a useless assignment.

The if/else chain in `createDetector` matches the detector kind on `detectorConfig.url_list` / `.word_list` / `.regular_expression` and assigns the corresponding `CLOUD_IDENTITY_SETTING_TYPES.DETECTOR_*` value, falling through to a thrown `'Unsupported detector type'` error if none match. Every reachable path either reassigns `detectorType` or throws, so the initial `= CLOUD_IDENTITY_SETTING_TYPES.DETECTOR` is never read.