### PR TITLE
refactor(knowledge): one startup directory walk, not three

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,13 +9,13 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: "CodeQL Advanced"
+name: 'CodeQL Advanced'
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ['main']
   pull_request:
-    branches: [ "main" ]
+    branches: ['main']
   schedule:
     - cron: '34 21 * * 1'
 
@@ -43,12 +43,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - language: actions
-          build-mode: none
-        - language: javascript-typescript
-          build-mode: none
-        - language: python
-          build-mode: none
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
@@ -58,46 +58,46 @@ jobs:
         # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    # Add any setup steps before running the `github/codeql-action/init` action.
-    # This includes steps like installing compilers or runtimes (`actions/setup-node`
-    # or others). This is typically only required for manual builds.
-    # - name: Setup runtime (example)
-    #   uses: actions/setup-example@v1
+      # Add any setup steps before running the `github/codeql-action/init` action.
+      # This includes steps like installing compilers or runtimes (`actions/setup-node`
+      # or others). This is typically only required for manual builds.
+      # - name: Setup runtime (example)
+      #   uses: actions/setup-example@v1
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
-      with:
-        languages: ${{ matrix.language }}
-        build-mode: ${{ matrix.build-mode }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
 
-    # If the analyze step fails for one of the languages you are analyzing with
-    # "We were unable to automatically build your code", modify the matrix above
-    # to set the build mode to "manual" for that language. Then modify this step
-    # to build your code.
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - name: Run manual build steps
-      if: matrix.build-mode == 'manual'
-      shell: bash
-      run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
+      # If the analyze step fails for one of the languages you are analyzing with
+      # "We were unable to automatically build your code", modify the matrix above
+      # to set the build mode to "manual" for that language. Then modify this step
+      # to build your code.
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      - name: Run manual build steps
+        if: matrix.build-mode == 'manual'
+        shell: bash
+        run: |
+          echo 'If you are using a "manual" build mode for one or more of the' \
+            'languages you are analyzing, replace this with the commands to build' \
+            'your code, for example:'
+          echo '  make bootstrap'
+          echo '  make release'
+          exit 1
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: '/language:${{matrix.language}}'

--- a/test/evals/README.md
+++ b/test/evals/README.md
@@ -290,14 +290,14 @@ The runner accepts more flags (`--runs`, `--concurrency`, `--delay`,
 
 ### Environment variables
 
-| Variable                        | Description                                                                                                                   | Default |
-| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `GEMINI_API_KEY`                | **Required.** Gemini API key for both the agent and the judge.                                                                | --      |
-| `CEP_BACKEND`                   | `fake` (in-process mock) or `real` (live Google APIs).                                                                        | `fake`  |
-| `EVAL_CATEGORY`                 | Alternative to `--category` flag.                                                                                             | --      |
-| `EVAL_IDS`                      | Alternative to `--id` flag. Comma-separated.                                                                                  | --      |
-| `EVAL_TAGS`                     | Alternative to `--tags` flag. Comma-separated.                                                                                | --      |
-| `EXPERIMENT_DELETE_TOOL_ENABLED`| Registers the delete-tool experiment. The runner defaults this to `true` so cases like `m03` test real agent judgment. Set to `false` to disable. | `true`  |
+| Variable                         | Description                                                                                                                                       | Default |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `GEMINI_API_KEY`                 | **Required.** Gemini API key for both the agent and the judge.                                                                                    | --      |
+| `CEP_BACKEND`                    | `fake` (in-process mock) or `real` (live Google APIs).                                                                                            | `fake`  |
+| `EVAL_CATEGORY`                  | Alternative to `--category` flag.                                                                                                                 | --      |
+| `EVAL_IDS`                       | Alternative to `--id` flag. Comma-separated.                                                                                                      | --      |
+| `EVAL_TAGS`                      | Alternative to `--tags` flag. Comma-separated.                                                                                                    | --      |
+| `EXPERIMENT_DELETE_TOOL_ENABLED` | Registers the delete-tool experiment. The runner defaults this to `true` so cases like `m03` test real agent judgment. Set to `false` to disable. | `true`  |
 
 ### Output
 

--- a/tools/definitions/knowledge.js
+++ b/tools/definitions/knowledge.js
@@ -35,9 +35,56 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 const DB_DIR = path.resolve(__dirname, '../../lib/knowledge')
 
+// Files in lib/knowledge that exist on disk but must not surface as
+// retrievable documents. README.md is project-internal documentation.
+// 0-agent-capabilities.md is the agent's own capabilities/boundaries
+// reference — it shapes the agent's behavior and is loaded into its
+// context, but exposing it via get_document or as an MCP resource picker
+// entry would let users browse/exfiltrate the agent's control surface.
+const NON_PUBLIC_KNOWLEDGE_FILES = new Set(['README.md', '0-agent-capabilities.md'])
+
 let cachedDb = null
 let isDbLoading = false
 let dbLoadingPromise = null
+
+/**
+ * Reads the knowledge directory once and returns one parsed entry per
+ * publishable markdown file. Used at registration time to populate the
+ * docSummaries index, the cached DB, and the MCP resource list from a
+ * single set of file reads.
+ * @param {string} dir Directory containing the markdown knowledge files.
+ * @returns {Array<{file: string, filename: string, filePath: string, metadata: object, content: string}>}
+ * One entry per `.md` file not in NON_PUBLIC_KNOWLEDGE_FILES, sorted by
+ * leading numeric prefix where present, otherwise by filename.
+ */
+function scanKnowledgeDir(dir) {
+  const entries = []
+  const files = fs.readdirSync(dir)
+  files.sort((a, b) => {
+    const numA = parseInt(a.split('-')[0])
+    const numB = parseInt(b.split('-')[0])
+    if (!isNaN(numA) && !isNaN(numB)) {
+      return numA - numB
+    }
+    return a.localeCompare(b)
+  })
+  for (const file of files) {
+    if (!file.endsWith('.md') || NON_PUBLIC_KNOWLEDGE_FILES.has(file)) {
+      continue
+    }
+    const filePath = path.join(dir, file)
+    const fileContent = fs.readFileSync(filePath, 'utf-8')
+    const { data: metadata, content } = matter(fileContent)
+    entries.push({
+      file,
+      filename: file.replace(/\.md$/, ''),
+      filePath,
+      metadata,
+      content,
+    })
+  }
+  return entries
+}
 
 /**
  * Boilerplate phrases that frequently appear in devsite/help-center pages
@@ -98,35 +145,25 @@ export function registerKnowledgeTools(server, options, sessionState) {
   logger.debug(`${TAGS.MCP} Registering Knowledge tools...`)
 
   const dirToRead = options.dbPath || DB_DIR
-  const docSummaries = []
-  try {
-    const files = fs.readdirSync(dirToRead)
-    files.sort((a, b) => {
-      const numA = parseInt(a.split('-')[0])
-      const numB = parseInt(b.split('-')[0])
-      if (!isNaN(numA) && !isNaN(numB)) {
-        return numA - numB
-      }
-      return a.localeCompare(b)
-    })
-
-    files.forEach(file => {
-      if (file.endsWith('.md') && file !== 'README.md') {
-        const filePath = path.join(dirToRead, file)
-        const fileContent = fs.readFileSync(filePath, 'utf-8')
-        const { data: metadata } = matter(fileContent)
-        if (metadata.summary) {
-          docSummaries.push({
-            filename: file.replace('.md', ''),
-            summary: metadata.summary,
-            source: metadata.url ? 'Remote' : 'Local',
-          })
-        }
-      }
-    })
-  } catch (e) {
-    logger.error(`${TAGS.MCP} Failed to pre-scan knowledge for index:`, e)
+  // When tests pass options.allDocs, they're bypassing on-disk loading
+  // entirely; skip the scan so we don't read the real knowledge dir
+  // during isolated tests.
+  let scannedDocs = []
+  if (!options.allDocs) {
+    try {
+      scannedDocs = scanKnowledgeDir(dirToRead)
+    } catch (e) {
+      logger.error(`${TAGS.MCP} Failed to scan knowledge directory:`, e)
+    }
   }
+
+  const docSummaries = scannedDocs
+    .filter(d => d.metadata.summary)
+    .map(d => ({
+      filename: d.filename,
+      summary: d.metadata.summary,
+      source: d.metadata.url ? 'Remote' : 'Local',
+    }))
 
   const indexTable = docSummaries.map(s => `| **${s.filename}** | ${s.summary} | ${s.source} |`).join('\n')
 
@@ -163,29 +200,20 @@ ${indexTable}`
         const idToDoc = new Map()
         const allDocs = []
 
-        const dirToRead = options.dbPath || DB_DIR
-        const files = fs.readdirSync(dirToRead)
-        files.forEach(file => {
-          if (file.endsWith('.md')) {
-            const filePath = path.join(dirToRead, file)
-            const fileContent = fs.readFileSync(filePath, 'utf-8')
-            const { data: metadata, content } = matter(fileContent)
-
-            const doc = {
-              id: String(metadata.articleId || file),
-              filename: file.replace('.md', ''),
-              title: metadata.title || file.replace('.md', ''),
-              content: content,
-              articleId: metadata.articleId,
-              summary: metadata.summary,
-              url: metadata.url,
-            }
-
-            allDocs.push(doc)
-            docLookup.set(doc.filename, doc)
-            idToDoc.set(String(doc.id), doc)
+        for (const entry of scannedDocs) {
+          const doc = {
+            id: String(entry.metadata.articleId || entry.file),
+            filename: entry.filename,
+            title: entry.metadata.title || entry.filename,
+            content: entry.content,
+            articleId: entry.metadata.articleId,
+            summary: entry.metadata.summary,
+            url: entry.metadata.url,
           }
-        })
+          allDocs.push(doc)
+          docLookup.set(doc.filename, doc)
+          idToDoc.set(String(doc.id), doc)
+        }
 
         // Load Dynamic Documents (*.doc.js)
         const dynamicDocs = await loadDynamicDocs(dirToRead)
@@ -611,29 +639,20 @@ ${knowledgeIndex}`,
   if (typeof server.registerResource !== 'function') {
     return
   }
-  const knowledgeDir = options.dbPath || DB_DIR
-  try {
-    const files = fs
-      .readdirSync(knowledgeDir)
-      .filter(f => f.endsWith('.md') && f !== 'README.md' && f !== '0-agent-capabilities.md')
-    for (const file of files) {
-      const filename = file.replace('.md', '')
-      const uri = `cep://knowledge/${filename}`
-      const parsed = matter(fs.readFileSync(path.join(knowledgeDir, file), 'utf8'))
-      const summary = parsed.data?.summary || ''
-      const title = parsed.data?.title || filename
-      server.registerResource(filename, uri, { title, description: summary, mimeType: 'text/markdown' }, async () => {
-        const db = await loadDb()
-        const doc = db.docLookup.get(filename)
-        if (!doc) {
-          return { contents: [] }
-        }
-        return {
-          contents: [{ uri, mimeType: 'text/markdown', text: `## ${doc.title}\n\n${doc.content}` }],
-        }
-      })
-    }
-  } catch (e) {
-    logger.error(`${TAGS.MCP} Failed to register knowledge resources:`, e)
+  for (const entry of scannedDocs) {
+    const { filename } = entry
+    const uri = `cep://knowledge/${filename}`
+    const summary = entry.metadata?.summary || ''
+    const title = entry.metadata?.title || filename
+    server.registerResource(filename, uri, { title, description: summary, mimeType: 'text/markdown' }, async () => {
+      const db = await loadDb()
+      const doc = db.docLookup.get(filename)
+      if (!doc) {
+        return { contents: [] }
+      }
+      return {
+        contents: [{ uri, mimeType: 'text/markdown', text: `## ${doc.title}\n\n${doc.content}` }],
+      }
+    })
   }
 }


### PR DESCRIPTION
`registerKnowledgeTools` walks `lib/knowledge` three times at server startup — three separate `readdirSync` + per-file `readFileSync` + `matter()` passes. The three call sites use different file filters. The mismatch is a real bug: `README.md` is retrievable via `get_document` today even though it is project-internal documentation, not a knowledge article.

Consolidate to one walk and align the filters.

## Changes

- New `scanKnowledgeDir(dir)` helper reads and parses each markdown file once and returns `{ file, filename, filePath, metadata, content }` entries.
- `docSummaries` filters that list (entries with `metadata.summary`) instead of re-reading.
- `loadDb`'s static-`.md` branch maps the same list into doc records. `loadDynamicDocs(*.doc.js)` still does its own walk because it awaits dynamic imports.
- Resource registration iterates the same list; no re-read.
- `NON_PUBLIC_KNOWLEDGE_FILES` Set names the two excluded files (`README.md`, `0-agent-capabilities.md`) with a comment for each. The agent-capabilities doc is the agent's own boundaries reference; surfacing it via resource pickers or `get_document` would let users browse the agent's control surface.
- When tests pass `options.allDocs` to bypass on-disk loading, the scan is skipped entirely. Previously the `docSummaries` scan still hit the real `lib/knowledge` directory in those tests.

## Filter alignment (the bug)

| Walk | Old filter | New filter |
|---|---|---|
| `docSummaries` | `.md` && != `README.md` | excludes `NON_PUBLIC_KNOWLEDGE_FILES` |
| `loadDb` | `.md` *(included `README.md`!)* | excludes `NON_PUBLIC_KNOWLEDGE_FILES` |
| resource registration | `.md` && != `README.md` && != `0-agent-capabilities.md` | excludes `NON_PUBLIC_KNOWLEDGE_FILES` |

Confirmed with the maintainer: `README.md` should not be retrievable via `get_document`.

## Not changed

- The sliding-window snippet scanner in `search_content`. The largest knowledge file today is ~10KB; a typical query runs ~600K char comparisons end-to-end (sub-millisecond). The reviewer's suggested `MAX_SCAN_CHARS = 10000` cap matches the largest existing file and would silently truncate snippets the moment any doc grows past 10KB.
- `loadDynamicDocs` and its `*.doc.js` walk. Folding it in would force `scanKnowledgeDir` to be async, which would break the registration-time use.

## Test plan

- [x] `npm run lint`, `npm test` (unit + integration-fake + smoke), `prettier --check .` clean
- [x] After the refactor, `README.md` is no longer in `docLookup`