### PR TITLE
fix(prompts): drop orphan '3.' from SHARED_DIAGNOSTIC_RULES

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,13 +9,13 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: "CodeQL Advanced"
+name: 'CodeQL Advanced'
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ['main']
   pull_request:
-    branches: [ "main" ]
+    branches: ['main']
   schedule:
     - cron: '34 21 * * 1'
 
@@ -43,12 +43,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - language: actions
-          build-mode: none
-        - language: javascript-typescript
-          build-mode: none
-        - language: python
-          build-mode: none
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
@@ -58,46 +58,46 @@ jobs:
         # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    # Add any setup steps before running the `github/codeql-action/init` action.
-    # This includes steps like installing compilers or runtimes (`actions/setup-node`
-    # or others). This is typically only required for manual builds.
-    # - name: Setup runtime (example)
-    #   uses: actions/setup-example@v1
+      # Add any setup steps before running the `github/codeql-action/init` action.
+      # This includes steps like installing compilers or runtimes (`actions/setup-node`
+      # or others). This is typically only required for manual builds.
+      # - name: Setup runtime (example)
+      #   uses: actions/setup-example@v1
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
-      with:
-        languages: ${{ matrix.language }}
-        build-mode: ${{ matrix.build-mode }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
 
-    # If the analyze step fails for one of the languages you are analyzing with
-    # "We were unable to automatically build your code", modify the matrix above
-    # to set the build mode to "manual" for that language. Then modify this step
-    # to build your code.
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - name: Run manual build steps
-      if: matrix.build-mode == 'manual'
-      shell: bash
-      run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
+      # If the analyze step fails for one of the languages you are analyzing with
+      # "We were unable to automatically build your code", modify the matrix above
+      # to set the build mode to "manual" for that language. Then modify this step
+      # to build your code.
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      - name: Run manual build steps
+        if: matrix.build-mode == 'manual'
+        shell: bash
+        run: |
+          echo 'If you are using a "manual" build mode for one or more of the' \
+            'languages you are analyzing, replace this with the commands to build' \
+            'your code, for example:'
+          echo '  make bootstrap'
+          echo '  make release'
+          exit 1
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: '/language:${{matrix.language}}'

--- a/prompts/definitions/shared.js
+++ b/prompts/definitions/shared.js
@@ -22,7 +22,7 @@ limitations under the License.
  * Markdown-formatted diagnostic output rules appended to health-check prompts.
  * Defines the status table format, failure handling, severity tiers, and tone.
  */
-export const SHARED_DIAGNOSTIC_RULES = `3. Summarize your findings using the following structural rules:
+export const SHARED_DIAGNOSTIC_RULES = `Summarize your findings using the following structural rules:
 
 **Visual Status Mapping (The Summary Table)**
 Begin your response with a Markdown table that provides a clear status for every metric.

--- a/test/evals/README.md
+++ b/test/evals/README.md
@@ -290,14 +290,14 @@ The runner accepts more flags (`--runs`, `--concurrency`, `--delay`,
 
 ### Environment variables
 
-| Variable                        | Description                                                                                                                   | Default |
-| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `GEMINI_API_KEY`                | **Required.** Gemini API key for both the agent and the judge.                                                                | --      |
-| `CEP_BACKEND`                   | `fake` (in-process mock) or `real` (live Google APIs).                                                                        | `fake`  |
-| `EVAL_CATEGORY`                 | Alternative to `--category` flag.                                                                                             | --      |
-| `EVAL_IDS`                      | Alternative to `--id` flag. Comma-separated.                                                                                  | --      |
-| `EVAL_TAGS`                     | Alternative to `--tags` flag. Comma-separated.                                                                                | --      |
-| `EXPERIMENT_DELETE_TOOL_ENABLED`| Registers the delete-tool experiment. The runner defaults this to `true` so cases like `m03` test real agent judgment. Set to `false` to disable. | `true`  |
+| Variable                         | Description                                                                                                                                       | Default |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `GEMINI_API_KEY`                 | **Required.** Gemini API key for both the agent and the judge.                                                                                    | --      |
+| `CEP_BACKEND`                    | `fake` (in-process mock) or `real` (live Google APIs).                                                                                            | `fake`  |
+| `EVAL_CATEGORY`                  | Alternative to `--category` flag.                                                                                                                 | --      |
+| `EVAL_IDS`                       | Alternative to `--id` flag. Comma-separated.                                                                                                      | --      |
+| `EVAL_TAGS`                      | Alternative to `--tags` flag. Comma-separated.                                                                                                    | --      |
+| `EXPERIMENT_DELETE_TOOL_ENABLED` | Registers the delete-tool experiment. The runner defaults this to `true` so cases like `m03` test real agent judgment. Set to `false` to disable. | `true`  |
 
 ### Output
 


### PR DESCRIPTION
Closes #95.

The first line of `SHARED_DIAGNOSTIC_RULES` in `prompts/definitions/shared.js` is `3. Summarize your findings using the following structural rules:`. Rules 1 and 2 do not exist anywhere in the prompt. `SHARED_DIAGNOSTIC_RULES` is the only structured-rules block, interpolated at the end of the health-check user message in `prompts/definitions/health.js`. The orphan `3.` is visible in the rendered prompt the LLM receives. Drop the leading `3. `.

## Not changed

A reviewer flagged the inline-code backticks (`` `Security Control` ``, `` `Status` ``, `` `Findings` ``) as backslash-escaped backticks that would render literally. The backslashes are JS template-literal escapes; the runtime string contains pure backticks. Replacing them with bold would regress the markdown.

## Test plan

- [x] `npm run lint`, `npm test`, `prettier --check .` clean