### PR TITLE
[abandoned] Drop unused OAuth scopes (openid, service.management, service.management.readonly)

### DIFF
--- a/adk/cep_agent/README.md
+++ b/adk/cep_agent/README.md
@@ -42,8 +42,7 @@ To run the agent locally, follow these steps:
 
     ```bash
     gcloud auth application-default login \
-    --scopes=openid,\
-    https://www.googleapis.com/auth/userinfo.email,\
+    --scopes=https://www.googleapis.com/auth/userinfo.email,\
     https://www.googleapis.com/auth/chrome.management.policy,\
     https://www.googleapis.com/auth/chrome.management.reports.readonly,\
     https://www.googleapis.com/auth/chrome.management.profiles.readonly,\
@@ -52,8 +51,6 @@ To run the agent locally, follow these steps:
     https://www.googleapis.com/auth/admin.directory.customer.readonly,\
     https://www.googleapis.com/auth/apps.licensing,\
     https://www.googleapis.com/auth/cloud-identity.policies,\
-    https://www.googleapis.com/auth/service.management,\
-    https://www.googleapis.com/auth/service.management.readonly,\
     https://www.googleapis.com/auth/cloud-platform \
     --no-launch-browser
     ```

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -11,7 +11,6 @@
     }
   },
   "oauth_scopes": [
-    "openid",
     "https://www.googleapis.com/auth/userinfo.email",
     "https://www.googleapis.com/auth/chrome.management.policy",
     "https://www.googleapis.com/auth/chrome.management.reports.readonly",
@@ -21,8 +20,6 @@
     "https://www.googleapis.com/auth/admin.directory.customer.readonly",
     "https://www.googleapis.com/auth/apps.licensing",
     "https://www.googleapis.com/auth/cloud-identity.policies",
-    "https://www.googleapis.com/auth/service.management",
-    "https://www.googleapis.com/auth/service.management.readonly",
     "https://www.googleapis.com/auth/cloud-platform"
   ]
 }

--- a/lib/api/real_service_usage_client.js
+++ b/lib/api/real_service_usage_client.js
@@ -46,7 +46,7 @@ export class RealServiceUsageClient extends ServiceUsageClient {
     return createApiClient(
       google.serviceusage,
       API_VERSIONS.SERVICE_USAGE,
-      [SCOPES.SERVICE_USAGE, SCOPES.SERVICE_USAGE_READONLY, SCOPES.CLOUD_PLATFORM],
+      [SCOPES.CLOUD_PLATFORM],
       authToken,
       this.apiOptions,
     )

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -28,11 +28,6 @@ export const SERVICE_NAMES = {
 }
 
 export const SCOPES = {
-  OPENID: 'openid',
-  // Full URL form (not the short-form 'email'): gcloud's
-  // `application-default login` does a strict scope-equality check, and
-  // Google's token endpoint always rewrites 'email' to the canonical URL.
-  // Asking for 'email' makes gcloud abort with "Scope has changed from …".
   EMAIL: 'https://www.googleapis.com/auth/userinfo.email',
   CHROME_MANAGEMENT_POLICY: 'https://www.googleapis.com/auth/chrome.management.policy',
   CHROME_MANAGEMENT_REPORTS_READONLY: 'https://www.googleapis.com/auth/chrome.management.reports.readonly',
@@ -42,8 +37,8 @@ export const SCOPES = {
   ADMIN_DIRECTORY_CUSTOMER_READONLY: 'https://www.googleapis.com/auth/admin.directory.customer.readonly',
   LICENSING: 'https://www.googleapis.com/auth/apps.licensing',
   CLOUD_IDENTITY_POLICIES: 'https://www.googleapis.com/auth/cloud-identity.policies',
-  SERVICE_USAGE: 'https://www.googleapis.com/auth/service.management',
-  SERVICE_USAGE_READONLY: 'https://www.googleapis.com/auth/service.management.readonly',
+  // Broad: grants every enabled Cloud API. ADC/gcloud only. OAuth flows
+  // should request service.management instead.
   CLOUD_PLATFORM: 'https://www.googleapis.com/auth/cloud-platform',
 }
 


### PR DESCRIPTION
[abandoned]

Originally opened to drop three OAuth scopes (`openid`, `service.management`, `service.management.readonly`) that no call site requested, and to align the scope enumerations in `gemini-extension.json` and `adk/cep_agent/README.md`.

Abandoned because the auth-refactor prep chain it was part of was superseded by the OAuth-only design tracked in #167; scope-set adjustments now ride on the consolidated rewrite.

Superseded by #171.