### PR TITLE
[abandoned] Add jose dep for JWT verification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "google-auth-library": "^10.4.0",
         "googleapis": "^166.0.0",
         "gray-matter": "^4.0.3",
+        "jose": "^5.10.0",
         "zod": "^3.25.76"
       },
       "bin": {
@@ -355,6 +356,14 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@noble/ciphers": {
@@ -2490,9 +2499,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "google-auth-library": "^10.4.0",
     "googleapis": "^166.0.0",
     "gray-matter": "^4.0.3",
+    "jose": "^5.10.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {


### PR DESCRIPTION
[abandoned]

Originally opened to add the `jose` library to `package.json` and `package-lock.json` for RFC-compliant JWT signature verification against Google's JWK set, as a prep dep for the credential-factories chain.

Abandoned because the auth-refactor prep chain it was part of was superseded by the OAuth-only design tracked in #167; the dep is pulled in directly by the consumer PR if needed.

Superseded by #171.