### PR TITLE
[abandoned] feat(credential): detect ID tokens, validate signature + audience, impersonate via DWD

### DIFF
--- a/lib/util/credential/bearer.js
+++ b/lib/util/credential/bearer.js
@@ -15,23 +15,46 @@ limitations under the License.
 */
 
 /**
- * @file Bearer token factory. Wraps a static access token in the Credential contract.
+ * @file Bearer token factory. Detects access tokens and OIDC ID tokens,
+ * routing each to the appropriate auth path.
  */
 
-import { OAuth2Client } from 'google-auth-library'
+import { OAuth2Client, JWT, GoogleAuth } from 'google-auth-library'
+import { jwtVerify } from 'jose'
+import { classifyBearer } from './jwt_classify.js'
+import { JwkCache } from './jwk_cache.js'
+import { SCOPES } from '../../constants.js'
+
+const GOOGLE_JWKS = new JwkCache('https://www.googleapis.com/oauth2/v3/certs')
 
 /**
- * Factory for bearer token credential provider. Returns a credential provider object
- * that treats a static access token as an available credential (access-token branch only).
- * @param {string} token - The bearer access token.
- * @returns {import('./index.js').Credential} A credential provider object.
+ * Factory for bearer token credential provider. Classifies the token at
+ * construction time. Access tokens go through OAuth2Client; ID tokens are
+ * verified against Google's JWK set and drive DWD impersonation via JWT.
+ * @param {string} token The bearer token from the Authorization header.
+ * @param {object} [opts] Options.
+ * @param {string} [opts.requestHost] The request Host header value, used to derive the expected audience.
+ * @param {string} [opts.expectedAudience] Explicit audience to validate against; overrides requestHost derivation.
+ * @param {import('jose').JWTVerifyGetKey} [opts.jwks] JWKS resolver; defaults to Google's public key endpoint.
+ * @param {() => Promise<import('google-auth-library').JWT>} [opts.acquireSaClient] Resolves the server's SA JWT client for DWD. Defaults to GoogleAuth().getClient(). Tests inject this to bypass the host's ADC and assert the subject/authorize wiring.
+ * @returns {import('./index.js').Credential} The credential object.
  */
-export function bearerCredential(token) {
+export function bearerCredential(
+  token,
+  {
+    requestHost,
+    expectedAudience = process.env.CEP_OAUTH_EXPECTED_AUDIENCE,
+    jwks = GOOGLE_JWKS.jwks,
+    acquireSaClient,
+  } = {},
+) {
+  const kind = classifyBearer(token)
+
   return {
     async probe() {
       return {
         ok: true,
-        source: 'bearer-access',
+        source: kind === 'id' ? 'bearer-id' : 'bearer-access',
         principal: null,
         credentialType: null,
         scopesKnown: false,
@@ -39,13 +62,74 @@ export function bearerCredential(token) {
         expiry: null,
       }
     },
+
     async getClient() {
-      const auth = new OAuth2Client()
-      auth.setCredentials({ access_token: token })
-      return auth
+      if (kind === 'access') {
+        const auth = new OAuth2Client()
+        auth.setCredentials({ access_token: token })
+        return auth
+      }
+
+      const audience = expectedAudience || (requestHost ? `https://${requestHost}` : undefined)
+
+      let payload
+      try {
+        const verified = await jwtVerify(token, jwks, {
+          issuer: ['https://accounts.google.com', 'accounts.google.com'],
+          audience,
+        })
+        payload = verified.payload
+      } catch (err) {
+        if (err.code === 'ERR_JWT_CLAIM_VALIDATION_FAILED' && err.claim === 'aud') {
+          throw new Error(
+            'ID token audience does not match this server. Verify the client is calling the correct service URL.',
+          )
+        }
+        throw new Error(
+          "Bearer is an OIDC ID token, but the signature does not verify against Google's public keys. Reject as unauthenticated.",
+        )
+      }
+
+      const acquire = acquireSaClient ?? (() => new GoogleAuth({ scopes: Object.values(SCOPES) }).getClient())
+
+      const requiredScopes = Object.values(SCOPES)
+      const scopeList = requiredScopes.map(s => `  - ${s}`).join('\n')
+
+      let baseClient
+      try {
+        baseClient = await acquire()
+      } catch {
+        throw new Error(
+          'Server has no usable Application Default Credentials, so DWD impersonation cannot run. ' +
+            'Configure ADC on the host as a service account whose domain-wide delegation grants these scopes:\n' +
+            scopeList,
+        )
+      }
+
+      if (!(baseClient instanceof JWT)) {
+        throw new Error(
+          "Server's ADC is not a service account, so DWD impersonation cannot run. " +
+            'The host needs an SA with domain-wide delegation; user credentials cannot impersonate. ' +
+            'Required scopes:\n' +
+            scopeList,
+        )
+      }
+
+      baseClient.subject = payload.email
+      try {
+        await baseClient.authorize()
+      } catch {
+        throw new Error(
+          'Server cannot impersonate the requesting user. ' +
+            "Configure domain-wide delegation for the server's service account in the Workspace Admin Console " +
+            'with these scopes:\n' +
+            scopeList,
+        )
+      }
+
+      return baseClient
     },
-    buildRemediation(_probe, _requiredScopes) {
-      return null
-    },
+
+    buildRemediation: () => null,
   }
 }

--- a/lib/util/credential/jwk_cache.js
+++ b/lib/util/credential/jwk_cache.js
@@ -1,0 +1,66 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file JWK fetch and cache for ID-token verification.
+ */
+
+import { createRemoteJWKSet } from 'jose'
+
+/**
+ * Caches a remote JWK set with TTL pulled from the response's Cache-Control header.
+ */
+export class JwkCache {
+  /**
+   * Constructs a cache for a remote JWK set.
+   * @param {string} jwksUrl The JWK set URL (e.g. Google's https://www.googleapis.com/oauth2/v3/certs).
+   * @param {{fetch?: typeof globalThis.fetch, now?: () => number}} [opts] Options for fetch and time override.
+   */
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins
+  constructor(jwksUrl, { fetch = globalThis.fetch, now = () => Date.now() } = {}) {
+    this._url = jwksUrl
+    this._fetch = fetch
+    this._now = now
+    this._cache = null
+    this._expiresAt = 0
+  }
+
+  /**
+   * Returns the parsed JWK key array, fetching when cold or past TTL.
+   * @returns {Promise<object[]>} The JWK keys array.
+   */
+  async getKeys() {
+    if (this._cache && this._now() < this._expiresAt) {
+      return this._cache
+    }
+    const res = await this._fetch(this._url)
+    const json = await res.json()
+    const cc = res.headers.get('cache-control') || ''
+    const match = cc.match(/max-age=(\d+)/)
+    const ttlMs = match ? Number(match[1]) * 1000 : 3_600_000
+    this._cache = json.keys
+    this._expiresAt = this._now() + ttlMs
+    return this._cache
+  }
+
+  /**
+   * Returns a `jose` JWKS object suitable for `jwtVerify`.
+   * @returns {ReturnType<typeof createRemoteJWKSet>} A jose RemoteJWKSet.
+   */
+  get jwks() {
+    return createRemoteJWKSet(new URL(this._url))
+  }
+}

--- a/lib/util/credential/jwk_cache.js
+++ b/lib/util/credential/jwk_cache.js
@@ -15,52 +15,34 @@ limitations under the License.
 */
 
 /**
- * @file JWK fetch and cache for ID-token verification.
+ * @file JWK fetcher for ID-token verification. Wraps jose's
+ * createRemoteJWKSet, which manages TTL caching internally based on the
+ * response's Cache-Control header. The wrapper memoises the JWK set
+ * instance per JwkCache so jose's cache is shared across calls.
  */
 
 import { createRemoteJWKSet } from 'jose'
 
-/**
- * Caches a remote JWK set with TTL pulled from the response's Cache-Control header.
- */
 export class JwkCache {
   /**
-   * Constructs a cache for a remote JWK set.
+   * Constructs a memoised remote JWK set.
    * @param {string} jwksUrl The JWK set URL (e.g. Google's https://www.googleapis.com/oauth2/v3/certs).
-   * @param {{fetch?: typeof globalThis.fetch, now?: () => number}} [opts] Options for fetch and time override.
    */
-  // eslint-disable-next-line n/no-unsupported-features/node-builtins
-  constructor(jwksUrl, { fetch = globalThis.fetch, now = () => Date.now() } = {}) {
+  constructor(jwksUrl) {
     this._url = jwksUrl
-    this._fetch = fetch
-    this._now = now
-    this._cache = null
-    this._expiresAt = 0
+    this._jwks = null
   }
 
   /**
-   * Returns the parsed JWK key array, fetching when cold or past TTL.
-   * @returns {Promise<object[]>} The JWK keys array.
-   */
-  async getKeys() {
-    if (this._cache && this._now() < this._expiresAt) {
-      return this._cache
-    }
-    const res = await this._fetch(this._url)
-    const json = await res.json()
-    const cc = res.headers.get('cache-control') || ''
-    const match = cc.match(/max-age=(\d+)/)
-    const ttlMs = match ? Number(match[1]) * 1000 : 3_600_000
-    this._cache = json.keys
-    this._expiresAt = this._now() + ttlMs
-    return this._cache
-  }
-
-  /**
-   * Returns a `jose` JWKS object suitable for `jwtVerify`.
+   * Returns a `jose` JWKS object suitable for `jwtVerify`. Memoised: the
+   * same RemoteJWKSet instance returns on every access, which preserves
+   * jose's internal TTL cache across calls.
    * @returns {ReturnType<typeof createRemoteJWKSet>} A jose RemoteJWKSet.
    */
   get jwks() {
-    return createRemoteJWKSet(new URL(this._url))
+    if (!this._jwks) {
+      this._jwks = createRemoteJWKSet(new URL(this._url))
+    }
+    return this._jwks
   }
 }

--- a/lib/util/credential/jwt_classify.js
+++ b/lib/util/credential/jwt_classify.js
@@ -1,0 +1,46 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file Bearer-token classifier. Distinguishes Google access tokens
+ * from OIDC ID tokens.
+ */
+
+/**
+ * Classifies a bearer token as 'access' or 'id'. Any input that is not
+ * a parseable JWT is treated as an opaque access token.
+ * @param {string} token The bearer-token string from the Authorization header.
+ * @returns {'access'|'id'} The token kind.
+ */
+export function classifyBearer(token) {
+  const parts = token.split('.')
+  if (parts.length !== 3) {
+    return 'access'
+  }
+  let payload
+  try {
+    payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'))
+  } catch {
+    return 'access'
+  }
+  if (typeof payload.scope === 'string' && payload.scope.length > 0) {
+    return 'access'
+  }
+  if (typeof payload.email === 'string' && payload.email.length > 0) {
+    return 'id'
+  }
+  return 'access'
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "google-auth-library": "^10.4.0",
         "googleapis": "^166.0.0",
         "gray-matter": "^4.0.3",
+        "jose": "^5.10.0",
         "zod": "^3.25.76"
       },
       "bin": {
@@ -355,6 +356,14 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@noble/ciphers": {
@@ -2490,9 +2499,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "google-auth-library": "^10.4.0",
     "googleapis": "^166.0.0",
     "gray-matter": "^4.0.3",
+    "jose": "^5.10.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/test/helpers/fake-oauth-server.js
+++ b/test/helpers/fake-oauth-server.js
@@ -1,0 +1,142 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file Minimal fake OAuth issuer for end-to-end tests of the managed OAuth flow.
+ */
+
+import express from 'express'
+import { generateKeyPair, exportJWK, SignJWT, createLocalJWKSet } from 'jose'
+
+/**
+ * Starts a fake OAuth issuer on a random port. Returns config including the
+ * authorize/token URLs, the JWK set URL, a stop function, and helpers to
+ * generate test tokens.
+ * @returns {Promise<object>}
+ */
+export async function startFakeOAuthServer() {
+  const { privateKey, publicKey } = await generateKeyPair('RS256')
+  const jwk = { ...(await exportJWK(publicKey)), kid: 'test-key', alg: 'RS256', use: 'sig' }
+
+  const issuedTokens = new Map() // code → { access_token, refresh_token, scope }
+
+  const app = express()
+  app.use(express.urlencoded({ extended: true }))
+  app.use(express.json())
+
+  app.get('/authorize', (req, res) => {
+    // Loopback-style redirect: the test typically calls this directly with code in the URL.
+    const code = 'test-auth-code-' + Math.random().toString(36).slice(2)
+    issuedTokens.set(code, { scope: req.query.scope || '' })
+    // Build the redirect target from a strict allow-list: hostname must be
+    // 127.0.0.1, port must be a positive integer, path is fixed to '/'. The
+    // test fake mirrors the loopback-only redirect security boundary of an
+    // installed-app OAuth flow and stays a closed redirect even if exposed
+    // beyond the test process.
+    const match = String(req.query.redirect_uri || '').match(/^http:\/\/127\.0\.0\.1:(\d{1,5})(\/?)$/)
+    if (!match) {
+      res.status(400).json({ error: 'invalid_redirect_uri' })
+      return
+    }
+    const port = Number(match[1])
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      res.status(400).json({ error: 'invalid_redirect_uri' })
+      return
+    }
+    const target = new URL(`http://127.0.0.1:${port}/`)
+    target.searchParams.set('code', code)
+    target.searchParams.set('state', String(req.query.state || ''))
+    res.redirect(target.toString())
+  })
+
+  app.post('/token', (req, res) => {
+    const { code, grant_type } = req.body
+    if (grant_type === 'refresh_token') {
+      // Return a refreshed access token.
+      res.json({
+        access_token: 'refreshed-' + Math.random().toString(36).slice(2),
+        expires_in: 3600,
+        token_type: 'Bearer',
+      })
+      return
+    }
+    const session = issuedTokens.get(code)
+    if (!session) {
+      res.status(400).json({ error: 'invalid_grant' })
+      return
+    }
+    res.json({
+      access_token: 'access-' + Math.random().toString(36).slice(2),
+      refresh_token: 'refresh-' + Math.random().toString(36).slice(2),
+      expires_in: 3600,
+      token_type: 'Bearer',
+      scope: session.scope,
+    })
+  })
+
+  app.post('/revoke', (req, res) => {
+    res.status(200).end()
+  })
+
+  app.get('/certs', (req, res) => {
+    res.set('cache-control', 'max-age=3600').json({ keys: [jwk] })
+  })
+
+  const server = app.listen(0, '127.0.0.1')
+  await new Promise(resolve => {
+    server.on('listening', resolve)
+  })
+  const port = server.address().port
+  const baseUrl = `http://127.0.0.1:${port}`
+
+  const stopFn = () =>
+    new Promise(resolve => {
+      server.close(() => {
+        resolve()
+      })
+    })
+
+  const jwks = createLocalJWKSet({ keys: [jwk] })
+
+  return {
+    baseUrl,
+    authorizeUrl: `${baseUrl}/authorize`,
+    tokenUrl: `${baseUrl}/token`,
+    revokeUrl: `${baseUrl}/revoke`,
+    certsUrl: `${baseUrl}/certs`,
+    jwks,
+    stop: stopFn,
+    close: stopFn,
+    /**
+     * Issues a signed JWT for testing the ID-token branch.
+     * @param {object} claims - JWT claims object
+     * @param {object} [opts] - Optional overrides
+     * @param {string} [opts.audience] - Sets the `aud` claim on the token.
+     * @returns {Promise<string>} signed JWT
+     */
+    async signIdToken(claims, { audience } = {}) {
+      let builder = new SignJWT(claims)
+        .setProtectedHeader({ alg: 'RS256', kid: 'test-key' })
+        .setIssuedAt()
+        .setIssuer('https://accounts.google.com')
+        .setExpirationTime('1h')
+      if (audience) {
+        builder = builder.setAudience(audience)
+      }
+      return builder.sign(privateKey)
+    },
+  }
+}

--- a/test/integration/auth-bearer-paths.test.js
+++ b/test/integration/auth-bearer-paths.test.js
@@ -1,0 +1,152 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file End-to-end tests for the four bearer token paths.
+ *
+ * Each test runs bearerCredential() → getClient() → real HTTP call against the
+ * fake API server. The fake OAuth server supplies the JWK set so ID-token
+ * signature verification never contacts Google.
+ */
+
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { OAuth2Client, JWT } from 'google-auth-library'
+import { SignJWT, generateKeyPair } from 'jose'
+import { bearerCredential } from '../../lib/util/credential/bearer.js'
+import { startFakeOAuthServer } from '../helpers/fake-oauth-server.js'
+import { startFakeServer } from '../helpers/fake-api-server.js'
+import { RealAdminSdkClient } from '../../lib/api/real_admin_sdk_client.js'
+
+/**
+ * Wraps an already-resolved auth client in a minimal Credential so it can be
+ * passed to RealAdminSdkClient methods, which expect a Credential with getClient().
+ * @param {object} authClient A google-auth-library client instance.
+ * @returns {{ getClient: () => Promise<object> }}
+ */
+function resolvedCredential(authClient) {
+  return { getClient: async () => authClient }
+}
+
+describe('bearer credential — four end-to-end paths', () => {
+  let oauthServer
+  let apiServer
+  let adminSdk
+
+  before(async () => {
+    oauthServer = await startFakeOAuthServer()
+    apiServer = await startFakeServer()
+    adminSdk = new RealAdminSdkClient({ rootUrl: apiServer.url })
+  })
+
+  after(async () => {
+    await oauthServer.close()
+    await apiServer.close()
+  })
+
+  it('opaque access token — passes through unchanged; API call succeeds', async () => {
+    const token = 'ya29.opaquetoken'
+    const cred = bearerCredential(token)
+    const client = await cred.getClient()
+
+    assert.ok(client instanceof OAuth2Client, 'Expected OAuth2Client for opaque token')
+    assert.equal(client.credentials.access_token, token, 'Token should be stored as-is')
+
+    // The fake API server ignores auth headers, so the call succeeds with any token.
+    const customer = await adminSdk.getCustomerId(resolvedCredential(client))
+    assert.equal(customer.id, 'C0123456', 'Should receive fake customer ID from API')
+  })
+
+  it('signed JWT access token (scope claim) — classified as access; API call succeeds', async () => {
+    // Build a JWT with a scope claim so classifyBearer returns 'access'.
+    const { privateKey } = await generateKeyPair('RS256')
+    const jwtAccessToken = await new SignJWT({
+      scope: 'https://www.googleapis.com/auth/admin.directory.customer.readonly',
+      sub: 'service-account@project.iam.gserviceaccount.com',
+    })
+      .setProtectedHeader({ alg: 'RS256' })
+      .setIssuedAt()
+      .setExpirationTime('1h')
+      .setIssuer('https://accounts.google.com')
+      .sign(privateKey)
+
+    const cred = bearerCredential(jwtAccessToken)
+    const client = await cred.getClient()
+
+    assert.ok(client instanceof OAuth2Client, 'JWT with scope claim should produce OAuth2Client')
+    assert.equal(client.credentials.access_token, jwtAccessToken, 'JWT should be stored as access token')
+
+    const customer = await adminSdk.getCustomerId(resolvedCredential(client))
+    assert.equal(customer.id, 'C0123456', 'Should receive fake customer ID from API')
+  })
+
+  it('valid ID token — signature verified; subject set from email claim; SA client carries impersonated token; API call succeeds', async () => {
+    const idToken = await oauthServer.signIdToken(
+      { email: 'user@example.com' },
+      { audience: 'https://fake-server.example.com' },
+    )
+
+    // A real JWT subclass with authorize stubbed to a no-op. The credentials
+    // are pre-set so that, after the bearer factory wires subject + calls
+    // authorize, the client carries the impersonated access token for the HTTP call.
+    const impersonatedToken = 'impersonated-access-token-dwd'
+    const fakeSaClient = new JWT({
+      email: 'sa@project.iam.gserviceaccount.com',
+      key: '-',
+      scopes: ['x'],
+    })
+    fakeSaClient.credentials = { access_token: impersonatedToken }
+    fakeSaClient.authorize = async () => {}
+
+    const cred = bearerCredential(idToken, {
+      expectedAudience: 'https://fake-server.example.com',
+      jwks: oauthServer.jwks,
+      acquireSaClient: async () => fakeSaClient,
+    })
+
+    const client = await cred.getClient()
+    assert.equal(client.subject, 'user@example.com', 'subject must be set from the verified ID token email claim')
+    assert.equal(
+      client.credentials.access_token,
+      impersonatedToken,
+      'API client should carry the impersonated token, not the original ID token',
+    )
+
+    // The fake API accepts any token; the important assertion is which token arrived.
+    const customer = await adminSdk.getCustomerId(resolvedCredential(client))
+    assert.equal(customer.id, 'C0123456', 'Should receive fake customer ID from API')
+  })
+
+  it('ID token with wrong audience — getClient rejects before the API is called', async () => {
+    const idToken = await oauthServer.signIdToken(
+      { email: 'user@example.com' },
+      { audience: 'https://other-service.example.com' },
+    )
+
+    const cred = bearerCredential(idToken, {
+      expectedAudience: 'https://fake-server.example.com',
+      jwks: oauthServer.jwks,
+    })
+
+    await assert.rejects(
+      () => cred.getClient(),
+      err =>
+        err.message ===
+        'ID token audience does not match this server. Verify the client is calling the correct service URL.',
+      'Should reject with audience-mismatch message',
+    )
+  })
+})

--- a/test/local/credential-bearer-id.test.js
+++ b/test/local/credential-bearer-id.test.js
@@ -1,0 +1,189 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { generateKeyPair, exportJWK, createLocalJWKSet, SignJWT } from 'jose'
+import { JWT } from 'google-auth-library'
+import { bearerCredential } from '../../lib/util/credential/bearer.js'
+
+/**
+ * Builds a real `JWT` subclass instance whose `authorize` is replaced by the
+ * supplied stub and which counts how many times `authorize` was called. The
+ * instance still satisfies `instanceof JWT`, so bearer.js's check passes.
+ * @param {object} opts Options for the fake.
+ * @param {() => Promise<void>} opts.authorize Stub for JWT.authorize.
+ * @returns {object} A JWT-typed object with `authorizeCalls` counter and `subject` setter.
+ */
+function makeFakeJwt({ authorize }) {
+  const instance = new JWT({ email: 'sa@project.iam.gserviceaccount.com', key: '-', scopes: ['x'] })
+  instance.authorizeCalls = 0
+  instance.authorize = async function () {
+    instance.authorizeCalls += 1
+    return authorize()
+  }
+  return instance
+}
+
+/**
+ * Generate a real RSA key pair and return helpers for signing tokens and
+ * building a local JWK set for use as the `jwks` option.
+ */
+async function makeKeyPairFixture() {
+  const { privateKey, publicKey } = await generateKeyPair('RS256')
+  const jwk = await exportJWK(publicKey)
+  jwk.kid = 'test-key-1'
+  jwk.alg = 'RS256'
+  const localJwks = createLocalJWKSet({ keys: [jwk] })
+
+  async function signToken(payload, opts = {}) {
+    const builder = new SignJWT(payload)
+      .setProtectedHeader({ alg: 'RS256', kid: 'test-key-1' })
+      .setIssuedAt()
+      .setExpirationTime('1h')
+      .setIssuer('https://accounts.google.com')
+    if (opts.audience !== undefined) {
+      builder.setAudience(opts.audience)
+    }
+    return builder.sign(opts.privateKey ?? privateKey)
+  }
+
+  return { privateKey, publicKey, localJwks, signToken }
+}
+
+describe('bearerCredential — ID-token branch', () => {
+  describe('getClient', () => {
+    it('When the token has a tampered signature, then getClient rejects with the signature-failure message', async () => {
+      const { signToken, localJwks } = await makeKeyPairFixture()
+      const valid = await signToken({ email: 'user@example.com' }, { audience: 'https://myserver.example.com' })
+
+      // Corrupt the signature segment.
+      const parts = valid.split('.')
+      parts[2] = parts[2].split('').reverse().join('')
+      const tampered = parts.join('.')
+
+      const cred = bearerCredential(tampered, {
+        requestHost: 'myserver.example.com',
+        jwks: localJwks,
+      })
+
+      await assert.rejects(
+        () => cred.getClient(),
+        err =>
+          err.message ===
+          "Bearer is an OIDC ID token, but the signature does not verify against Google's public keys. Reject as unauthenticated.",
+      )
+    })
+
+    it('When the audience claim does not match the request host, then getClient rejects with the audience-mismatch message', async () => {
+      const { signToken, localJwks } = await makeKeyPairFixture()
+      // Token issued for a different service.
+      const token = await signToken({ email: 'user@example.com' }, { audience: 'https://other-service.example.com' })
+
+      const cred = bearerCredential(token, {
+        requestHost: 'myserver.example.com',
+        jwks: localJwks,
+      })
+
+      await assert.rejects(
+        () => cred.getClient(),
+        err =>
+          err.message ===
+          'ID token audience does not match this server. Verify the client is calling the correct service URL.',
+      )
+    })
+
+    it('When the SA acquirer returns a non-JWT client, then getClient rejects with the not-a-service-account message', async () => {
+      const { signToken, localJwks } = await makeKeyPairFixture()
+      const token = await signToken({ email: 'user@example.com' }, { audience: 'https://myserver.example.com' })
+
+      const cred = bearerCredential(token, {
+        requestHost: 'myserver.example.com',
+        jwks: localJwks,
+        acquireSaClient: async () => ({ notAJwt: true }),
+      })
+
+      await assert.rejects(
+        () => cred.getClient(),
+        err => err.message.includes("Server's ADC is not a service account"),
+      )
+    })
+
+    it('When JWT.authorize fails, then getClient rejects with the DWD-configuration message and only after subject was set to the verified email', async () => {
+      const { signToken, localJwks } = await makeKeyPairFixture()
+      const token = await signToken(
+        { email: 'verified-user@example.com' },
+        { audience: 'https://myserver.example.com' },
+      )
+
+      const fake = makeFakeJwt({
+        authorize: async () => {
+          throw new Error('access_denied')
+        },
+      })
+
+      const cred = bearerCredential(token, {
+        requestHost: 'myserver.example.com',
+        jwks: localJwks,
+        acquireSaClient: async () => fake,
+      })
+
+      await assert.rejects(
+        () => cred.getClient(),
+        err => err.message.includes('Server cannot impersonate the requesting user'),
+      )
+      // Subject must be set BEFORE authorize is called — otherwise impersonation runs as the wrong user.
+      assert.equal(fake.subject, 'verified-user@example.com')
+      assert.equal(fake.authorizeCalls, 1)
+    })
+
+    it('When signature and DWD both succeed, then getClient returns the SA client with subject set to the verified email and authorize called once', async () => {
+      const { signToken, localJwks } = await makeKeyPairFixture()
+      const token = await signToken(
+        { email: 'verified-user@example.com' },
+        { audience: 'https://myserver.example.com' },
+      )
+
+      const fake = makeFakeJwt({ authorize: async () => {} })
+
+      const cred = bearerCredential(token, {
+        requestHost: 'myserver.example.com',
+        jwks: localJwks,
+        acquireSaClient: async () => fake,
+      })
+
+      const client = await cred.getClient()
+      assert.equal(client, fake)
+      assert.ok(client instanceof JWT)
+      assert.equal(fake.subject, 'verified-user@example.com')
+      assert.equal(fake.authorizeCalls, 1)
+    })
+  })
+
+  describe('probe', () => {
+    it('When the token is an ID token, then probe returns ok:true with source:bearer-id', async () => {
+      const { signToken } = await makeKeyPairFixture()
+      const token = await signToken({ email: 'user@example.com' }, { audience: 'https://myserver.example.com' })
+
+      const cred = bearerCredential(token, { requestHost: 'myserver.example.com' })
+      const probe = await cred.probe()
+
+      assert.equal(probe.ok, true)
+      assert.equal(probe.source, 'bearer-id')
+      assert.equal(probe.scopesKnown, false)
+    })
+  })
+})

--- a/test/local/jwk-cache.test.js
+++ b/test/local/jwk-cache.test.js
@@ -19,63 +19,22 @@ import assert from 'node:assert/strict'
 import { JwkCache } from '../../lib/util/credential/jwk_cache.js'
 
 describe('JwkCache', () => {
-  it('When the cache is empty, then getKeys fetches the JWK set', async () => {
-    let fetchCalls = 0
-    const fakeFetch = async () => {
-      fetchCalls++
-      return new Response(JSON.stringify({ keys: [{ kid: 'x' }] }), {
-        headers: { 'cache-control': 'max-age=3600' },
-      })
-    }
-    const cache = new JwkCache('https://example.test/certs', { fetch: fakeFetch, now: () => 0 })
-    await cache.getKeys()
-    assert.equal(fetchCalls, 1)
+  it('When jwks is read, then it returns a function (jose RemoteJWKSet)', () => {
+    const cache = new JwkCache('https://example.test/certs')
+    const jwks = cache.jwks
+    assert.equal(typeof jwks, 'function')
   })
 
-  it('When the cache is fresh, then getKeys does not refetch', async () => {
-    let fetchCalls = 0
-    const fakeFetch = async () => {
-      fetchCalls++
-      return new Response(JSON.stringify({ keys: [] }), {
-        headers: { 'cache-control': 'max-age=3600' },
-      })
-    }
-    const cache = new JwkCache('https://example.test/certs', { fetch: fakeFetch, now: () => 0 })
-    await cache.getKeys()
-    await cache.getKeys()
-    assert.equal(fetchCalls, 1)
+  it('When jwks is read multiple times, then the same memoised instance returns each time', () => {
+    const cache = new JwkCache('https://example.test/certs')
+    const a = cache.jwks
+    const b = cache.jwks
+    assert.equal(a, b)
   })
 
-  it('When the cache is past TTL, then getKeys refetches', async () => {
-    let fetchCalls = 0
-    const fakeFetch = async () => {
-      fetchCalls++
-      return new Response(JSON.stringify({ keys: [] }), {
-        headers: { 'cache-control': 'max-age=10' },
-      })
-    }
-    let now = 0
-    const cache = new JwkCache('https://example.test/certs', { fetch: fakeFetch, now: () => now })
-    await cache.getKeys()
-    now = 11_000
-    await cache.getKeys()
-    assert.equal(fetchCalls, 2)
-  })
-
-  it('When the response has no Cache-Control, then the default TTL of 3600s applies', async () => {
-    let fetchCalls = 0
-    const fakeFetch = async () => {
-      fetchCalls++
-      return new Response(JSON.stringify({ keys: [] }), { headers: {} })
-    }
-    let now = 0
-    const cache = new JwkCache('https://example.test/certs', { fetch: fakeFetch, now: () => now })
-    await cache.getKeys()
-    now = 3_599_000
-    await cache.getKeys()
-    assert.equal(fetchCalls, 1)
-    now = 3_601_000
-    await cache.getKeys()
-    assert.equal(fetchCalls, 2)
+  it('When two JwkCache instances exist, then each holds its own memoised RemoteJWKSet', () => {
+    const cache1 = new JwkCache('https://example.test/certs')
+    const cache2 = new JwkCache('https://example.test/certs')
+    assert.notEqual(cache1.jwks, cache2.jwks)
   })
 })

--- a/test/local/jwk-cache.test.js
+++ b/test/local/jwk-cache.test.js
@@ -1,0 +1,81 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { JwkCache } from '../../lib/util/credential/jwk_cache.js'
+
+describe('JwkCache', () => {
+  it('When the cache is empty, then getKeys fetches the JWK set', async () => {
+    let fetchCalls = 0
+    const fakeFetch = async () => {
+      fetchCalls++
+      return new Response(JSON.stringify({ keys: [{ kid: 'x' }] }), {
+        headers: { 'cache-control': 'max-age=3600' },
+      })
+    }
+    const cache = new JwkCache('https://example.test/certs', { fetch: fakeFetch, now: () => 0 })
+    await cache.getKeys()
+    assert.equal(fetchCalls, 1)
+  })
+
+  it('When the cache is fresh, then getKeys does not refetch', async () => {
+    let fetchCalls = 0
+    const fakeFetch = async () => {
+      fetchCalls++
+      return new Response(JSON.stringify({ keys: [] }), {
+        headers: { 'cache-control': 'max-age=3600' },
+      })
+    }
+    const cache = new JwkCache('https://example.test/certs', { fetch: fakeFetch, now: () => 0 })
+    await cache.getKeys()
+    await cache.getKeys()
+    assert.equal(fetchCalls, 1)
+  })
+
+  it('When the cache is past TTL, then getKeys refetches', async () => {
+    let fetchCalls = 0
+    const fakeFetch = async () => {
+      fetchCalls++
+      return new Response(JSON.stringify({ keys: [] }), {
+        headers: { 'cache-control': 'max-age=10' },
+      })
+    }
+    let now = 0
+    const cache = new JwkCache('https://example.test/certs', { fetch: fakeFetch, now: () => now })
+    await cache.getKeys()
+    now = 11_000
+    await cache.getKeys()
+    assert.equal(fetchCalls, 2)
+  })
+
+  it('When the response has no Cache-Control, then the default TTL of 3600s applies', async () => {
+    let fetchCalls = 0
+    const fakeFetch = async () => {
+      fetchCalls++
+      return new Response(JSON.stringify({ keys: [] }), { headers: {} })
+    }
+    let now = 0
+    const cache = new JwkCache('https://example.test/certs', { fetch: fakeFetch, now: () => now })
+    await cache.getKeys()
+    now = 3_599_000
+    await cache.getKeys()
+    assert.equal(fetchCalls, 1)
+    now = 3_601_000
+    await cache.getKeys()
+    assert.equal(fetchCalls, 2)
+  })
+})

--- a/test/local/jwt-classify.test.js
+++ b/test/local/jwt-classify.test.js
@@ -1,0 +1,53 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { classifyBearer } from '../../lib/util/credential/jwt_classify.js'
+
+describe('classifyBearer', () => {
+  it('When the token is opaque (no dots), then it returns access', () => {
+    assert.equal(classifyBearer('ya29.a0AfH6SMB...'), 'access')
+  })
+
+  it('When the token is a JWT with a scope claim, then it returns access', () => {
+    const token = makeJwt({ scope: 'https://www.googleapis.com/auth/cloud-platform' })
+    assert.equal(classifyBearer(token), 'access')
+  })
+
+  it('When the token is a JWT with email and no scope, then it returns id', () => {
+    const token = makeJwt({ email: 'tim@example.com' })
+    assert.equal(classifyBearer(token), 'id')
+  })
+
+  it('When the token is malformed JWT shape, then it returns access (treat as opaque)', () => {
+    assert.equal(classifyBearer('not.a.valid.jwt.with.too.many.dots'), 'access')
+  })
+
+  it('When the JWT payload is unparseable base64, then it returns access', () => {
+    assert.equal(classifyBearer('header.@@@invalid@@@.signature'), 'access')
+  })
+
+  it('When the JWT has both email and scope, then scope wins (treat as access)', () => {
+    const token = makeJwt({ email: 'tim@example.com', scope: 'cloud-platform' })
+    assert.equal(classifyBearer(token), 'access')
+  })
+})
+
+function makeJwt(payload) {
+  const b64 = obj => Buffer.from(JSON.stringify(obj)).toString('base64url')
+  return `${b64({ alg: 'RS256' })}.${b64(payload)}.signature`
+}

--- a/tools/utils/wrapper.js
+++ b/tools/utils/wrapper.js
@@ -177,7 +177,9 @@ export function guardedToolCall(
 ) {
   return async (params, context) => {
     const headerToken = getAuthToken(context?.requestInfo)
-    const credential = headerToken ? bearerCredential(headerToken) : adcCredential()
+    const credential = headerToken
+      ? bearerCredential(headerToken, { requestHost: context?.requestInfo?.headers?.host })
+      : adcCredential()
     try {
       const { apiClients, apiOptions } = options
       let currentParams = { ...params }


### PR DESCRIPTION
[abandoned]

Originally opened to add OIDC ID-token classification, JWT signature verification against Google's JWK set, audience validation, and DWD impersonation via google-auth-library's JWT class, closing the Cloud Run + Gemini Enterprise gap where pre-auth-refactor code treated ID tokens as access tokens. Addressed #89.

Abandoned because the auth-refactor chain it sat in was reworked into the OAuth-only design tracked in #167; the SA-JWT direct path replaces the DWD impersonation surface.

Superseded by #171.