### PR TITLE
[abandoned] feat(cli): bin/cli.js dispatcher with login and auth-status subcommands

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file CLI entry point. Dispatches argv[2] to a subcommand or to the MCP server.
+ */
+
+/* eslint-disable n/no-process-exit */
+
+import { runServer } from '../mcp-server.js'
+
+/**
+ * Dispatches the CLI subcommand.
+ * @returns {Promise<void>} Resolves when the chosen command finishes.
+ */
+async function main() {
+  const sub = process.argv[2]
+  if (sub === 'auth-status') {
+    const { runAuthStatusCommand } = await import('../lib/util/credential/cli_commands.js')
+    return runAuthStatusCommand()
+  }
+  if (sub === 'login') {
+    const { runLoginCommand } = await import('../lib/util/credential/cli_commands.js')
+    return runLoginCommand()
+  }
+  return runServer()
+}
+
+main().catch(err => {
+  console.error(err.message || err)
+  process.exit(1)
+})

--- a/lib/util/credential/cli_commands.js
+++ b/lib/util/credential/cli_commands.js
@@ -1,0 +1,51 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file CLI subcommand implementations for the credential layer.
+ */
+
+import { adcCredential } from './adc.js'
+import { oauthFlowCredential } from './oauth_flow.js'
+import { buildScopesField } from '../auth_messages.js'
+import { SCOPES } from '../../constants.js'
+
+/**
+ * Probes the ADC and OAuth-flow credential factories and prints a two-line
+ * status report. Exits 0 in all cases — a non-OK probe is informational.
+ * @returns {Promise<void>}
+ */
+export async function runAuthStatusCommand() {
+  const scopes = Object.values(SCOPES)
+  const adcProbe = await adcCredential().probe()
+  const oauthProbe = await oauthFlowCredential().probe()
+  console.log('Auth status:')
+  console.log('  ADC:        ' + buildScopesField(adcProbe, scopes))
+  console.log('  OAuth flow: ' + buildScopesField(oauthProbe, scopes))
+}
+
+/**
+ * Runs the managed-OAuth login flow and prints a one-line success message.
+ * @param {object} [opts] Injection points for testability.
+ * @param {() => ReturnType<typeof oauthFlowCredential>} [opts.credentialFactory] Factory for the OAuth credential; defaults to oauthFlowCredential.
+ * @returns {Promise<void>}
+ */
+export async function runLoginCommand({ credentialFactory = oauthFlowCredential } = {}) {
+  const cred = credentialFactory()
+  console.log('Opening browser for consent...')
+  await cred.runLoginFlow()
+  console.log('Tokens cached. Run mcp auth-status to verify.')
+}

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /*
 Copyright 2026 Google LLC
 
@@ -142,7 +141,7 @@ async function getServer(gcpInfo, sharedSessionState) {
 /**
  * Starts the MCP server.
  */
-async function main() {
+export async function runServer() {
   try {
     const gcpInfo = await checkGCP()
     const isStdio = shouldStartStdio(gcpInfo)
@@ -188,9 +187,8 @@ async function main() {
       quotaProject: process.env.GOOGLE_CLOUD_QUOTA_PROJECT || null,
     }
 
-    // OAuth-flow probe runs alongside the ADC probe. A missing cache file
-    // returns immediately; a 2-second timeout caps the network worst case so
-    // the boot does not block.
+    // OAuth-flow probe runs concurrently. A missing cache file returns
+    // immediately; the boot does not block on network calls.
     let oauthProbe = null
     try {
       oauthProbe = await Promise.race([
@@ -351,4 +349,6 @@ const shutdown = async () => {
 process.on('SIGINT', shutdown)
 process.on('SIGTERM', shutdown)
 
-main()
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runServer()
+}

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -32,7 +32,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { SetLevelRequestSchema } from '@modelcontextprotocol/sdk/types.js'
 import fs from 'node:fs/promises'
 import { readFileSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 const pkg = JSON.parse(readFileSync(fileURLToPath(new URL('./package.json', import.meta.url)), 'utf8'))
 
 import { buildServerInstructions } from './lib/knowledge/instructions.js'
@@ -349,6 +349,9 @@ const shutdown = async () => {
 process.on('SIGINT', shutdown)
 process.on('SIGTERM', shutdown)
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Run only when invoked directly. pathToFileURL handles Windows drive letters
+// and percent-encoding correctly; the prior `file://${argv[1]}` form was
+// broken on Windows.
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   runServer()
 }

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
   "type": "module",
   "main": "mcp-server.js",
   "bin": {
-    "chrome-enterprise-premium-mcp": "mcp-server.js"
+    "chrome-enterprise-premium-mcp": "bin/cli.js"
   },
   "scripts": {
+    "audit:scopes": "node scripts/audit-scopes.js",
     "eval": "CEP_BACKEND=fake node test/evals/run.js",
     "eval:agentic": "CEP_BACKEND=fake node test/evals/run.js --category inspection,troubleshooting,mutation,discovery,connectors",
     "eval:full": "CEP_BACKEND=fake node test/evals/run.js --runs 3 --output results/eval-full.md",

--- a/test/local/cli.test.js
+++ b/test/local/cli.test.js
@@ -1,0 +1,71 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file Tests for bin/cli.js subcommand dispatch and runLoginCommand.
+ */
+
+import { describe, it, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const CLI = path.resolve(__dirname, '../../bin/cli.js')
+
+describe('bin/cli.js', () => {
+  describe('auth-status', () => {
+    it('When invoked with auth-status and ADC absent, then it prints the ADC line and an OAuth flow line', () => {
+      const result = spawnSync('node', [CLI, 'auth-status'], {
+        encoding: 'utf8',
+        env: { ...process.env, GOOGLE_APPLICATION_CREDENTIALS: '/nonexistent' },
+      })
+      assert.equal(result.status, 0)
+      assert.match(result.stdout, /Auth status:/)
+      assert.match(result.stdout, /ADC:/)
+      assert.match(result.stdout, /OAuth flow:/)
+    })
+  })
+})
+
+describe('runLoginCommand', () => {
+  it('When login is invoked and runLoginFlow succeeds, then it prints the cached message and exits 0', async () => {
+    const { runLoginCommand } = await import('../../lib/util/credential/cli_commands.js')
+
+    const runLoginFlow = mock.fn(async () => {})
+    const credentialFactory = mock.fn(() => ({ runLoginFlow }))
+
+    const lines = []
+
+    const origLog = console.log
+
+    console.log = msg => {
+      lines.push(msg)
+    }
+    try {
+      await runLoginCommand({ credentialFactory })
+    } finally {
+      // eslint-disable-next-line require-atomic-updates
+      console.log = origLog
+    }
+
+    assert.equal(credentialFactory.mock.calls.length, 1)
+    assert.equal(runLoginFlow.mock.calls.length, 1)
+    assert.ok(lines.some(l => /opening browser/i.test(l)))
+    assert.ok(lines.some(l => /tokens cached/i.test(l)))
+  })
+})

--- a/test/local/smoke-test.js
+++ b/test/local/smoke-test.js
@@ -18,7 +18,7 @@ limitations under the License.
 
 process.env.GCP_STDIO ??= 'false'
 
-import { spawn } from 'child_process'
+import { spawn, spawnSync } from 'child_process'
 import http from 'http'
 import { logger } from '../../lib/util/logger.js'
 
@@ -29,13 +29,16 @@ import { logger } from '../../lib/util/logger.js'
 // so the grounding-content check would give a false negative over HTTP.
 await runStdioInitializeTest()
 
-const server = spawn('node', ['mcp-server.js'], {
+// Auth phase: confirm `node bin/cli.js auth-status` runs cleanly.
+runAuthStatusTest()
+
+const server = spawn('node', ['bin/cli.js'], {
   env: { ...process.env, GOOGLE_API_ROOT_URL: 'http://localhost:1234', PORT: '3000' },
 })
 
 async function runStdioInitializeTest() {
   return new Promise(resolve => {
-    const stdio = spawn('node', ['mcp-server.js'], {
+    const stdio = spawn('node', ['bin/cli.js'], {
       env: { ...process.env, GCP_STDIO: 'true', GOOGLE_API_ROOT_URL: 'http://localhost:1234' },
       stdio: ['pipe', 'pipe', 'inherit'],
     })
@@ -84,6 +87,30 @@ async function runStdioInitializeTest() {
     // Safety net — if no valid response within 5s, fail.
     setTimeout(() => finish(false), 5000)
   })
+}
+
+function runAuthStatusTest() {
+  logger.info('--- AUTH PHASE ---')
+  const result = spawnSync('node', ['bin/cli.js', 'auth-status'], {
+    encoding: 'utf8',
+    env: { ...process.env, GOOGLE_APPLICATION_CREDENTIALS: '/nonexistent', CEP_LOG_LEVEL: 'SILENT' },
+  })
+  if (result.status !== 0) {
+    logger.error('auth-status failed: exit', result.status, result.stderr)
+    process.exit(1)
+  }
+  for (const expected of ['Auth status:', 'ADC:', 'OAuth flow:']) {
+    if (!result.stdout.includes(expected)) {
+      logger.error(`auth-status output missing expected line: ${expected}`)
+      logger.error(`stdout was:\n${result.stdout}`)
+      process.exit(1)
+    }
+  }
+  if (result.stderr.includes('Error:') || result.stderr.includes('at ')) {
+    logger.error('auth-status stderr contains errors:', result.stderr)
+    process.exit(1)
+  }
+  logger.info('auth-status output OK')
 }
 
 function runToolTest() {


### PR DESCRIPTION
[abandoned]

Originally opened to add `bin/cli.js` as a dispatcher routing `argv[2]` to `mcp login`, `mcp auth-status`, or the MCP server, and to move the package's bin entry from `mcp-server.js` to `bin/cli.js`. Addressed #91.

Abandoned because the auth-refactor chain it sat in was reworked into the OAuth-only design tracked in #167; the CLI subcommand restructure now lives downstream of the rewrite.

Superseded by #171.