### PR TITLE
[abandoned] feat(credential): BYO OAuth client override + managed-client placeholder + custom-client notice

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file CLI entry point. Dispatches argv[2] to a subcommand or to the MCP server.
+ */
+
+/* eslint-disable n/no-process-exit */
+
+import { runServer } from '../mcp-server.js'
+
+/**
+ * Dispatches the CLI subcommand.
+ * @returns {Promise<void>} Resolves when the chosen command finishes.
+ */
+async function main() {
+  const sub = process.argv[2]
+  if (sub === 'auth-status') {
+    const { runAuthStatusCommand } = await import('../lib/util/credential/cli_commands.js')
+    return runAuthStatusCommand()
+  }
+  if (sub === 'login') {
+    const { runLoginCommand } = await import('../lib/util/credential/cli_commands.js')
+    return runLoginCommand()
+  }
+  return runServer()
+}
+
+main().catch(err => {
+  console.error(err.message || err)
+  process.exit(1)
+})

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -55,6 +55,11 @@ export const CEP_CONSTANTS = {
   SKU_ID: '1010400001',
 }
 
+// TODO(managed-oauth): replace with the allowlisted Google-managed OAuth client.
+export const MANAGED_OAUTH_CLIENT_PLACEHOLDER = 'TODO_MANAGED_OAUTH_CLIENT'
+export const MANAGED_OAUTH_CLIENT_ID = MANAGED_OAUTH_CLIENT_PLACEHOLDER
+export const MANAGED_OAUTH_CLIENT_SECRET = MANAGED_OAUTH_CLIENT_PLACEHOLDER
+
 export const DEFAULT_CONFIG = {
   REGION: 'europe-west1',
   MAX_RETRIES: 7,

--- a/lib/util/auth_messages.js
+++ b/lib/util/auth_messages.js
@@ -182,6 +182,21 @@ export function buildQuotaProjectWarning(adc) {
 }
 
 /**
+ * Renders the banner field for the active OAuth client config.
+ * @param {?{clientId: string, clientSecret: string, source: 'managed'|'custom'}} config The resolved OAuth client config, or null when resolution failed.
+ * @returns {string} The banner field text.
+ */
+export function buildOAuthClientField(config) {
+  if (!config) {
+    return 'OAuth client: TODO (managed client not yet provisioned; set CEP_OAUTH_CLIENT_ID/SECRET to bring your own)'
+  }
+  if (config.source === 'managed') {
+    return 'OAuth client: Google-managed'
+  }
+  return `OAuth client: custom (${config.clientId.slice(0, 8)}...)`
+}
+
+/**
  * Collapses bash `\<LF>` line continuations and splits on whitespace, the
  * way the shell would tokenize an unquoted command. Useful for verifying
  * that a printed command parses into the intended argv.

--- a/lib/util/credential/cli_commands.js
+++ b/lib/util/credential/cli_commands.js
@@ -18,10 +18,14 @@ limitations under the License.
  * @file CLI subcommand implementations for the credential layer.
  */
 
+import path from 'node:path'
+import fs from 'node:fs/promises'
 import { adcCredential } from './adc.js'
 import { oauthFlowCredential } from './oauth_flow.js'
 import { buildScopesField } from '../auth_messages.js'
 import { SCOPES } from '../../constants.js'
+import { resolveOAuthClientConfig } from './oauth_client_config.js'
+import { TokenCache } from './token_cache.js'
 
 /**
  * Probes the ADC and OAuth-flow credential factories and prints a two-line
@@ -37,13 +41,55 @@ export async function runAuthStatusCommand() {
   console.log('  OAuth flow: ' + buildScopesField(oauthProbe, scopes))
 }
 
+const NOTICE_LINES = [
+  'Custom OAuth client detected. Verify the following before proceeding:',
+  '  - Redirect URI: http://127.0.0.1 (and optionally http://localhost) is registered on the client.',
+  '  - Scopes: every entry from lib/constants.js#SCOPES is granted on the consent screen.',
+  '  - Brand verification: required for non-internal users on Workspace-restricted scopes (Admin SDK Directory and Reports).',
+  'See docs/auth-bring-your-own-oauth-client.md for the full setup.',
+]
+
+/**
+ * Prints a one-time notice if using a custom OAuth client and the marker file
+ * does not exist. Creates the marker file after printing.
+ * @param {object} [opts] Injection points for testability.
+ * @param {string} [opts.noticePath] Path to the marker file; defaults to byo-notice.shown in the cache dir.
+ * @param {(env?: object) => ReturnType<typeof resolveOAuthClientConfig>} [opts.configResolver]
+ * Resolves OAuth client config; defaults to resolveOAuthClientConfig.
+ * @returns {Promise<void>}
+ * @private
+ */
+async function maybePrintCustomClientNotice({ noticePath, configResolver = resolveOAuthClientConfig } = {}) {
+  const config = configResolver()
+  if (config.source !== 'custom') {
+    return
+  }
+  const markerPath = noticePath || path.join(path.dirname(TokenCache.defaultPath()), 'byo-notice.shown')
+  try {
+    await fs.access(markerPath)
+    return
+  } catch {
+    // missing — show notice
+  }
+  for (const line of NOTICE_LINES) {
+    console.log(line)
+  }
+  console.log()
+  await fs.mkdir(path.dirname(markerPath), { recursive: true })
+  await fs.writeFile(markerPath, new Date().toISOString())
+}
+
 /**
  * Runs the managed-OAuth login flow and prints a one-line success message.
+ * When using a custom OAuth client, prints a one-time notice on the first run.
  * @param {object} [opts] Injection points for testability.
  * @param {() => ReturnType<typeof oauthFlowCredential>} [opts.credentialFactory] Factory for the OAuth credential; defaults to oauthFlowCredential.
+ * @param {string} [opts.noticePath] Path to the BYO-notice marker file for testing.
+ * @param {(env?: object) => ReturnType<typeof resolveOAuthClientConfig>} [opts.configResolver] Resolves OAuth client config; defaults to resolveOAuthClientConfig.
  * @returns {Promise<void>}
  */
-export async function runLoginCommand({ credentialFactory = oauthFlowCredential } = {}) {
+export async function runLoginCommand({ credentialFactory = oauthFlowCredential, noticePath, configResolver } = {}) {
+  await maybePrintCustomClientNotice({ noticePath, configResolver })
   const cred = credentialFactory()
   console.log('Opening browser for consent...')
   await cred.runLoginFlow()

--- a/lib/util/credential/cli_commands.js
+++ b/lib/util/credential/cli_commands.js
@@ -59,22 +59,41 @@ const NOTICE_LINES = [
  * @returns {Promise<void>}
  * @private
  */
+/**
+ * Prints the one-time custom-client notice when the marker is missing.
+ * Does NOT write the marker — the caller writes it after `runLoginFlow`
+ * succeeds, so a failed login surfaces the notice again next time.
+ * @param {object} opts
+ * @param {string} [opts.noticePath]
+ * @param {Function} [opts.configResolver]
+ * @returns {Promise<{markerPath: string, printed: boolean}>}
+ */
 async function maybePrintCustomClientNotice({ noticePath, configResolver = resolveOAuthClientConfig } = {}) {
   const config = configResolver()
   if (config.source !== 'custom') {
-    return
+    return { markerPath: null, printed: false }
   }
   const markerPath = noticePath || path.join(path.dirname(TokenCache.defaultPath()), 'byo-notice.shown')
   try {
     await fs.access(markerPath)
-    return
+    return { markerPath, printed: false }
   } catch {
-    // missing — show notice
+    // missing — show notice below
   }
   for (const line of NOTICE_LINES) {
     console.log(line)
   }
   console.log()
+  return { markerPath, printed: true }
+}
+
+/**
+ * Writes the BYO-notice marker. Called after a successful runLoginFlow so a
+ * failed login does not silently suppress the next reminder.
+ * @param {string} markerPath
+ * @returns {Promise<void>}
+ */
+async function writeCustomClientNoticeMarker(markerPath) {
   await fs.mkdir(path.dirname(markerPath), { recursive: true })
   await fs.writeFile(markerPath, new Date().toISOString())
 }
@@ -89,9 +108,12 @@ async function maybePrintCustomClientNotice({ noticePath, configResolver = resol
  * @returns {Promise<void>}
  */
 export async function runLoginCommand({ credentialFactory = oauthFlowCredential, noticePath, configResolver } = {}) {
-  await maybePrintCustomClientNotice({ noticePath, configResolver })
+  const notice = await maybePrintCustomClientNotice({ noticePath, configResolver })
   const cred = credentialFactory()
   console.log('Opening browser for consent...')
   await cred.runLoginFlow()
+  if (notice.printed && notice.markerPath) {
+    await writeCustomClientNoticeMarker(notice.markerPath)
+  }
   console.log('Tokens cached. Run mcp auth-status to verify.')
 }

--- a/lib/util/credential/cli_commands.js
+++ b/lib/util/credential/cli_commands.js
@@ -1,0 +1,51 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file CLI subcommand implementations for the credential layer.
+ */
+
+import { adcCredential } from './adc.js'
+import { oauthFlowCredential } from './oauth_flow.js'
+import { buildScopesField } from '../auth_messages.js'
+import { SCOPES } from '../../constants.js'
+
+/**
+ * Probes the ADC and OAuth-flow credential factories and prints a two-line
+ * status report. Exits 0 in all cases — a non-OK probe is informational.
+ * @returns {Promise<void>}
+ */
+export async function runAuthStatusCommand() {
+  const scopes = Object.values(SCOPES)
+  const adcProbe = await adcCredential().probe()
+  const oauthProbe = await oauthFlowCredential().probe()
+  console.log('Auth status:')
+  console.log('  ADC:        ' + buildScopesField(adcProbe, scopes))
+  console.log('  OAuth flow: ' + buildScopesField(oauthProbe, scopes))
+}
+
+/**
+ * Runs the managed-OAuth login flow and prints a one-line success message.
+ * @param {object} [opts] Injection points for testability.
+ * @param {() => ReturnType<typeof oauthFlowCredential>} [opts.credentialFactory] Factory for the OAuth credential; defaults to oauthFlowCredential.
+ * @returns {Promise<void>}
+ */
+export async function runLoginCommand({ credentialFactory = oauthFlowCredential } = {}) {
+  const cred = credentialFactory()
+  console.log('Opening browser for consent...')
+  await cred.runLoginFlow()
+  console.log('Tokens cached. Run mcp auth-status to verify.')
+}

--- a/lib/util/credential/oauth_client_config.js
+++ b/lib/util/credential/oauth_client_config.js
@@ -1,0 +1,80 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file Resolves the OAuth client config (client id + secret) for the managed
+ * OAuth flow. Either both env-var overrides are set, or neither is, with the
+ * bundled Google-managed values used as the default.
+ */
+
+import {
+  MANAGED_OAUTH_CLIENT_ID,
+  MANAGED_OAUTH_CLIENT_SECRET,
+  MANAGED_OAUTH_CLIENT_PLACEHOLDER,
+} from '../../constants.js'
+
+/**
+ * @typedef {object} OAuthClientConfig
+ * @property {string} clientId The OAuth client ID.
+ * @property {string} clientSecret The OAuth client secret.
+ * @property {'managed'|'custom'} source The source of the configuration ('managed' or 'custom').
+ */
+
+/**
+ * True when MANAGED_OAUTH_CLIENT_ID/SECRET still hold the TODO placeholder
+ * value. The managed flow cannot run until both are replaced with the real
+ * Google-managed client credentials.
+ * @returns {boolean} Whether the managed client is unprovisioned.
+ */
+export function managedClientIsPlaceholder() {
+  return (
+    MANAGED_OAUTH_CLIENT_ID === MANAGED_OAUTH_CLIENT_PLACEHOLDER ||
+    MANAGED_OAUTH_CLIENT_SECRET === MANAGED_OAUTH_CLIENT_PLACEHOLDER
+  )
+}
+
+/**
+ * Resolves OAuth client configuration from environment variables or bundled defaults.
+ * @param {object} [env] Environment variables object. Defaults to process.env.
+ * @returns {OAuthClientConfig} OAuth client configuration object.
+ * @throws {Error} When exactly one of the two env vars is set, or when the bundled managed client is still a TODO placeholder and no custom override is provided.
+ */
+export function resolveOAuthClientConfig(env = process.env) {
+  const id = env.CEP_OAUTH_CLIENT_ID
+  const secret = env.CEP_OAUTH_CLIENT_SECRET
+  const idSet = typeof id === 'string' && id.length > 0
+  const secretSet = typeof secret === 'string' && secret.length > 0
+  if (idSet !== secretSet) {
+    throw new Error(
+      'Set both CEP_OAUTH_CLIENT_ID and CEP_OAUTH_CLIENT_SECRET, or unset both to use the bundled Google-managed client.',
+    )
+  }
+  if (idSet && secretSet) {
+    return { clientId: id, clientSecret: secret, source: 'custom' }
+  }
+  if (managedClientIsPlaceholder()) {
+    throw new Error(
+      'Managed OAuth client is not yet provisioned. ' +
+        'Set CEP_OAUTH_CLIENT_ID and CEP_OAUTH_CLIENT_SECRET to bring your own OAuth client, ' +
+        'or wait until the bundled managed client is allowlisted for the scopes in lib/constants.js#SCOPES.',
+    )
+  }
+  return {
+    clientId: MANAGED_OAUTH_CLIENT_ID,
+    clientSecret: MANAGED_OAUTH_CLIENT_SECRET,
+    source: 'managed',
+  }
+}

--- a/lib/util/credential/oauth_flow.js
+++ b/lib/util/credential/oauth_flow.js
@@ -127,7 +127,9 @@ export function oauthFlowCredential({
       const expiry = tokens.expiry_date ? new Date(tokens.expiry_date) : null
       const permissionsWarning = !(await cache.modeIsTight())
       const isExpired = expiry && expiry.getTime() < Date.now()
-      // Refresh logic lives in Task 19. For now: if expired, probe is not ok.
+      // The cache stores access tokens only; no refresh path. An expired
+      // probe surfaces "Run mcp auth login" remediation so the user
+      // re-consents.
       if (isExpired) {
         return {
           ok: false,
@@ -202,8 +204,14 @@ export function oauthFlowCredential({
           redirectUri: server.redirectUri,
           ...(Object.keys(endpoints).length > 0 ? { endpoints } : {}),
         })
+        // access_type: 'online' — request an access-token-only response. The
+        // server is not cleared to store refresh tokens for the first-party
+        // managed OAuth client; the same policy applies to BYO clients
+        // because the requested scopes are sensitive (Workspace Admin
+        // Directory, Reports, Cloud Identity policies, Chrome Management).
+        // When the access token expires, the user re-runs `mcp auth login`.
         const consentUrl = oauth2.generateAuthUrl({
-          access_type: 'offline',
+          access_type: 'online',
           prompt: 'consent',
           scope: requiredScopes,
         })

--- a/lib/util/credential/oauth_flow.js
+++ b/lib/util/credential/oauth_flow.js
@@ -22,7 +22,12 @@ import { spawn } from 'node:child_process'
 import { OAuth2Client } from 'google-auth-library'
 import { TokenCache } from './token_cache.js'
 import { startLoopbackServer } from './loopback_server.js'
-import { SCOPES } from '../../constants.js'
+import {
+  SCOPES,
+  MANAGED_OAUTH_CLIENT_ID,
+  MANAGED_OAUTH_CLIENT_SECRET,
+  MANAGED_OAUTH_CLIENT_PLACEHOLDER,
+} from '../../constants.js'
 
 /**
  * Opens the given URL in the user's default browser. Respects BROWSER env var.
@@ -89,8 +94,8 @@ function mapOAuthError(err, clientId) {
 /**
  * Creates a credential object backed by the managed OAuth flow token cache.
  * @param {object} [opts] Configuration options.
- * @param {string} [opts.clientId] OAuth client id; defaults to CEP_OAUTH_CLIENT_ID env var. The bundled managed client default lands in the BYO override sub-issue.
- * @param {string} [opts.clientSecret] OAuth client secret; defaults to CEP_OAUTH_CLIENT_SECRET env var.
+ * @param {string} [opts.clientId] OAuth client id; defaults to env var or bundled managed client.
+ * @param {string} [opts.clientSecret] OAuth client secret.
  * @param {string} [opts.cachePath] Token cache path; defaults to TokenCache.defaultPath().
  * @param {string[]} [opts.requiredScopes] The scope set the probe checks against; defaults to Object.values(SCOPES).
  * @param {string} [opts.authUrl] Override for the OAuth authorization base URL. Defaults to the Google endpoint.
@@ -98,8 +103,8 @@ function mapOAuthError(err, clientId) {
  * @returns {import('./index.js').Credential & {permissionsWarning?: boolean}} The credential object.
  */
 export function oauthFlowCredential({
-  clientId = process.env.CEP_OAUTH_CLIENT_ID,
-  clientSecret = process.env.CEP_OAUTH_CLIENT_SECRET,
+  clientId = process.env.CEP_OAUTH_CLIENT_ID || MANAGED_OAUTH_CLIENT_ID,
+  clientSecret = process.env.CEP_OAUTH_CLIENT_SECRET || MANAGED_OAUTH_CLIENT_SECRET,
   cachePath = TokenCache.defaultPath(),
   requiredScopes = Object.values(SCOPES),
   authUrl,
@@ -135,7 +140,7 @@ export function oauthFlowCredential({
           ok: false,
           source: 'oauth-flow',
           principal,
-          credentialType: 'custom',
+          credentialType: clientId === MANAGED_OAUTH_CLIENT_ID ? 'managed' : 'custom',
           scopesKnown: true,
           missingScopes: missing,
           expiry,
@@ -145,7 +150,7 @@ export function oauthFlowCredential({
         ok: missing.length === 0,
         source: 'oauth-flow',
         principal,
-        credentialType: 'custom',
+        credentialType: clientId === MANAGED_OAUTH_CLIENT_ID ? 'managed' : 'custom',
         scopesKnown: true,
         missingScopes: missing,
         expiry,
@@ -172,7 +177,8 @@ export function oauthFlowCredential({
       }
       if (probe.missingScopes.length > 0) {
         return [
-          `Cached OAuth tokens do not cover ${probe.missingScopes.length} required scope(s).`,
+          `Cached OAuth tokens do not cover ${probe.missingScopes.length} required scope(s):`,
+          ...probe.missingScopes.map(s => `  - ${s}`),
           'Re-run mcp auth login to re-consent with the full scope set.',
         ]
       }
@@ -189,6 +195,13 @@ export function oauthFlowCredential({
      * @returns {Promise<object>} The token object returned by the code exchange.
      */
     async runLoginFlow({ openBrowser = defaultOpenBrowser, createOAuth2Client = cfg => new OAuth2Client(cfg) } = {}) {
+      if (clientId === MANAGED_OAUTH_CLIENT_PLACEHOLDER || clientSecret === MANAGED_OAUTH_CLIENT_PLACEHOLDER) {
+        throw new Error(
+          'Managed OAuth client is not yet provisioned. ' +
+            'Set CEP_OAUTH_CLIENT_ID and CEP_OAUTH_CLIENT_SECRET to bring your own OAuth client, ' +
+            'or wait until the bundled managed client is allowlisted for the scopes in lib/constants.js#SCOPES.',
+        )
+      }
       const server = await startLoopbackServer()
       try {
         const endpoints = {}

--- a/lib/util/credential/token_cache.js
+++ b/lib/util/credential/token_cache.js
@@ -15,7 +15,14 @@ limitations under the License.
 */
 
 /**
- * @file Persistent cache for the managed-OAuth flow's refresh + access tokens.
+ * @file Persistent cache for the managed-OAuth flow's access token only.
+ *
+ * Refresh tokens are NEVER persisted. The CEP MCP server is not cleared to
+ * store refresh tokens for the first-party managed OAuth client, and the
+ * scopes the server requests (Workspace Admin Directory, Reports, Cloud
+ * Identity policies, Chrome Management) are sensitive enough that the same
+ * policy applies to BYO clients. When the cached access token expires, the
+ * user re-runs `mcp auth login` to consent again.
  */
 
 import fs from 'node:fs/promises'
@@ -23,6 +30,9 @@ import path from 'node:path'
 
 /**
  * Reads and writes the OAuth-flow token cache file with a 0600 mode invariant.
+ * The persisted shape contains `access_token`, `expiry_date`, `id_token`, and
+ * `scope` only. Any `refresh_token` field on the input to `write()` is
+ * dropped before persisting (see file-level comment for the policy).
  */
 export class TokenCache {
   /**
@@ -50,13 +60,17 @@ export class TokenCache {
   }
 
   /**
-   * Writes the cache file with mode 0600. Creates parent directories as needed.
+   * Writes the cache file with mode 0600. Strips `refresh_token` before
+   * persisting (the cache is access-token-only by policy; see file header).
+   * Creates parent directories as needed.
    * @param {object} tokens - The token object to persist.
    * @returns {Promise<void>} Resolves when the file has been written.
    */
   async write(tokens) {
+    const safe = { ...tokens }
+    delete safe.refresh_token
     await fs.mkdir(path.dirname(this._path), { recursive: true })
-    await fs.writeFile(this._path, JSON.stringify(tokens, null, 2), { mode: 0o600 })
+    await fs.writeFile(this._path, JSON.stringify(safe, null, 2), { mode: 0o600 })
     await fs.chmod(this._path, 0o600)
   }
 

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -42,10 +42,16 @@ import { checkGCP } from './lib/util/gcp.js'
 import { featureFlags, FLAGS } from './lib/util/feature_flags.js'
 import { logger } from './lib/util/logger.js'
 import { printBanner, dim } from './lib/util/banner.js'
-import { buildScopesField, buildAuthRemediationLines, buildQuotaProjectWarning } from './lib/util/auth_messages.js'
+import {
+  buildScopesField,
+  buildAuthRemediationLines,
+  buildQuotaProjectWarning,
+  buildOAuthClientField,
+} from './lib/util/auth_messages.js'
 import { TAGS, SCOPES } from './lib/constants.js'
 import { adcCredential } from './lib/util/credential/adc.js'
 import { oauthFlowCredential } from './lib/util/credential/oauth_flow.js'
+import { resolveOAuthClientConfig } from './lib/util/credential/oauth_client_config.js'
 
 // Import Real Clients
 import { RealAdminSdkClient } from './lib/api/real_admin_sdk_client.js'
@@ -201,12 +207,20 @@ export async function runServer() {
       logger.warn(`${TAGS.MCP} OAuth-flow probe skipped: ${err.message}`)
     }
 
+    let oauthClientConfig = null
+    try {
+      oauthClientConfig = resolveOAuthClientConfig()
+    } catch (err) {
+      logger.warn(`${TAGS.MCP} OAuth client config unavailable: ${err.message}`)
+    }
+
     printBanner({
       transport: isStdio ? 'Stdio' : ['SSE/HTTP', `(Port: ${process.env.PORT || '0'})`],
       auth: isStdio ? ['None', '(Local channel)'] : ['None', '(Unauthenticated)'],
       apiCreds: adc.valid ? ['ADC', adc.email ? `(${adc.email})` : '(detected)'] : ['ADC', '(not configured)'],
       scopes: buildScopesField(adc, requiredScopes),
       oauthFlowScopes: oauthProbe ? buildScopesField(oauthProbe, requiredScopes) : '⚪ OAuth flow: probe unavailable',
+      oauthClient: buildOAuthClientField(oauthClientConfig),
       dataAccess: process.env.GOOGLE_API_ROOT_URL ? 'Fake' : 'Production',
       knowledge: ['lib/knowledge', `(${articleCount} articles)`],
     })

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /*
 Copyright 2026 Google LLC
 
@@ -142,7 +141,7 @@ async function getServer(gcpInfo, sharedSessionState) {
 /**
  * Starts the MCP server.
  */
-async function main() {
+export async function runServer() {
   try {
     const gcpInfo = await checkGCP()
     const isStdio = shouldStartStdio(gcpInfo)
@@ -188,9 +187,8 @@ async function main() {
       quotaProject: process.env.GOOGLE_CLOUD_QUOTA_PROJECT || null,
     }
 
-    // OAuth-flow probe runs alongside the ADC probe. A missing cache file
-    // returns immediately; a 2-second timeout caps the network worst case so
-    // the boot does not block.
+    // OAuth-flow probe runs concurrently. A missing cache file returns
+    // immediately; the boot does not block on network calls.
     let oauthProbe = null
     try {
       oauthProbe = await Promise.race([
@@ -351,4 +349,6 @@ const shutdown = async () => {
 process.on('SIGINT', shutdown)
 process.on('SIGTERM', shutdown)
 
-main()
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runServer()
+}

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
   "type": "module",
   "main": "mcp-server.js",
   "bin": {
-    "chrome-enterprise-premium-mcp": "mcp-server.js"
+    "chrome-enterprise-premium-mcp": "bin/cli.js"
   },
   "scripts": {
+    "audit:scopes": "node scripts/audit-scopes.js",
     "eval": "CEP_BACKEND=fake node test/evals/run.js",
     "eval:agentic": "CEP_BACKEND=fake node test/evals/run.js --category inspection,troubleshooting,mutation,discovery,connectors",
     "eval:full": "CEP_BACKEND=fake node test/evals/run.js --runs 3 --output results/eval-full.md",

--- a/test/integration/auth-oauth-flow.test.js
+++ b/test/integration/auth-oauth-flow.test.js
@@ -67,9 +67,8 @@ describe('OAuth flow end-to-end', () => {
 
       const tokens = JSON.parse(await fs.readFile(cachePath, 'utf8'))
       assert.ok(tokens.access_token, 'cache must contain access_token')
-      assert.ok(tokens.refresh_token, 'cache must contain refresh_token')
       assert.ok(tokens.access_token.startsWith('access-'), 'access_token must come from the fake issuer')
-      assert.ok(tokens.refresh_token.startsWith('refresh-'), 'refresh_token must come from the fake issuer')
+      assert.equal(tokens.refresh_token, undefined, 'cache must not persist refresh_token (policy)')
     } finally {
       await fake.stop()
       await fs.rm(cacheDir, { recursive: true, force: true })

--- a/test/local/auth_messages.test.js
+++ b/test/local/auth_messages.test.js
@@ -20,6 +20,7 @@ import {
   buildScopesField,
   buildAuthRemediationLines,
   buildQuotaProjectWarning,
+  buildOAuthClientField,
   shellTokenize,
 } from '../../lib/util/auth_messages.js'
 import { SCOPES } from '../../lib/constants.js'
@@ -343,6 +344,32 @@ describe('buildAuthRemediationLines', () => {
         `scope "${scope}" must be a full googleapis.com/auth/ URL; short-form scopes trigger gcloud's "Scope has changed" abort`,
       )
     }
+  })
+})
+
+describe('buildOAuthClientField', () => {
+  test('When source is managed, then it returns "OAuth client: Google-managed"', () => {
+    assert.equal(
+      buildOAuthClientField({ clientId: 'a', clientSecret: 'b', source: 'managed' }),
+      'OAuth client: Google-managed',
+    )
+  })
+  test('When source is custom, then it returns "OAuth client: custom (<first 8 chars>...)"', () => {
+    assert.equal(
+      buildOAuthClientField({ clientId: '1234567890abcdef', clientSecret: 'b', source: 'custom' }),
+      'OAuth client: custom (12345678...)',
+    )
+  })
+  test('When the custom client_id is shorter than 8 chars, then it returns the full id followed by ...', () => {
+    assert.equal(
+      buildOAuthClientField({ clientId: 'short', clientSecret: 'b', source: 'custom' }),
+      'OAuth client: custom (short...)',
+    )
+  })
+  test('When config is null, then it returns a TODO line flagging the unprovisioned managed client', () => {
+    const text = buildOAuthClientField(null)
+    assert.match(text, /TODO/)
+    assert.match(text, /CEP_OAUTH_CLIENT_ID/)
   })
 })
 

--- a/test/local/cli.test.js
+++ b/test/local/cli.test.js
@@ -48,6 +48,7 @@ describe('runLoginCommand', () => {
 
     const runLoginFlow = mock.fn(async () => {})
     const credentialFactory = mock.fn(() => ({ runLoginFlow }))
+    const configResolver = mock.fn(() => ({ source: 'managed', clientId: '', clientSecret: '' }))
 
     const lines = []
 
@@ -57,7 +58,7 @@ describe('runLoginCommand', () => {
       lines.push(msg)
     }
     try {
-      await runLoginCommand({ credentialFactory })
+      await runLoginCommand({ credentialFactory, configResolver })
     } finally {
       // eslint-disable-next-line require-atomic-updates
       console.log = origLog
@@ -67,5 +68,112 @@ describe('runLoginCommand', () => {
     assert.equal(runLoginFlow.mock.calls.length, 1)
     assert.ok(lines.some(l => /opening browser/i.test(l)))
     assert.ok(lines.some(l => /tokens cached/i.test(l)))
+  })
+})
+
+describe('runLoginCommand BYO notice', () => {
+  it('When source is managed, then no notice prints', async () => {
+    const { runLoginCommand } = await import('../../lib/util/credential/cli_commands.js')
+
+    const runLoginFlow = mock.fn(async () => {})
+    const credentialFactory = mock.fn(() => ({ runLoginFlow }))
+    const configResolver = mock.fn(() => ({
+      source: 'managed',
+      clientId: '',
+      clientSecret: '',
+    }))
+
+    const lines = []
+
+    const origLog = console.log
+
+    console.log = msg => {
+      lines.push(msg)
+    }
+    try {
+      await runLoginCommand({ credentialFactory, configResolver })
+    } finally {
+      // eslint-disable-next-line require-atomic-updates
+      console.log = origLog
+    }
+
+    const noticePresent = lines.some(l => /Custom OAuth client detected/i.test(l))
+    assert.equal(noticePresent, false)
+  })
+
+  it('When source is custom and no marker exists, then notice prints and marker is created', async () => {
+    const { runLoginCommand } = await import('../../lib/util/credential/cli_commands.js')
+    const fs = await import('node:fs/promises')
+    const os = await import('node:os')
+    const path = await import('node:path')
+
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cep-mcp-test-'))
+    const noticePath = path.join(tmpDir, 'byo-notice.shown')
+
+    const runLoginFlow = mock.fn(async () => {})
+    const credentialFactory = mock.fn(() => ({ runLoginFlow }))
+    const configResolver = mock.fn(() => ({
+      source: 'custom',
+      clientId: 'test',
+      clientSecret: 'test',
+    }))
+
+    const lines = []
+
+    const origLog = console.log
+
+    console.log = msg => {
+      lines.push(msg)
+    }
+    try {
+      await runLoginCommand({ credentialFactory, noticePath, configResolver })
+    } finally {
+      // eslint-disable-next-line require-atomic-updates
+      console.log = origLog
+      await fs.rm(tmpDir, { recursive: true, force: true })
+    }
+
+    const noticePresent = lines.some(l => /Custom OAuth client detected/i.test(l))
+    assert.equal(noticePresent, true)
+  })
+
+  it('When source is custom and marker exists, then notice does not print', async () => {
+    const { runLoginCommand } = await import('../../lib/util/credential/cli_commands.js')
+    const fs = await import('node:fs/promises')
+    const os = await import('node:os')
+    const path = await import('node:path')
+
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cep-mcp-test-'))
+    const noticePath = path.join(tmpDir, 'byo-notice.shown')
+
+    // Pre-create marker
+    await fs.mkdir(path.dirname(noticePath), { recursive: true })
+    await fs.writeFile(noticePath, new Date().toISOString())
+
+    const runLoginFlow = mock.fn(async () => {})
+    const credentialFactory = mock.fn(() => ({ runLoginFlow }))
+    const configResolver = mock.fn(() => ({
+      source: 'custom',
+      clientId: 'test',
+      clientSecret: 'test',
+    }))
+
+    const lines = []
+
+    const origLog = console.log
+
+    console.log = msg => {
+      lines.push(msg)
+    }
+    try {
+      await runLoginCommand({ credentialFactory, noticePath, configResolver })
+    } finally {
+      // eslint-disable-next-line require-atomic-updates
+      console.log = origLog
+      await fs.rm(tmpDir, { recursive: true, force: true })
+    }
+
+    const noticePresent = lines.some(l => /Custom OAuth client detected/i.test(l))
+    assert.equal(noticePresent, false)
   })
 })

--- a/test/local/cli.test.js
+++ b/test/local/cli.test.js
@@ -1,0 +1,71 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file Tests for bin/cli.js subcommand dispatch and runLoginCommand.
+ */
+
+import { describe, it, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const CLI = path.resolve(__dirname, '../../bin/cli.js')
+
+describe('bin/cli.js', () => {
+  describe('auth-status', () => {
+    it('When invoked with auth-status and ADC absent, then it prints the ADC line and an OAuth flow line', () => {
+      const result = spawnSync('node', [CLI, 'auth-status'], {
+        encoding: 'utf8',
+        env: { ...process.env, GOOGLE_APPLICATION_CREDENTIALS: '/nonexistent' },
+      })
+      assert.equal(result.status, 0)
+      assert.match(result.stdout, /Auth status:/)
+      assert.match(result.stdout, /ADC:/)
+      assert.match(result.stdout, /OAuth flow:/)
+    })
+  })
+})
+
+describe('runLoginCommand', () => {
+  it('When login is invoked and runLoginFlow succeeds, then it prints the cached message and exits 0', async () => {
+    const { runLoginCommand } = await import('../../lib/util/credential/cli_commands.js')
+
+    const runLoginFlow = mock.fn(async () => {})
+    const credentialFactory = mock.fn(() => ({ runLoginFlow }))
+
+    const lines = []
+
+    const origLog = console.log
+
+    console.log = msg => {
+      lines.push(msg)
+    }
+    try {
+      await runLoginCommand({ credentialFactory })
+    } finally {
+      // eslint-disable-next-line require-atomic-updates
+      console.log = origLog
+    }
+
+    assert.equal(credentialFactory.mock.calls.length, 1)
+    assert.equal(runLoginFlow.mock.calls.length, 1)
+    assert.ok(lines.some(l => /opening browser/i.test(l)))
+    assert.ok(lines.some(l => /tokens cached/i.test(l)))
+  })
+})

--- a/test/local/credential-oauth-flow.test.js
+++ b/test/local/credential-oauth-flow.test.js
@@ -217,13 +217,13 @@ describe('oauthFlowCredential runLoginFlow', () => {
 
     const returned = await cred.runLoginFlow({ openBrowser, createOAuth2Client })
     assert.equal(returned.access_token, fakeTokens.access_token)
-    assert.equal(returned.refresh_token, fakeTokens.refresh_token)
 
-    // Verify the cache file exists with the correct tokens and mode 0600.
+    // Verify the cache file exists with the access token but no refresh
+    // token (policy: refresh tokens are never persisted).
     const raw = await fs.readFile(cachePath, 'utf8')
     const cached = JSON.parse(raw)
     assert.equal(cached.access_token, fakeTokens.access_token)
-    assert.equal(cached.refresh_token, fakeTokens.refresh_token)
+    assert.equal(cached.refresh_token, undefined, 'refresh_token must not be in the persisted cache')
 
     const stat = await fs.stat(cachePath)
     assert.equal(stat.mode & 0o777, 0o600, `expected cache file mode 0600, got ${(stat.mode & 0o777).toString(8)}`)

--- a/test/local/credential-oauth-flow.test.js
+++ b/test/local/credential-oauth-flow.test.js
@@ -218,8 +218,6 @@ describe('oauthFlowCredential runLoginFlow', () => {
     const returned = await cred.runLoginFlow({ openBrowser, createOAuth2Client })
     assert.equal(returned.access_token, fakeTokens.access_token)
 
-    // Verify the cache file exists with the access token but no refresh
-    // token (policy: refresh tokens are never persisted).
     const raw = await fs.readFile(cachePath, 'utf8')
     const cached = JSON.parse(raw)
     assert.equal(cached.access_token, fakeTokens.access_token)

--- a/test/local/oauth-client-config.test.js
+++ b/test/local/oauth-client-config.test.js
@@ -1,0 +1,72 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { resolveOAuthClientConfig, managedClientIsPlaceholder } from '../../lib/util/credential/oauth_client_config.js'
+import {
+  MANAGED_OAUTH_CLIENT_ID,
+  MANAGED_OAUTH_CLIENT_SECRET,
+  MANAGED_OAUTH_CLIENT_PLACEHOLDER,
+} from '../../lib/constants.js'
+
+describe('managed OAuth client placeholder', () => {
+  it('Both managed constants reference the shared TODO placeholder', () => {
+    assert.equal(MANAGED_OAUTH_CLIENT_ID, MANAGED_OAUTH_CLIENT_PLACEHOLDER)
+    assert.equal(MANAGED_OAUTH_CLIENT_SECRET, MANAGED_OAUTH_CLIENT_PLACEHOLDER)
+  })
+
+  it('managedClientIsPlaceholder() returns true while the constants hold the TODO value', () => {
+    assert.equal(managedClientIsPlaceholder(), true)
+  })
+})
+
+describe('resolveOAuthClientConfig', () => {
+  it('When neither env var is set and managed client is unprovisioned, then it throws a clear TODO message', () => {
+    assert.throws(() => resolveOAuthClientConfig({}), /Managed OAuth client is not yet provisioned/)
+  })
+
+  it('When env vars are empty strings (set but blank), then it falls through to the unprovisioned-managed throw', () => {
+    assert.throws(
+      () => resolveOAuthClientConfig({ CEP_OAUTH_CLIENT_ID: '', CEP_OAUTH_CLIENT_SECRET: '' }),
+      /Managed OAuth client is not yet provisioned/,
+    )
+  })
+
+  it('When both env vars are set, then it returns the custom values with source:custom', () => {
+    const config = resolveOAuthClientConfig({
+      CEP_OAUTH_CLIENT_ID: 'custom-id-1234567890',
+      CEP_OAUTH_CLIENT_SECRET: 'custom-secret',
+    })
+    assert.equal(config.source, 'custom')
+    assert.equal(config.clientId, 'custom-id-1234567890')
+    assert.equal(config.clientSecret, 'custom-secret')
+  })
+
+  it('When only CEP_OAUTH_CLIENT_ID is set, then it throws the asymmetric-env message', () => {
+    assert.throws(
+      () => resolveOAuthClientConfig({ CEP_OAUTH_CLIENT_ID: 'x' }),
+      /Set both CEP_OAUTH_CLIENT_ID and CEP_OAUTH_CLIENT_SECRET/,
+    )
+  })
+
+  it('When only CEP_OAUTH_CLIENT_SECRET is set, then it throws the asymmetric-env message', () => {
+    assert.throws(
+      () => resolveOAuthClientConfig({ CEP_OAUTH_CLIENT_SECRET: 'x' }),
+      /Set both CEP_OAUTH_CLIENT_ID and CEP_OAUTH_CLIENT_SECRET/,
+    )
+  })
+})

--- a/test/local/smoke-test.js
+++ b/test/local/smoke-test.js
@@ -18,7 +18,7 @@ limitations under the License.
 
 process.env.GCP_STDIO ??= 'false'
 
-import { spawn } from 'child_process'
+import { spawn, spawnSync } from 'child_process'
 import http from 'http'
 import { logger } from '../../lib/util/logger.js'
 
@@ -29,13 +29,16 @@ import { logger } from '../../lib/util/logger.js'
 // so the grounding-content check would give a false negative over HTTP.
 await runStdioInitializeTest()
 
-const server = spawn('node', ['mcp-server.js'], {
+// Auth phase: confirm `node bin/cli.js auth-status` runs cleanly.
+runAuthStatusTest()
+
+const server = spawn('node', ['bin/cli.js'], {
   env: { ...process.env, GOOGLE_API_ROOT_URL: 'http://localhost:1234', PORT: '3000' },
 })
 
 async function runStdioInitializeTest() {
   return new Promise(resolve => {
-    const stdio = spawn('node', ['mcp-server.js'], {
+    const stdio = spawn('node', ['bin/cli.js'], {
       env: { ...process.env, GCP_STDIO: 'true', GOOGLE_API_ROOT_URL: 'http://localhost:1234' },
       stdio: ['pipe', 'pipe', 'inherit'],
     })
@@ -84,6 +87,30 @@ async function runStdioInitializeTest() {
     // Safety net — if no valid response within 5s, fail.
     setTimeout(() => finish(false), 5000)
   })
+}
+
+function runAuthStatusTest() {
+  logger.info('--- AUTH PHASE ---')
+  const result = spawnSync('node', ['bin/cli.js', 'auth-status'], {
+    encoding: 'utf8',
+    env: { ...process.env, GOOGLE_APPLICATION_CREDENTIALS: '/nonexistent', CEP_LOG_LEVEL: 'SILENT' },
+  })
+  if (result.status !== 0) {
+    logger.error('auth-status failed: exit', result.status, result.stderr)
+    process.exit(1)
+  }
+  for (const expected of ['Auth status:', 'ADC:', 'OAuth flow:']) {
+    if (!result.stdout.includes(expected)) {
+      logger.error(`auth-status output missing expected line: ${expected}`)
+      logger.error(`stdout was:\n${result.stdout}`)
+      process.exit(1)
+    }
+  }
+  if (result.stderr.includes('Error:') || result.stderr.includes('at ')) {
+    logger.error('auth-status stderr contains errors:', result.stderr)
+    process.exit(1)
+  }
+  logger.info('auth-status output OK')
 }
 
 function runToolTest() {

--- a/test/local/token-cache.test.js
+++ b/test/local/token-cache.test.js
@@ -44,12 +44,27 @@ describe('TokenCache', () => {
     assert.ok(stat.isFile())
   })
 
-  it('When write then read, then the round-trip preserves the JSON shape', async () => {
+  it('When write then read, then the round-trip preserves access_token, expiry_date, and scope', async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'cep-mcp-test-'))
     const cache = new TokenCache(path.join(dir, 'tokens.json'))
-    const tokens = { access_token: 'a', refresh_token: 'r', expiry_date: 12345, scope: 'x y z' }
-    await cache.write(tokens)
-    assert.deepEqual(await cache.read(), tokens)
+    const input = { access_token: 'a', expiry_date: 12345, scope: 'x y z' }
+    await cache.write(input)
+    assert.deepEqual(await cache.read(), input)
+  })
+
+  it('When the input includes a refresh_token, then write strips it before persisting', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'cep-mcp-test-'))
+    const cache = new TokenCache(path.join(dir, 'tokens.json'))
+    await cache.write({
+      access_token: 'a',
+      refresh_token: 'must-not-persist',
+      expiry_date: 12345,
+      scope: 'x',
+    })
+    const persisted = await cache.read()
+    assert.equal(persisted.refresh_token, undefined, 'refresh_token must not be persisted')
+    assert.equal(persisted.access_token, 'a')
+    assert.equal(persisted.scope, 'x')
   })
 
   it('When the existing file has mode 0644, then write tightens it to 0600', async () => {


### PR DESCRIPTION
[abandoned]

Originally opened to add the BYO env-var override for the OAuth client (`CEP_OAUTH_CLIENT_ID`/`CEP_OAUTH_CLIENT_SECRET`), the bundled Google-managed client constants, the banner OAuth client field, and the one-time custom-client responsibilities notice. Addressed #92.

Abandoned because the auth-refactor chain it sat in was reworked into the OAuth-only design tracked in #167.

Superseded by #171.