### PR TITLE
[abandoned] docs(auth): document the layered auth model and recommend OAuth for Gemini Enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ don't have it, then create
 
 ```bash
 gcloud auth application-default login \
---scopes=openid,\
-https://www.googleapis.com/auth/userinfo.email,\
+--scopes=https://www.googleapis.com/auth/userinfo.email,\
 https://www.googleapis.com/auth/chrome.management.policy,\
 https://www.googleapis.com/auth/chrome.management.reports.readonly,\
 https://www.googleapis.com/auth/chrome.management.profiles.readonly,\
@@ -54,25 +53,25 @@ https://www.googleapis.com/auth/admin.directory.orgunit.readonly,\
 https://www.googleapis.com/auth/admin.directory.customer.readonly,\
 https://www.googleapis.com/auth/apps.licensing,\
 https://www.googleapis.com/auth/cloud-identity.policies,\
-https://www.googleapis.com/auth/service.management,\
-https://www.googleapis.com/auth/service.management.readonly,\
 https://www.googleapis.com/auth/cloud-platform
 ```
 
+For service-account, BYO-OAuth, or managed-OAuth setups, see [docs/configuration.md#authentication](docs/configuration.md#authentication).
+
 These scopes map to the underlying APIs:
 
-| Scope                                                                 | API                                                                             | Used for                                                           |
-| :-------------------------------------------------------------------- | :------------------------------------------------------------------------------ | :----------------------------------------------------------------- |
-| `openid`, `userinfo.email`                                            | OpenID Connect                                                                  | Identifies the principal in startup banner output                  |
-| `chrome.management.policy`                                            | [Chrome Policy](https://developers.google.com/chrome/policy)                    | Reading and writing connector policies, extension install policies |
-| `chrome.management.reports.readonly`                                  | [Chrome Management](https://developers.google.com/chrome/management)            | Browser version counts                                             |
-| `chrome.management.profiles.readonly`                                 | [Chrome Management](https://developers.google.com/chrome/management)            | Listing managed browser profiles                                   |
-| `admin.reports.audit.readonly`                                        | [Admin SDK Reports](https://developers.google.com/admin-sdk/reports)            | Chrome activity logs                                               |
-| `admin.directory.orgunit.readonly`                                    | [Admin SDK Directory](https://developers.google.com/admin-sdk/directory)        | Organizational unit hierarchy                                      |
-| `admin.directory.customer.readonly`                                   | [Admin SDK Directory](https://developers.google.com/admin-sdk/directory)        | Customer ID resolution                                             |
-| `apps.licensing`                                                      | [Enterprise License Manager](https://developers.google.com/admin-sdk/licensing) | CEP subscription and per-user license checks                       |
-| `cloud-identity.policies`                                             | [Cloud Identity](https://cloud.google.com/identity/docs)                        | DLP rules and content detectors (CRUD)                             |
-| `service.management`, `service.management.readonly`, `cloud-platform` | [Service Usage](https://cloud.google.com/service-usage/docs)                    | Checking and enabling required APIs                                |
+| Scope                                 | API                                                                             | Used for                                                           |
+| :------------------------------------ | :------------------------------------------------------------------------------ | :----------------------------------------------------------------- |
+| `userinfo.email`                      | OpenID Connect                                                                  | Identifies the principal in startup banner output                  |
+| `chrome.management.policy`            | [Chrome Policy](https://developers.google.com/chrome/policy)                    | Reading and writing connector policies, extension install policies |
+| `chrome.management.reports.readonly`  | [Chrome Management](https://developers.google.com/chrome/management)            | Browser version counts                                             |
+| `chrome.management.profiles.readonly` | [Chrome Management](https://developers.google.com/chrome/management)            | Listing managed browser profiles                                   |
+| `admin.reports.audit.readonly`        | [Admin SDK Reports](https://developers.google.com/admin-sdk/reports)            | Chrome activity logs                                               |
+| `admin.directory.orgunit.readonly`    | [Admin SDK Directory](https://developers.google.com/admin-sdk/directory)        | Organizational unit hierarchy                                      |
+| `admin.directory.customer.readonly`   | [Admin SDK Directory](https://developers.google.com/admin-sdk/directory)        | Customer ID resolution                                             |
+| `apps.licensing`                      | [Enterprise License Manager](https://developers.google.com/admin-sdk/licensing) | CEP subscription and per-user license checks                       |
+| `cloud-identity.policies`             | [Cloud Identity](https://cloud.google.com/identity/docs)                        | DLP rules and content detectors (CRUD)                             |
+| `cloud-platform`                      | [Service Usage](https://cloud.google.com/service-usage/docs)                    | Checking and enabling required APIs                                |
 
 Then set a quota project (identifies which GCP project's API enablement and
 quotas to use):

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file CLI entry point. Dispatches argv[2] to a subcommand or to the MCP server.
+ */
+
+/* eslint-disable n/no-process-exit */
+
+import { runServer } from '../mcp-server.js'
+
+/**
+ * Dispatches the CLI subcommand.
+ * @returns {Promise<void>} Resolves when the chosen command finishes.
+ */
+async function main() {
+  const sub = process.argv[2]
+  if (sub === 'auth-status') {
+    const { runAuthStatusCommand } = await import('../lib/util/credential/cli_commands.js')
+    return runAuthStatusCommand()
+  }
+  if (sub === 'login') {
+    const { runLoginCommand } = await import('../lib/util/credential/cli_commands.js')
+    return runLoginCommand()
+  }
+  return runServer()
+}
+
+main().catch(err => {
+  console.error(err.message || err)
+  process.exit(1)
+})

--- a/docs/auth-bring-your-own-oauth-client.md
+++ b/docs/auth-bring-your-own-oauth-client.md
@@ -52,6 +52,6 @@ If both variables are unset and the bundled managed client has not yet been prov
 
 ## Authenticate with the custom client
 
-Run `mcp auth login` to authenticate against the custom client. The command opens your browser to the Google consent screen. Grant consent; the server caches your refresh and access tokens locally.
+Run `mcp auth login` to authenticate against the custom client. The command opens your browser to the Google consent screen. After you grant consent, your access token is cached locally. Refresh tokens are not persisted; the server uses an access-token-only grant because the requested scopes are sensitive.
 
-Subsequent server starts use the cached tokens. Run `mcp auth login` again if the tokens are revoked or scopes change.
+Once the cached token has expired, run `mcp auth login` again. Run it again whenever scopes change or the token has been revoked.

--- a/docs/auth-bring-your-own-oauth-client.md
+++ b/docs/auth-bring-your-own-oauth-client.md
@@ -1,0 +1,57 @@
+# Bring Your Own OAuth Client
+
+The CEP MCP server will eventually ship with a bundled Google-managed OAuth client. Until that managed client is published and allowlisted, **bring-your-own (BYO) is the only way to use the `mcp auth login` flow**. After the managed client ships, BYO remains supported for customers who need it for audit, brand, compliance, or scope-restriction reasons.
+
+## Register the OAuth client
+
+The OAuth client must be an **installed-app (Desktop) client**, not a Web client. Web clients do not allow loopback redirect URIs.
+
+1. Open the [Google Cloud Console](https://console.cloud.google.com/).
+2. Navigate to **APIs & Services** > **Credentials**.
+3. Click **Create Credentials** > **OAuth client ID**.
+4. Select **Application type: Desktop app**.
+5. Click **Create**.
+6. Note the **Client ID** and **Client Secret**; you will need them in the next section.
+
+## Configure redirect URIs
+
+The OAuth client must allow loopback redirect URIs. Add both of these to the client's **Authorized redirect URIs**:
+
+- `http://127.0.0.1`
+- `http://localhost` (optional)
+
+## Grant scopes on the consent screen
+
+The OAuth consent screen must include every scope that the CEP MCP server requires. In the Google Cloud Console, navigate to **APIs & Services** > **OAuth consent screen** and add these scopes:
+
+- `EMAIL` (https://www.googleapis.com/auth/userinfo.email)
+- `CHROME_MANAGEMENT_POLICY` (https://www.googleapis.com/auth/chrome.management.policy)
+- `CHROME_MANAGEMENT_REPORTS_READONLY` (https://www.googleapis.com/auth/chrome.management.reports.readonly)
+- `CHROME_MANAGEMENT_PROFILES_READONLY` (https://www.googleapis.com/auth/chrome.management.profiles.readonly)
+- `ADMIN_REPORTS_AUDIT_READONLY` (https://www.googleapis.com/auth/admin.reports.audit.readonly)
+- `ADMIN_DIRECTORY_ORGUNIT_READONLY` (https://www.googleapis.com/auth/admin.directory.orgunit.readonly)
+- `ADMIN_DIRECTORY_CUSTOMER_READONLY` (https://www.googleapis.com/auth/admin.directory.customer.readonly)
+- `LICENSING` (https://www.googleapis.com/auth/apps.licensing)
+- `CLOUD_IDENTITY_POLICIES` (https://www.googleapis.com/auth/cloud-identity.policies)
+- `CLOUD_PLATFORM` (https://www.googleapis.com/auth/cloud-platform)
+
+## Brand verification for restricted scopes
+
+Admin SDK Directory and Reports are restricted scopes. The OAuth consent screen must pass [Google brand verification](https://support.google.com/cloud/answer/13463073) before non-internal users can consent. If the organization has not passed brand verification, only users with project owner or editor roles can complete the consent flow.
+
+## Set environment variables
+
+The server reads the custom OAuth client from the `CEP_OAUTH_CLIENT_ID` and `CEP_OAUTH_CLIENT_SECRET` environment variables. **Both must be set.** If only one is set, the server exits with a fatal error.
+
+```bash
+export CEP_OAUTH_CLIENT_ID="<client-id>"
+export CEP_OAUTH_CLIENT_SECRET="<client-secret>"
+```
+
+If both variables are unset and the bundled managed client has not yet been provisioned, the server prints `OAuth client: TODO …` in the boot banner and `mcp auth login` exits with a clear "Managed OAuth client is not yet provisioned" error. Once the managed client ships, leaving both env vars unset selects it.
+
+## Authenticate with the custom client
+
+Run `mcp auth login` to authenticate against the custom client. The command opens your browser to the Google consent screen. Grant consent; the server caches your refresh and access tokens locally.
+
+Subsequent server starts use the cached tokens. Run `mcp auth login` again if the tokens are revoked or scopes change.

--- a/docs/auth-cloud-run-and-gemini-enterprise.md
+++ b/docs/auth-cloud-run-and-gemini-enterprise.md
@@ -8,7 +8,7 @@ The reference pattern is the [ADK + OAuth + Gemini Enterprise article](https://f
 
 ## Status of this guide
 
-The CEP MCP server's existing OAuth flow (`mcp auth login`) ships with a loopback redirect URI for local CLI use, not the web-redirect URI Vertex AI Agent Engine expects. A web-redirect OAuth path for the Cloud Run topology is a tracked follow-up; until it ships, **a complete Cloud Run + Gemini Enterprise deployment guide is out of scope of this repository**. The detailed instructions in earlier drafts of this file pointed at SA + DWD, which we no longer recommend; we have removed them rather than leave conflicting guidance in place.
+The existing `mcp auth login` flow uses a loopback redirect URI for local CLI use; Vertex AI Agent Engine expects a web redirect URI. The web-redirect OAuth factory lives in PR #117 (issue #114). A complete Cloud Run + Gemini Enterprise deployment guide is out of scope of this repository for now; the [ADK + OAuth + Gemini Enterprise reference](https://fmind.medium.com/powering-up-your-agent-in-production-with-adk-oauth-and-gemini-enterprise-a52b0716fcba) is the canonical pattern.
 
 ## What is in the repository today
 

--- a/docs/auth-cloud-run-and-gemini-enterprise.md
+++ b/docs/auth-cloud-run-and-gemini-enterprise.md
@@ -1,94 +1,18 @@
 # Cloud Run + Gemini Enterprise
 
-## Why this topology exists
-
-Cloud Run + Gemini Enterprise is the deployment pattern the launch video targets. Gemini Enterprise authenticates to remote MCP servers using OIDC ID tokens. The server must act on behalf of the user to call Google APIs.
-
 ## Recommendation: prefer OAuth over service-account + DWD
 
-For new Cloud Run + Gemini Enterprise deployments, prefer the **OAuth flow** over server-side service-account + DWD impersonation. SA + DWD grants the server's service account the ability to impersonate any user in the domain for the granted scopes — too broad as a default. The OAuth flow scopes are bounded to the consenting user and revocable at `myaccount.google.com`.
+For Cloud Run deployments consumed by Gemini Enterprise, the recommended auth pattern is **OAuth on behalf of the user**, not server-side service-account + domain-wide-delegation (DWD) impersonation. SA + DWD grants the server's service account the ability to impersonate any user in the domain for the granted scopes — too broad as a default. The OAuth flow scopes are bounded to the consenting user and revocable at `myaccount.google.com`.
 
-The reference pattern is the [ADK + OAuth + Gemini Enterprise article](https://fmind.medium.com/powering-up-your-agent-in-production-with-adk-oauth-and-gemini-enterprise-a52b0716fcba): Authorization Code flow with redirect URI `https://vertexaisearch.cloud.google.com/oauth-redirect`, consent handled by the Vertex AI Agent Engine on the user's behalf, tokens cached in agent state.
+The reference pattern is the [ADK + OAuth + Gemini Enterprise article](https://fmind.medium.com/powering-up-your-agent-in-production-with-adk-oauth-and-gemini-enterprise-a52b0716fcba). Authorization Code flow with redirect URI `https://vertexaisearch.cloud.google.com/oauth-redirect`, consent handled by the Vertex AI Agent Engine on the user's behalf, tokens cached in agent state.
 
-The CEP MCP server's existing OAuth flow (`mcp auth login`) ships with a loopback redirect URI (`http://127.0.0.1:<port>`), which is the right design for **local CLI use** but not for Cloud Run deployments consumed by Gemini Enterprise. A web-redirect OAuth path for the Cloud Run topology is a tracked follow-up; until it ships, the SA + DWD flow documented below is the available path.
+## Status of this guide
 
-Use SA + DWD only when OAuth is not viable: cross-org automation, headless contexts, or environments where the user cannot complete an interactive consent.
+The CEP MCP server's existing OAuth flow (`mcp auth login`) ships with a loopback redirect URI for local CLI use, not the web-redirect URI Vertex AI Agent Engine expects. A web-redirect OAuth path for the Cloud Run topology is a tracked follow-up; until it ships, **a complete Cloud Run + Gemini Enterprise deployment guide is out of scope of this repository**. The detailed instructions in earlier drafts of this file pointed at SA + DWD, which we no longer recommend; we have removed them rather than leave conflicting guidance in place.
 
-## The deployment shape (SA + DWD path)
+## What is in the repository today
 
-The MCP server runs as a Cloud Run service with a service account configured for domain-wide delegation (DWD) in the Workspace Admin Console. Inbound requests from Gemini Enterprise carry an OIDC ID token in the `Authorization: Bearer ...` header. The server validates the JWT, extracts the `email` claim, and uses its service account to mint a user-scoped access token for that email via the google-auth-library's JWT class. The user-scoped token is then passed to Google APIs.
+- `lib/util/credential/bearer.js` implements the SA + DWD impersonation path for callers that already have an ID token and a DWD-configured service account. Use this only when OAuth is not viable (cross-org automation, headless contexts).
+- `lib/util/credential/oauth_flow.js` implements the loopback OAuth flow for local CLI use (`mcp auth login`). It does not target Cloud Run.
 
-## Configuration steps
-
-### a. Create the service account
-
-In the Cloud Console, create a service account:
-
-```bash
-gcloud iam service-accounts create cep-mcp-sa --project=<project>
-```
-
-Note the service account's numeric Client ID (the `unique_id`). Step 3b requires this value.
-
-### b. Configure domain-wide delegation
-
-In the Workspace Admin Console:
-
-1. Go to **Security** → **API Controls** → **Domain-wide Delegation**.
-2. Click **Add new**.
-3. Enter the service account's numeric Client ID (not the email address).
-4. In the **Scopes** field, paste all scopes from `lib/constants.js#SCOPES`:
-
-   ```
-   https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/chrome.management.policy,https://www.googleapis.com/auth/chrome.management.reports.readonly,https://www.googleapis.com/auth/chrome.management.profiles.readonly,https://www.googleapis.com/auth/admin.reports.audit.readonly,https://www.googleapis.com/auth/admin.directory.orgunit.readonly,https://www.googleapis.com/auth/admin.directory.customer.readonly,https://www.googleapis.com/auth/apps.licensing,https://www.googleapis.com/auth/cloud-identity.policies,https://www.googleapis.com/auth/cloud-platform
-   ```
-
-5. Click **Authorize**.
-
-### c. Deploy to Cloud Run
-
-Build and push the image:
-
-```bash
-docker build -t gcr.io/<project>/cep-mcp:latest .
-docker push gcr.io/<project>/cep-mcp:latest
-```
-
-Deploy to Cloud Run with the service account:
-
-```bash
-gcloud run deploy cep-mcp \
-  --image=gcr.io/<project>/cep-mcp:latest \
-  --service-account=cep-mcp-sa@<project>.iam.gserviceaccount.com \
-  --project=<project>
-```
-
-The output includes `Service URL: https://...`. Store this URL for step 3d.
-
-### d. Set environment variables
-
-In the Cloud Run service configuration, set the following environment variables:
-
-- `GCP_STDIO=false` — Run in HTTP mode.
-- `GOOGLE_CLOUD_QUOTA_PROJECT=<project>` — Set the quota project for API calls.
-- `CEP_OAUTH_EXPECTED_AUDIENCE=<service-url>` (optional) — Set this only if Cloud Run is fronted by a custom domain or load balancer that rewrites the Host header. Otherwise, leave unset and the server uses the `Host` header from the request.
-
-## Failure modes the server reports
-
-The server validates the OIDC token at request time and reports these errors:
-
-- **JWT signature fails** — "Bearer is an OIDC ID token, but the signature does not verify against Google's public keys." The token did not come from Google or was tampered with.
-- **Audience mismatch** — "ID token audience does not match this server. Verify the client is calling the correct service URL." The Cloud Run service URL does not match the `aud` claim in the token.
-- **Server SA not DWD-configured** — "Server cannot impersonate the requesting user. Configure domain-wide delegation for the server's service account in the Workspace Admin Console with the scopes from lib/constants.js#SCOPES." Step 3b was skipped or incomplete.
-- **Insufficient scopes in DWD** — "Domain-wide delegation does not grant scope X." An API call requires a scope that is not listed in the DWD configuration. Add the missing scope to the SA's DWD grant in the Workspace Admin Console and redeploy.
-
-## Verification
-
-Send a test request to the service using Gemini Enterprise's OIDC token:
-
-```bash
-gcloud auth print-identity-token --audiences=<service-url> | \
-  curl -H "Authorization: Bearer $(cat)" https://<service-url>/some-mcp-endpoint
-```
-
-The server responds with real CEP data, indicating that impersonation succeeded.
+When the web-redirect OAuth path lands, this document will gain step-by-step deployment instructions. Until then, follow the ADK reference linked above.

--- a/docs/auth-cloud-run-and-gemini-enterprise.md
+++ b/docs/auth-cloud-run-and-gemini-enterprise.md
@@ -1,0 +1,94 @@
+# Cloud Run + Gemini Enterprise
+
+## Why this topology exists
+
+Cloud Run + Gemini Enterprise is the deployment pattern the launch video targets. Gemini Enterprise authenticates to remote MCP servers using OIDC ID tokens. The server must act on behalf of the user to call Google APIs.
+
+## Recommendation: prefer OAuth over service-account + DWD
+
+For new Cloud Run + Gemini Enterprise deployments, prefer the **OAuth flow** over server-side service-account + DWD impersonation. SA + DWD grants the server's service account the ability to impersonate any user in the domain for the granted scopes — too broad as a default. The OAuth flow scopes are bounded to the consenting user and revocable at `myaccount.google.com`.
+
+The reference pattern is the [ADK + OAuth + Gemini Enterprise article](https://fmind.medium.com/powering-up-your-agent-in-production-with-adk-oauth-and-gemini-enterprise-a52b0716fcba): Authorization Code flow with redirect URI `https://vertexaisearch.cloud.google.com/oauth-redirect`, consent handled by the Vertex AI Agent Engine on the user's behalf, tokens cached in agent state.
+
+The CEP MCP server's existing OAuth flow (`mcp auth login`) ships with a loopback redirect URI (`http://127.0.0.1:<port>`), which is the right design for **local CLI use** but not for Cloud Run deployments consumed by Gemini Enterprise. A web-redirect OAuth path for the Cloud Run topology is a tracked follow-up; until it ships, the SA + DWD flow documented below is the available path.
+
+Use SA + DWD only when OAuth is not viable: cross-org automation, headless contexts, or environments where the user cannot complete an interactive consent.
+
+## The deployment shape (SA + DWD path)
+
+The MCP server runs as a Cloud Run service with a service account configured for domain-wide delegation (DWD) in the Workspace Admin Console. Inbound requests from Gemini Enterprise carry an OIDC ID token in the `Authorization: Bearer ...` header. The server validates the JWT, extracts the `email` claim, and uses its service account to mint a user-scoped access token for that email via the google-auth-library's JWT class. The user-scoped token is then passed to Google APIs.
+
+## Configuration steps
+
+### a. Create the service account
+
+In the Cloud Console, create a service account:
+
+```bash
+gcloud iam service-accounts create cep-mcp-sa --project=<project>
+```
+
+Note the service account's numeric Client ID (the `unique_id`). Step 3b requires this value.
+
+### b. Configure domain-wide delegation
+
+In the Workspace Admin Console:
+
+1. Go to **Security** → **API Controls** → **Domain-wide Delegation**.
+2. Click **Add new**.
+3. Enter the service account's numeric Client ID (not the email address).
+4. In the **Scopes** field, paste all scopes from `lib/constants.js#SCOPES`:
+
+   ```
+   https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/chrome.management.policy,https://www.googleapis.com/auth/chrome.management.reports.readonly,https://www.googleapis.com/auth/chrome.management.profiles.readonly,https://www.googleapis.com/auth/admin.reports.audit.readonly,https://www.googleapis.com/auth/admin.directory.orgunit.readonly,https://www.googleapis.com/auth/admin.directory.customer.readonly,https://www.googleapis.com/auth/apps.licensing,https://www.googleapis.com/auth/cloud-identity.policies,https://www.googleapis.com/auth/cloud-platform
+   ```
+
+5. Click **Authorize**.
+
+### c. Deploy to Cloud Run
+
+Build and push the image:
+
+```bash
+docker build -t gcr.io/<project>/cep-mcp:latest .
+docker push gcr.io/<project>/cep-mcp:latest
+```
+
+Deploy to Cloud Run with the service account:
+
+```bash
+gcloud run deploy cep-mcp \
+  --image=gcr.io/<project>/cep-mcp:latest \
+  --service-account=cep-mcp-sa@<project>.iam.gserviceaccount.com \
+  --project=<project>
+```
+
+The output includes `Service URL: https://...`. Store this URL for step 3d.
+
+### d. Set environment variables
+
+In the Cloud Run service configuration, set the following environment variables:
+
+- `GCP_STDIO=false` — Run in HTTP mode.
+- `GOOGLE_CLOUD_QUOTA_PROJECT=<project>` — Set the quota project for API calls.
+- `CEP_OAUTH_EXPECTED_AUDIENCE=<service-url>` (optional) — Set this only if Cloud Run is fronted by a custom domain or load balancer that rewrites the Host header. Otherwise, leave unset and the server uses the `Host` header from the request.
+
+## Failure modes the server reports
+
+The server validates the OIDC token at request time and reports these errors:
+
+- **JWT signature fails** — "Bearer is an OIDC ID token, but the signature does not verify against Google's public keys." The token did not come from Google or was tampered with.
+- **Audience mismatch** — "ID token audience does not match this server. Verify the client is calling the correct service URL." The Cloud Run service URL does not match the `aud` claim in the token.
+- **Server SA not DWD-configured** — "Server cannot impersonate the requesting user. Configure domain-wide delegation for the server's service account in the Workspace Admin Console with the scopes from lib/constants.js#SCOPES." Step 3b was skipped or incomplete.
+- **Insufficient scopes in DWD** — "Domain-wide delegation does not grant scope X." An API call requires a scope that is not listed in the DWD configuration. Add the missing scope to the SA's DWD grant in the Workspace Admin Console and redeploy.
+
+## Verification
+
+Send a test request to the service using Gemini Enterprise's OIDC token:
+
+```bash
+gcloud auth print-identity-token --audiences=<service-url> | \
+  curl -H "Authorization: Bearer $(cat)" https://<service-url>/some-mcp-endpoint
+```
+
+The server responds with real CEP data, indicating that impersonation succeeded.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,9 +62,92 @@ PORT=8080 GCP_STDIO=false npx -y @google/chrome-enterprise-premium-mcp@latest
 > random available port. The actual port is logged at startup, e.g.
 > `Chrome Enterprise Premium MCP server listening on port X`.
 
-## Authenticating to Google APIs
+## Authentication
 
-The server authenticates to Google APIs via Application Default Credentials
-(ADC), regardless of transport. Set ADC up using the Quick Start in the root
-[`README.md`](../README.md). The HTTP transport is unauthenticated at the
-network layer; bind it to a trusted interface only.
+Authentication has two independent layers.
+
+**Layer 1 — transport.** Stdio has no transport-layer auth; the OS process
+boundary is the security perimeter. HTTP has no built-in transport auth; bind
+it to a trusted interface (reverse proxy, VPC, localhost) and that boundary is
+the access control.
+
+**Layer 2 — Google API credentials.** Three delivery mechanisms are in scope:
+ADC discovery, bearer pass-through via `Authorization: Bearer …`, and an OAuth
+flow with cached tokens (proposed). Two principal types exist: EUC (end-user
+credentials) and SA (service account).
+
+### Credential matrix
+
+| #   | Transport     | Delivery                                  | Principal | Status    |
+| --- | ------------- | ----------------------------------------- | --------- | --------- |
+| 1   | stdio         | ADC                                       | EUC       | Available |
+| 2   | stdio         | ADC                                       | SA        | Available |
+| 3   | HTTP          | ADC                                       | EUC       | Available |
+| 4   | HTTP          | ADC                                       | SA        | Available |
+| 5   | HTTP          | Bearer (Google access token)              | EUC or SA | Available |
+| 6   | HTTP          | Bearer (OIDC ID token) + DWD on server SA | EUC       | Proposed  |
+| 7   | stdio or HTTP | OAuth flow with cached tokens             | EUC       | Proposed  |
+
+Stdio has no `Authorization` header concept, so stdio + bearer is not a valid
+combination.
+
+### Cell 1 — stdio + ADC + EUC (Quick Start path)
+
+`gcloud auth application-default login --scopes=…`, then run the server in
+stdio mode (`GCP_STDIO=true`, the default). Quick Start path.
+
+### Cell 2 — stdio + ADC + service account
+
+`GOOGLE_APPLICATION_CREDENTIALS=path/to/sa.json` (the SA needs domain-wide
+delegation in the Workspace Admin Console), then run the server in stdio mode.
+
+### Cell 3 — HTTP + ADC + EUC (single shared user)
+
+`gcloud auth application-default login --scopes=…`, then run the server with
+`GCP_STDIO=false`. The host's ADC user is the principal for every connecting
+client.
+
+### Cell 4 — HTTP + ADC + service account
+
+`GOOGLE_APPLICATION_CREDENTIALS=path/to/sa.json` (or
+workload-identity-equivalent on the host), then run the server with
+`GCP_STDIO=false`. The SA is the principal for every connecting client.
+
+### Cell 5 — HTTP + bearer access token
+
+Run the server with `GCP_STDIO=false`. The client acquires a Google access
+token out of band (e.g., `gcloud auth print-access-token`) and sends
+`Authorization: Bearer <token>` on each MCP request. The server forwards the
+token verbatim and does not verify it.
+
+### Cell 6 — HTTP + OIDC ID token + DWD impersonation (proposed)
+
+The Cloud Run + Gemini Enterprise topology. The client (Gemini CLI / Enterprise)
+sends its standard OIDC ID token in `Authorization: Bearer …`. The server
+validates the JWT, extracts the `email` claim, and uses its own service account
+— configured with domain-wide delegation in the Workspace Admin Console — to
+mint a user-scoped access token for that principal.
+
+This cell is proposed and not in the published version.
+
+### Cell 7 — OAuth flow with cached tokens (proposed)
+
+`npx -y @google/chrome-enterprise-premium-mcp@latest login` runs the consent
+flow against a Google-managed CEP OAuth client (public, loopback redirect URI)
+and caches refresh and access tokens locally. Subsequent server starts use the
+cached tokens. Set `CEP_OAUTH_CLIENT_ID` and `CEP_OAUTH_CLIENT_SECRET` to use
+your own OAuth client instead of the bundled one.
+
+The managed client is not yet provisioned. Until it ships, only the BYO path
+works — see `docs/auth-bring-your-own-oauth-client.md`. Until the managed
+client is allowlisted, leaving both env vars unset prints
+`OAuth client: TODO …` in the banner and `mcp auth login` exits with a
+"Managed OAuth client is not yet provisioned" error.
+
+### Decision tree
+
+- **stdio + one user or service account** → Cell 1 (EUC) or Cell 2 (SA).
+- **HTTP + all clients share one identity** → Cell 3 (EUC) or Cell 4 (SA).
+- **HTTP + per-client Google access tokens** → Cell 5.
+- **HTTP + per-user identity (Gemini CLI / Enterprise)** → Cell 6 once it ships; Cell 5 until then.
+- **stdio or HTTP + interactive consent, cached tokens** → Cell 7 once it ships.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,12 +120,23 @@ token out of band (e.g., `gcloud auth print-access-token`) and sends
 `Authorization: Bearer <token>` on each MCP request. The server forwards the
 token verbatim and does not verify it.
 
-### Cell 6 — HTTP + OIDC ID token + DWD impersonation (proposed)
+### Cell 6 — HTTP + OIDC ID token + DWD impersonation (fallback only)
+
+> **Recommendation: do not start here.** For Cloud Run + Gemini Enterprise
+> deployments, the recommended auth pattern is OAuth on behalf of the user,
+> not server-side service-account + DWD impersonation. SA + DWD grants the
+> server's service account the ability to impersonate any user in the
+> domain for the granted scopes; the OAuth flow is bounded to the
+> consenting user and revocable at `myaccount.google.com`. See the
+> [ADK + OAuth + Gemini Enterprise reference](https://fmind.medium.com/powering-up-your-agent-in-production-with-adk-oauth-and-gemini-enterprise-a52b0716fcba)
+> for the recommended pattern. Cell 6 is the fallback for cross-org
+> automation, headless contexts, and environments where the user cannot
+> complete an interactive consent.
 
 The Cloud Run + Gemini Enterprise topology. The client (Gemini CLI / Enterprise)
 sends its standard OIDC ID token in `Authorization: Bearer …`. The server
 validates the JWT, extracts the `email` claim, and uses its own service account
-— configured with domain-wide delegation in the Workspace Admin Console — to
+(configured with domain-wide delegation in the Workspace Admin Console) to
 mint a user-scoped access token for that principal.
 
 This cell is proposed and not in the published version.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,8 +85,8 @@ credentials) and SA (service account).
 | 3   | HTTP          | ADC                                       | EUC       | Available |
 | 4   | HTTP          | ADC                                       | SA        | Available |
 | 5   | HTTP          | Bearer (Google access token)              | EUC or SA | Available |
-| 6   | HTTP          | Bearer (OIDC ID token) + DWD on server SA | EUC       | Proposed  |
-| 7   | stdio or HTTP | OAuth flow with cached tokens             | EUC       | Proposed  |
+| 6   | HTTP          | Bearer (OIDC ID token) + DWD on server SA | EUC       | Available |
+| 7   | stdio or HTTP | OAuth flow with cached tokens (BYO)       | EUC       | Available |
 
 Stdio has no `Authorization` header concept, so stdio + bearer is not a valid
 combination.
@@ -139,9 +139,9 @@ validates the JWT, extracts the `email` claim, and uses its own service account
 (configured with domain-wide delegation in the Workspace Admin Console) to
 mint a user-scoped access token for that principal.
 
-This cell is proposed and not in the published version.
+This cell ships in the auth-refactor chain (PR #107). The bearer factory verifies the JWT signature against Google's JWK set, validates the audience against the request `Host` header, then uses google-auth-library's `JWT` class with `subject = <email from token>` for the DWD impersonation.
 
-### Cell 7 — OAuth flow with cached tokens (proposed)
+### Cell 7 — OAuth flow with cached tokens
 
 `npx -y @google/chrome-enterprise-premium-mcp@latest login` runs the consent
 flow against a Google-managed CEP OAuth client (public, loopback redirect URI)
@@ -160,5 +160,5 @@ client is allowlisted, leaving both env vars unset prints
 - **stdio + one user or service account** → Cell 1 (EUC) or Cell 2 (SA).
 - **HTTP + all clients share one identity** → Cell 3 (EUC) or Cell 4 (SA).
 - **HTTP + per-client Google access tokens** → Cell 5.
-- **HTTP + per-user identity (Gemini CLI / Enterprise)** → Cell 6 once it ships; Cell 5 until then.
-- **stdio or HTTP + interactive consent, cached tokens** → Cell 7 once it ships.
+- **HTTP + per-user identity (Gemini CLI / Enterprise)** → Cell 6.
+- **stdio or HTTP + interactive consent, cached tokens** → Cell 7 (BYO available; managed client pending product).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -57,3 +57,11 @@ EXPERIMENT_DELETE_TOOL_ENABLED=true npm start
 
 See [`lib/util/feature_flags.js`](../lib/util/feature_flags.js) for the full
 list.
+
+## Which auth path should I use?
+
+- One developer on a workstation, stdio MCP client → cell 1 (`gcloud auth application-default login`).
+- Server-to-server automation with a service account → cell 2 (or cell 4 for HTTP), with domain-wide delegation in the Workspace Admin Console.
+- Cloud Run deployment with Gemini Enterprise → prefer OAuth over server-side SA + DWD impersonation. SA + DWD grants the server's service account broad domain-wide impersonation; OAuth is bounded to the consenting user and revocable. See the [ADK + OAuth + Gemini Enterprise reference](https://fmind.medium.com/powering-up-your-agent-in-production-with-adk-oauth-and-gemini-enterprise-a52b0716fcba). When OAuth is not viable (cross-org automation, headless contexts), fall back to cell 6 (server validates the OIDC ID token and impersonates via DWD; see [`docs/auth-cloud-run-and-gemini-enterprise.md`](auth-cloud-run-and-gemini-enterprise.md)).
+- Interactive developer who wants OAuth instead of `gcloud` → cell 7 (`mcp auth login`, once the managed client ships).
+- Bringing your own OAuth client → see [`docs/auth-bring-your-own-oauth-client.md`](auth-bring-your-own-oauth-client.md).

--- a/gemini-extension/README.md
+++ b/gemini-extension/README.md
@@ -24,5 +24,15 @@ commands) we want it to cite when answering CEP questions.
 
 The extension manifest at the repo root
 ([`gemini-extension.json`](../gemini-extension.json)) points at this
-file, declares the OAuth scopes the agent requests on first run, and
-tells Gemini CLI to launch `mcp-server.js` as the MCP backend.
+file, declares the OAuth scopes for Gemini CLI's install-time consent
+flow, and tells Gemini CLI to launch `mcp-server.js` as the MCP backend.
+The scopes declared in `gemini-extension.json#oauth_scopes` drive the
+consent flow that Gemini CLI runs on the user's behalf when they install
+the extension. Gemini CLI requests those scopes; Google issues an access
+token covering them; Gemini CLI uses that token internally and may
+forward it to the MCP server in HTTP transport mode (see
+`docs/configuration.md#authentication` for the cells where that path is
+in scope). The MCP server itself does not read the `oauth_scopes` field
+at runtime; it requests scopes via `lib/constants.js#SCOPES` for ADC and
+via the bundled or BYO OAuth client config when the `mcp auth login`
+flow runs.

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -55,6 +55,11 @@ export const CEP_CONSTANTS = {
   SKU_ID: '1010400001',
 }
 
+// TODO(managed-oauth): replace with the allowlisted Google-managed OAuth client.
+export const MANAGED_OAUTH_CLIENT_PLACEHOLDER = 'TODO_MANAGED_OAUTH_CLIENT'
+export const MANAGED_OAUTH_CLIENT_ID = MANAGED_OAUTH_CLIENT_PLACEHOLDER
+export const MANAGED_OAUTH_CLIENT_SECRET = MANAGED_OAUTH_CLIENT_PLACEHOLDER
+
 export const DEFAULT_CONFIG = {
   REGION: 'europe-west1',
   MAX_RETRIES: 7,

--- a/lib/util/README.md
+++ b/lib/util/README.md
@@ -23,14 +23,31 @@ logging, retry, GCP detection, CEL validation, and feature flags.
 
 **Auth**
 
-- `auth.js` — `getAuthClient()` returns an authenticated client using
-  Application Default Credentials (ADC), or wraps a supplied bearer when
-  one is passed. Also exports `ensureADCCredentials()`.
-- `auth-error.js` — Generates descriptive error messages for auth failures
-  (missing credentials, insufficient scopes, quota project not set). Detects
-  `gcloud` installation and suggests fix commands.
-- `google-auth-provider.js` — Production auth provider class. Wraps
-  `getAuthClient` for use by real API clients.
+- `credential/` — three credential factories sharing one contract
+  (`probe()`, `getClient()`, `buildRemediation()`):
+  - `adc.js` — Application Default Credentials. The boot probe runs
+    tokeninfo against the access token, resolves the principal email,
+    and diffs granted scopes against `lib/constants.js#SCOPES`.
+  - `bearer.js` — wraps an `Authorization: Bearer …` token from an HTTP
+    request. Detects access tokens vs OIDC ID tokens; ID tokens go
+    through signature verification (jose, JWK set at `oauth2/v3/certs`),
+    audience validation, and DWD impersonation via google-auth-library's
+    `JWT` class.
+  - `oauth_flow.js` — managed OAuth flow. Loopback installed-app
+    consent, refresh + access tokens cached at
+    `~/.config/cep-mcp/tokens.json` mode `0600`. Reads
+    `CEP_OAUTH_CLIENT_ID` / `CEP_OAUTH_CLIENT_SECRET` for BYO;
+    falls back to the bundled Google-managed client.
+  - `cli_commands.js` — `runAuthStatusCommand`, `runLoginCommand`.
+  - `oauth_client_config.js`, `token_cache.js`, `loopback_server.js`,
+    `jwt_classify.js`, `jwk_cache.js` — supporting helpers.
+- `auth_messages.js` — banner-field renderers (`buildScopesField`,
+  `buildAuthRemediationLines`, `buildOAuthClientField`,
+  `buildQuotaProjectWarning`).
+- `auth-error.js` — Google API error → human-readable message.
+  Detects `gcloud` installation and suggests fix commands.
+- `google-auth-provider.js` — production auth provider used by the
+  real API clients.
 
 **API plumbing**
 

--- a/lib/util/README.md
+++ b/lib/util/README.md
@@ -34,9 +34,10 @@ logging, retry, GCP detection, CEL validation, and feature flags.
     audience validation, and DWD impersonation via google-auth-library's
     `JWT` class.
   - `oauth_flow.js` — managed OAuth flow. Loopback installed-app
-    consent, refresh + access tokens cached at
-    `~/.config/cep-mcp/tokens.json` mode `0600`. Reads
-    `CEP_OAUTH_CLIENT_ID` / `CEP_OAUTH_CLIENT_SECRET` for BYO;
+    consent. Access tokens are cached at
+    `~/.config/cep-mcp/tokens.json` mode `0600`; refresh tokens are
+    not persisted (consent uses an access-token-only grant).
+    Reads `CEP_OAUTH_CLIENT_ID` / `CEP_OAUTH_CLIENT_SECRET` for BYO;
     falls back to the bundled Google-managed client.
   - `cli_commands.js` — `runAuthStatusCommand`, `runLoginCommand`.
   - `oauth_client_config.js`, `token_cache.js`, `loopback_server.js`,

--- a/lib/util/auth_messages.js
+++ b/lib/util/auth_messages.js
@@ -182,6 +182,21 @@ export function buildQuotaProjectWarning(adc) {
 }
 
 /**
+ * Renders the banner field for the active OAuth client config.
+ * @param {?{clientId: string, clientSecret: string, source: 'managed'|'custom'}} config The resolved OAuth client config, or null when resolution failed.
+ * @returns {string} The banner field text.
+ */
+export function buildOAuthClientField(config) {
+  if (!config) {
+    return 'OAuth client: TODO (managed client not yet provisioned; set CEP_OAUTH_CLIENT_ID/SECRET to bring your own)'
+  }
+  if (config.source === 'managed') {
+    return 'OAuth client: Google-managed'
+  }
+  return `OAuth client: custom (${config.clientId.slice(0, 8)}...)`
+}
+
+/**
  * Collapses bash `\<LF>` line continuations and splits on whitespace, the
  * way the shell would tokenize an unquoted command. Useful for verifying
  * that a printed command parses into the intended argv.

--- a/lib/util/credential/cli_commands.js
+++ b/lib/util/credential/cli_commands.js
@@ -18,10 +18,14 @@ limitations under the License.
  * @file CLI subcommand implementations for the credential layer.
  */
 
+import path from 'node:path'
+import fs from 'node:fs/promises'
 import { adcCredential } from './adc.js'
 import { oauthFlowCredential } from './oauth_flow.js'
 import { buildScopesField } from '../auth_messages.js'
 import { SCOPES } from '../../constants.js'
+import { resolveOAuthClientConfig } from './oauth_client_config.js'
+import { TokenCache } from './token_cache.js'
 
 /**
  * Probes the ADC and OAuth-flow credential factories and prints a two-line
@@ -37,13 +41,55 @@ export async function runAuthStatusCommand() {
   console.log('  OAuth flow: ' + buildScopesField(oauthProbe, scopes))
 }
 
+const NOTICE_LINES = [
+  'Custom OAuth client detected. Verify the following before proceeding:',
+  '  - Redirect URI: http://127.0.0.1 (and optionally http://localhost) is registered on the client.',
+  '  - Scopes: every entry from lib/constants.js#SCOPES is granted on the consent screen.',
+  '  - Brand verification: required for non-internal users on Workspace-restricted scopes (Admin SDK Directory and Reports).',
+  'See docs/auth-bring-your-own-oauth-client.md for the full setup.',
+]
+
+/**
+ * Prints a one-time notice if using a custom OAuth client and the marker file
+ * does not exist. Creates the marker file after printing.
+ * @param {object} [opts] Injection points for testability.
+ * @param {string} [opts.noticePath] Path to the marker file; defaults to byo-notice.shown in the cache dir.
+ * @param {(env?: object) => ReturnType<typeof resolveOAuthClientConfig>} [opts.configResolver]
+ * Resolves OAuth client config; defaults to resolveOAuthClientConfig.
+ * @returns {Promise<void>}
+ * @private
+ */
+async function maybePrintCustomClientNotice({ noticePath, configResolver = resolveOAuthClientConfig } = {}) {
+  const config = configResolver()
+  if (config.source !== 'custom') {
+    return
+  }
+  const markerPath = noticePath || path.join(path.dirname(TokenCache.defaultPath()), 'byo-notice.shown')
+  try {
+    await fs.access(markerPath)
+    return
+  } catch {
+    // missing — show notice
+  }
+  for (const line of NOTICE_LINES) {
+    console.log(line)
+  }
+  console.log()
+  await fs.mkdir(path.dirname(markerPath), { recursive: true })
+  await fs.writeFile(markerPath, new Date().toISOString())
+}
+
 /**
  * Runs the managed-OAuth login flow and prints a one-line success message.
+ * When using a custom OAuth client, prints a one-time notice on the first run.
  * @param {object} [opts] Injection points for testability.
  * @param {() => ReturnType<typeof oauthFlowCredential>} [opts.credentialFactory] Factory for the OAuth credential; defaults to oauthFlowCredential.
+ * @param {string} [opts.noticePath] Path to the BYO-notice marker file for testing.
+ * @param {(env?: object) => ReturnType<typeof resolveOAuthClientConfig>} [opts.configResolver] Resolves OAuth client config; defaults to resolveOAuthClientConfig.
  * @returns {Promise<void>}
  */
-export async function runLoginCommand({ credentialFactory = oauthFlowCredential } = {}) {
+export async function runLoginCommand({ credentialFactory = oauthFlowCredential, noticePath, configResolver } = {}) {
+  await maybePrintCustomClientNotice({ noticePath, configResolver })
   const cred = credentialFactory()
   console.log('Opening browser for consent...')
   await cred.runLoginFlow()

--- a/lib/util/credential/cli_commands.js
+++ b/lib/util/credential/cli_commands.js
@@ -1,0 +1,51 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file CLI subcommand implementations for the credential layer.
+ */
+
+import { adcCredential } from './adc.js'
+import { oauthFlowCredential } from './oauth_flow.js'
+import { buildScopesField } from '../auth_messages.js'
+import { SCOPES } from '../../constants.js'
+
+/**
+ * Probes the ADC and OAuth-flow credential factories and prints a two-line
+ * status report. Exits 0 in all cases — a non-OK probe is informational.
+ * @returns {Promise<void>}
+ */
+export async function runAuthStatusCommand() {
+  const scopes = Object.values(SCOPES)
+  const adcProbe = await adcCredential().probe()
+  const oauthProbe = await oauthFlowCredential().probe()
+  console.log('Auth status:')
+  console.log('  ADC:        ' + buildScopesField(adcProbe, scopes))
+  console.log('  OAuth flow: ' + buildScopesField(oauthProbe, scopes))
+}
+
+/**
+ * Runs the managed-OAuth login flow and prints a one-line success message.
+ * @param {object} [opts] Injection points for testability.
+ * @param {() => ReturnType<typeof oauthFlowCredential>} [opts.credentialFactory] Factory for the OAuth credential; defaults to oauthFlowCredential.
+ * @returns {Promise<void>}
+ */
+export async function runLoginCommand({ credentialFactory = oauthFlowCredential } = {}) {
+  const cred = credentialFactory()
+  console.log('Opening browser for consent...')
+  await cred.runLoginFlow()
+  console.log('Tokens cached. Run mcp auth-status to verify.')
+}

--- a/lib/util/credential/oauth_client_config.js
+++ b/lib/util/credential/oauth_client_config.js
@@ -1,0 +1,80 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file Resolves the OAuth client config (client id + secret) for the managed
+ * OAuth flow. Either both env-var overrides are set, or neither is, with the
+ * bundled Google-managed values used as the default.
+ */
+
+import {
+  MANAGED_OAUTH_CLIENT_ID,
+  MANAGED_OAUTH_CLIENT_SECRET,
+  MANAGED_OAUTH_CLIENT_PLACEHOLDER,
+} from '../../constants.js'
+
+/**
+ * @typedef {object} OAuthClientConfig
+ * @property {string} clientId The OAuth client ID.
+ * @property {string} clientSecret The OAuth client secret.
+ * @property {'managed'|'custom'} source The source of the configuration ('managed' or 'custom').
+ */
+
+/**
+ * True when MANAGED_OAUTH_CLIENT_ID/SECRET still hold the TODO placeholder
+ * value. The managed flow cannot run until both are replaced with the real
+ * Google-managed client credentials.
+ * @returns {boolean} Whether the managed client is unprovisioned.
+ */
+export function managedClientIsPlaceholder() {
+  return (
+    MANAGED_OAUTH_CLIENT_ID === MANAGED_OAUTH_CLIENT_PLACEHOLDER ||
+    MANAGED_OAUTH_CLIENT_SECRET === MANAGED_OAUTH_CLIENT_PLACEHOLDER
+  )
+}
+
+/**
+ * Resolves OAuth client configuration from environment variables or bundled defaults.
+ * @param {object} [env] Environment variables object. Defaults to process.env.
+ * @returns {OAuthClientConfig} OAuth client configuration object.
+ * @throws {Error} When exactly one of the two env vars is set, or when the bundled managed client is still a TODO placeholder and no custom override is provided.
+ */
+export function resolveOAuthClientConfig(env = process.env) {
+  const id = env.CEP_OAUTH_CLIENT_ID
+  const secret = env.CEP_OAUTH_CLIENT_SECRET
+  const idSet = typeof id === 'string' && id.length > 0
+  const secretSet = typeof secret === 'string' && secret.length > 0
+  if (idSet !== secretSet) {
+    throw new Error(
+      'Set both CEP_OAUTH_CLIENT_ID and CEP_OAUTH_CLIENT_SECRET, or unset both to use the bundled Google-managed client.',
+    )
+  }
+  if (idSet && secretSet) {
+    return { clientId: id, clientSecret: secret, source: 'custom' }
+  }
+  if (managedClientIsPlaceholder()) {
+    throw new Error(
+      'Managed OAuth client is not yet provisioned. ' +
+        'Set CEP_OAUTH_CLIENT_ID and CEP_OAUTH_CLIENT_SECRET to bring your own OAuth client, ' +
+        'or wait until the bundled managed client is allowlisted for the scopes in lib/constants.js#SCOPES.',
+    )
+  }
+  return {
+    clientId: MANAGED_OAUTH_CLIENT_ID,
+    clientSecret: MANAGED_OAUTH_CLIENT_SECRET,
+    source: 'managed',
+  }
+}

--- a/lib/util/credential/oauth_flow.js
+++ b/lib/util/credential/oauth_flow.js
@@ -22,7 +22,12 @@ import { spawn } from 'node:child_process'
 import { OAuth2Client } from 'google-auth-library'
 import { TokenCache } from './token_cache.js'
 import { startLoopbackServer } from './loopback_server.js'
-import { SCOPES } from '../../constants.js'
+import {
+  SCOPES,
+  MANAGED_OAUTH_CLIENT_ID,
+  MANAGED_OAUTH_CLIENT_SECRET,
+  MANAGED_OAUTH_CLIENT_PLACEHOLDER,
+} from '../../constants.js'
 
 /**
  * Opens the given URL in the user's default browser. Respects BROWSER env var.
@@ -89,8 +94,8 @@ function mapOAuthError(err, clientId) {
 /**
  * Creates a credential object backed by the managed OAuth flow token cache.
  * @param {object} [opts] Configuration options.
- * @param {string} [opts.clientId] OAuth client id; defaults to CEP_OAUTH_CLIENT_ID env var. The bundled managed client default lands in the BYO override sub-issue.
- * @param {string} [opts.clientSecret] OAuth client secret; defaults to CEP_OAUTH_CLIENT_SECRET env var.
+ * @param {string} [opts.clientId] OAuth client id; defaults to env var or bundled managed client.
+ * @param {string} [opts.clientSecret] OAuth client secret.
  * @param {string} [opts.cachePath] Token cache path; defaults to TokenCache.defaultPath().
  * @param {string[]} [opts.requiredScopes] The scope set the probe checks against; defaults to Object.values(SCOPES).
  * @param {string} [opts.authUrl] Override for the OAuth authorization base URL. Defaults to the Google endpoint.
@@ -98,8 +103,8 @@ function mapOAuthError(err, clientId) {
  * @returns {import('./index.js').Credential & {permissionsWarning?: boolean}} The credential object.
  */
 export function oauthFlowCredential({
-  clientId = process.env.CEP_OAUTH_CLIENT_ID,
-  clientSecret = process.env.CEP_OAUTH_CLIENT_SECRET,
+  clientId = process.env.CEP_OAUTH_CLIENT_ID || MANAGED_OAUTH_CLIENT_ID,
+  clientSecret = process.env.CEP_OAUTH_CLIENT_SECRET || MANAGED_OAUTH_CLIENT_SECRET,
   cachePath = TokenCache.defaultPath(),
   requiredScopes = Object.values(SCOPES),
   authUrl,
@@ -133,7 +138,7 @@ export function oauthFlowCredential({
           ok: false,
           source: 'oauth-flow',
           principal,
-          credentialType: 'custom',
+          credentialType: clientId === MANAGED_OAUTH_CLIENT_ID ? 'managed' : 'custom',
           scopesKnown: true,
           missingScopes: missing,
           expiry,
@@ -143,7 +148,7 @@ export function oauthFlowCredential({
         ok: missing.length === 0,
         source: 'oauth-flow',
         principal,
-        credentialType: 'custom',
+        credentialType: clientId === MANAGED_OAUTH_CLIENT_ID ? 'managed' : 'custom',
         scopesKnown: true,
         missingScopes: missing,
         expiry,
@@ -170,7 +175,8 @@ export function oauthFlowCredential({
       }
       if (probe.missingScopes.length > 0) {
         return [
-          `Cached OAuth tokens do not cover ${probe.missingScopes.length} required scope(s).`,
+          `Cached OAuth tokens do not cover ${probe.missingScopes.length} required scope(s):`,
+          ...probe.missingScopes.map(s => `  - ${s}`),
           'Re-run mcp auth login to re-consent with the full scope set.',
         ]
       }
@@ -187,6 +193,13 @@ export function oauthFlowCredential({
      * @returns {Promise<object>} The token object returned by the code exchange.
      */
     async runLoginFlow({ openBrowser = defaultOpenBrowser, createOAuth2Client = cfg => new OAuth2Client(cfg) } = {}) {
+      if (clientId === MANAGED_OAUTH_CLIENT_PLACEHOLDER || clientSecret === MANAGED_OAUTH_CLIENT_PLACEHOLDER) {
+        throw new Error(
+          'Managed OAuth client is not yet provisioned. ' +
+            'Set CEP_OAUTH_CLIENT_ID and CEP_OAUTH_CLIENT_SECRET to bring your own OAuth client, ' +
+            'or wait until the bundled managed client is allowlisted for the scopes in lib/constants.js#SCOPES.',
+        )
+      }
       const server = await startLoopbackServer()
       try {
         const endpoints = {}

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -42,10 +42,16 @@ import { checkGCP } from './lib/util/gcp.js'
 import { featureFlags, FLAGS } from './lib/util/feature_flags.js'
 import { logger } from './lib/util/logger.js'
 import { printBanner, dim } from './lib/util/banner.js'
-import { buildScopesField, buildAuthRemediationLines, buildQuotaProjectWarning } from './lib/util/auth_messages.js'
+import {
+  buildScopesField,
+  buildAuthRemediationLines,
+  buildQuotaProjectWarning,
+  buildOAuthClientField,
+} from './lib/util/auth_messages.js'
 import { TAGS, SCOPES } from './lib/constants.js'
 import { adcCredential } from './lib/util/credential/adc.js'
 import { oauthFlowCredential } from './lib/util/credential/oauth_flow.js'
+import { resolveOAuthClientConfig } from './lib/util/credential/oauth_client_config.js'
 
 // Import Real Clients
 import { RealAdminSdkClient } from './lib/api/real_admin_sdk_client.js'
@@ -201,12 +207,20 @@ export async function runServer() {
       logger.warn(`${TAGS.MCP} OAuth-flow probe skipped: ${err.message}`)
     }
 
+    let oauthClientConfig = null
+    try {
+      oauthClientConfig = resolveOAuthClientConfig()
+    } catch (err) {
+      logger.warn(`${TAGS.MCP} OAuth client config unavailable: ${err.message}`)
+    }
+
     printBanner({
       transport: isStdio ? 'Stdio' : ['SSE/HTTP', `(Port: ${process.env.PORT || '0'})`],
       auth: isStdio ? ['None', '(Local channel)'] : ['None', '(Unauthenticated)'],
       apiCreds: adc.valid ? ['ADC', adc.email ? `(${adc.email})` : '(detected)'] : ['ADC', '(not configured)'],
       scopes: buildScopesField(adc, requiredScopes),
       oauthFlowScopes: oauthProbe ? buildScopesField(oauthProbe, requiredScopes) : '⚪ OAuth flow: probe unavailable',
+      oauthClient: buildOAuthClientField(oauthClientConfig),
       dataAccess: process.env.GOOGLE_API_ROOT_URL ? 'Fake' : 'Production',
       knowledge: ['lib/knowledge', `(${articleCount} articles)`],
     })

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /*
 Copyright 2026 Google LLC
 
@@ -142,7 +141,7 @@ async function getServer(gcpInfo, sharedSessionState) {
 /**
  * Starts the MCP server.
  */
-async function main() {
+export async function runServer() {
   try {
     const gcpInfo = await checkGCP()
     const isStdio = shouldStartStdio(gcpInfo)
@@ -188,9 +187,8 @@ async function main() {
       quotaProject: process.env.GOOGLE_CLOUD_QUOTA_PROJECT || null,
     }
 
-    // OAuth-flow probe runs alongside the ADC probe. A missing cache file
-    // returns immediately; a 2-second timeout caps the network worst case so
-    // the boot does not block.
+    // OAuth-flow probe runs concurrently. A missing cache file returns
+    // immediately; the boot does not block on network calls.
     let oauthProbe = null
     try {
       oauthProbe = await Promise.race([
@@ -351,4 +349,6 @@ const shutdown = async () => {
 process.on('SIGINT', shutdown)
 process.on('SIGTERM', shutdown)
 
-main()
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runServer()
+}

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
   "type": "module",
   "main": "mcp-server.js",
   "bin": {
-    "chrome-enterprise-premium-mcp": "mcp-server.js"
+    "chrome-enterprise-premium-mcp": "bin/cli.js"
   },
   "scripts": {
+    "audit:scopes": "node scripts/audit-scopes.js",
     "eval": "CEP_BACKEND=fake node test/evals/run.js",
     "eval:agentic": "CEP_BACKEND=fake node test/evals/run.js --category inspection,troubleshooting,mutation,discovery,connectors",
     "eval:full": "CEP_BACKEND=fake node test/evals/run.js --runs 3 --output results/eval-full.md",

--- a/test/local/auth_messages.test.js
+++ b/test/local/auth_messages.test.js
@@ -20,6 +20,7 @@ import {
   buildScopesField,
   buildAuthRemediationLines,
   buildQuotaProjectWarning,
+  buildOAuthClientField,
   shellTokenize,
 } from '../../lib/util/auth_messages.js'
 import { SCOPES } from '../../lib/constants.js'
@@ -343,6 +344,32 @@ describe('buildAuthRemediationLines', () => {
         `scope "${scope}" must be a full googleapis.com/auth/ URL; short-form scopes trigger gcloud's "Scope has changed" abort`,
       )
     }
+  })
+})
+
+describe('buildOAuthClientField', () => {
+  test('When source is managed, then it returns "OAuth client: Google-managed"', () => {
+    assert.equal(
+      buildOAuthClientField({ clientId: 'a', clientSecret: 'b', source: 'managed' }),
+      'OAuth client: Google-managed',
+    )
+  })
+  test('When source is custom, then it returns "OAuth client: custom (<first 8 chars>...)"', () => {
+    assert.equal(
+      buildOAuthClientField({ clientId: '1234567890abcdef', clientSecret: 'b', source: 'custom' }),
+      'OAuth client: custom (12345678...)',
+    )
+  })
+  test('When the custom client_id is shorter than 8 chars, then it returns the full id followed by ...', () => {
+    assert.equal(
+      buildOAuthClientField({ clientId: 'short', clientSecret: 'b', source: 'custom' }),
+      'OAuth client: custom (short...)',
+    )
+  })
+  test('When config is null, then it returns a TODO line flagging the unprovisioned managed client', () => {
+    const text = buildOAuthClientField(null)
+    assert.match(text, /TODO/)
+    assert.match(text, /CEP_OAUTH_CLIENT_ID/)
   })
 })
 

--- a/test/local/cli.test.js
+++ b/test/local/cli.test.js
@@ -48,6 +48,7 @@ describe('runLoginCommand', () => {
 
     const runLoginFlow = mock.fn(async () => {})
     const credentialFactory = mock.fn(() => ({ runLoginFlow }))
+    const configResolver = mock.fn(() => ({ source: 'managed', clientId: '', clientSecret: '' }))
 
     const lines = []
 
@@ -57,7 +58,7 @@ describe('runLoginCommand', () => {
       lines.push(msg)
     }
     try {
-      await runLoginCommand({ credentialFactory })
+      await runLoginCommand({ credentialFactory, configResolver })
     } finally {
       // eslint-disable-next-line require-atomic-updates
       console.log = origLog
@@ -67,5 +68,112 @@ describe('runLoginCommand', () => {
     assert.equal(runLoginFlow.mock.calls.length, 1)
     assert.ok(lines.some(l => /opening browser/i.test(l)))
     assert.ok(lines.some(l => /tokens cached/i.test(l)))
+  })
+})
+
+describe('runLoginCommand BYO notice', () => {
+  it('When source is managed, then no notice prints', async () => {
+    const { runLoginCommand } = await import('../../lib/util/credential/cli_commands.js')
+
+    const runLoginFlow = mock.fn(async () => {})
+    const credentialFactory = mock.fn(() => ({ runLoginFlow }))
+    const configResolver = mock.fn(() => ({
+      source: 'managed',
+      clientId: '',
+      clientSecret: '',
+    }))
+
+    const lines = []
+
+    const origLog = console.log
+
+    console.log = msg => {
+      lines.push(msg)
+    }
+    try {
+      await runLoginCommand({ credentialFactory, configResolver })
+    } finally {
+      // eslint-disable-next-line require-atomic-updates
+      console.log = origLog
+    }
+
+    const noticePresent = lines.some(l => /Custom OAuth client detected/i.test(l))
+    assert.equal(noticePresent, false)
+  })
+
+  it('When source is custom and no marker exists, then notice prints and marker is created', async () => {
+    const { runLoginCommand } = await import('../../lib/util/credential/cli_commands.js')
+    const fs = await import('node:fs/promises')
+    const os = await import('node:os')
+    const path = await import('node:path')
+
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cep-mcp-test-'))
+    const noticePath = path.join(tmpDir, 'byo-notice.shown')
+
+    const runLoginFlow = mock.fn(async () => {})
+    const credentialFactory = mock.fn(() => ({ runLoginFlow }))
+    const configResolver = mock.fn(() => ({
+      source: 'custom',
+      clientId: 'test',
+      clientSecret: 'test',
+    }))
+
+    const lines = []
+
+    const origLog = console.log
+
+    console.log = msg => {
+      lines.push(msg)
+    }
+    try {
+      await runLoginCommand({ credentialFactory, noticePath, configResolver })
+    } finally {
+      // eslint-disable-next-line require-atomic-updates
+      console.log = origLog
+      await fs.rm(tmpDir, { recursive: true, force: true })
+    }
+
+    const noticePresent = lines.some(l => /Custom OAuth client detected/i.test(l))
+    assert.equal(noticePresent, true)
+  })
+
+  it('When source is custom and marker exists, then notice does not print', async () => {
+    const { runLoginCommand } = await import('../../lib/util/credential/cli_commands.js')
+    const fs = await import('node:fs/promises')
+    const os = await import('node:os')
+    const path = await import('node:path')
+
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cep-mcp-test-'))
+    const noticePath = path.join(tmpDir, 'byo-notice.shown')
+
+    // Pre-create marker
+    await fs.mkdir(path.dirname(noticePath), { recursive: true })
+    await fs.writeFile(noticePath, new Date().toISOString())
+
+    const runLoginFlow = mock.fn(async () => {})
+    const credentialFactory = mock.fn(() => ({ runLoginFlow }))
+    const configResolver = mock.fn(() => ({
+      source: 'custom',
+      clientId: 'test',
+      clientSecret: 'test',
+    }))
+
+    const lines = []
+
+    const origLog = console.log
+
+    console.log = msg => {
+      lines.push(msg)
+    }
+    try {
+      await runLoginCommand({ credentialFactory, noticePath, configResolver })
+    } finally {
+      // eslint-disable-next-line require-atomic-updates
+      console.log = origLog
+      await fs.rm(tmpDir, { recursive: true, force: true })
+    }
+
+    const noticePresent = lines.some(l => /Custom OAuth client detected/i.test(l))
+    assert.equal(noticePresent, false)
   })
 })

--- a/test/local/cli.test.js
+++ b/test/local/cli.test.js
@@ -1,0 +1,71 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file Tests for bin/cli.js subcommand dispatch and runLoginCommand.
+ */
+
+import { describe, it, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const CLI = path.resolve(__dirname, '../../bin/cli.js')
+
+describe('bin/cli.js', () => {
+  describe('auth-status', () => {
+    it('When invoked with auth-status and ADC absent, then it prints the ADC line and an OAuth flow line', () => {
+      const result = spawnSync('node', [CLI, 'auth-status'], {
+        encoding: 'utf8',
+        env: { ...process.env, GOOGLE_APPLICATION_CREDENTIALS: '/nonexistent' },
+      })
+      assert.equal(result.status, 0)
+      assert.match(result.stdout, /Auth status:/)
+      assert.match(result.stdout, /ADC:/)
+      assert.match(result.stdout, /OAuth flow:/)
+    })
+  })
+})
+
+describe('runLoginCommand', () => {
+  it('When login is invoked and runLoginFlow succeeds, then it prints the cached message and exits 0', async () => {
+    const { runLoginCommand } = await import('../../lib/util/credential/cli_commands.js')
+
+    const runLoginFlow = mock.fn(async () => {})
+    const credentialFactory = mock.fn(() => ({ runLoginFlow }))
+
+    const lines = []
+
+    const origLog = console.log
+
+    console.log = msg => {
+      lines.push(msg)
+    }
+    try {
+      await runLoginCommand({ credentialFactory })
+    } finally {
+      // eslint-disable-next-line require-atomic-updates
+      console.log = origLog
+    }
+
+    assert.equal(credentialFactory.mock.calls.length, 1)
+    assert.equal(runLoginFlow.mock.calls.length, 1)
+    assert.ok(lines.some(l => /opening browser/i.test(l)))
+    assert.ok(lines.some(l => /tokens cached/i.test(l)))
+  })
+})

--- a/test/local/oauth-client-config.test.js
+++ b/test/local/oauth-client-config.test.js
@@ -1,0 +1,72 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { resolveOAuthClientConfig, managedClientIsPlaceholder } from '../../lib/util/credential/oauth_client_config.js'
+import {
+  MANAGED_OAUTH_CLIENT_ID,
+  MANAGED_OAUTH_CLIENT_SECRET,
+  MANAGED_OAUTH_CLIENT_PLACEHOLDER,
+} from '../../lib/constants.js'
+
+describe('managed OAuth client placeholder', () => {
+  it('Both managed constants reference the shared TODO placeholder', () => {
+    assert.equal(MANAGED_OAUTH_CLIENT_ID, MANAGED_OAUTH_CLIENT_PLACEHOLDER)
+    assert.equal(MANAGED_OAUTH_CLIENT_SECRET, MANAGED_OAUTH_CLIENT_PLACEHOLDER)
+  })
+
+  it('managedClientIsPlaceholder() returns true while the constants hold the TODO value', () => {
+    assert.equal(managedClientIsPlaceholder(), true)
+  })
+})
+
+describe('resolveOAuthClientConfig', () => {
+  it('When neither env var is set and managed client is unprovisioned, then it throws a clear TODO message', () => {
+    assert.throws(() => resolveOAuthClientConfig({}), /Managed OAuth client is not yet provisioned/)
+  })
+
+  it('When env vars are empty strings (set but blank), then it falls through to the unprovisioned-managed throw', () => {
+    assert.throws(
+      () => resolveOAuthClientConfig({ CEP_OAUTH_CLIENT_ID: '', CEP_OAUTH_CLIENT_SECRET: '' }),
+      /Managed OAuth client is not yet provisioned/,
+    )
+  })
+
+  it('When both env vars are set, then it returns the custom values with source:custom', () => {
+    const config = resolveOAuthClientConfig({
+      CEP_OAUTH_CLIENT_ID: 'custom-id-1234567890',
+      CEP_OAUTH_CLIENT_SECRET: 'custom-secret',
+    })
+    assert.equal(config.source, 'custom')
+    assert.equal(config.clientId, 'custom-id-1234567890')
+    assert.equal(config.clientSecret, 'custom-secret')
+  })
+
+  it('When only CEP_OAUTH_CLIENT_ID is set, then it throws the asymmetric-env message', () => {
+    assert.throws(
+      () => resolveOAuthClientConfig({ CEP_OAUTH_CLIENT_ID: 'x' }),
+      /Set both CEP_OAUTH_CLIENT_ID and CEP_OAUTH_CLIENT_SECRET/,
+    )
+  })
+
+  it('When only CEP_OAUTH_CLIENT_SECRET is set, then it throws the asymmetric-env message', () => {
+    assert.throws(
+      () => resolveOAuthClientConfig({ CEP_OAUTH_CLIENT_SECRET: 'x' }),
+      /Set both CEP_OAUTH_CLIENT_ID and CEP_OAUTH_CLIENT_SECRET/,
+    )
+  })
+})

--- a/test/local/smoke-test.js
+++ b/test/local/smoke-test.js
@@ -18,7 +18,7 @@ limitations under the License.
 
 process.env.GCP_STDIO ??= 'false'
 
-import { spawn } from 'child_process'
+import { spawn, spawnSync } from 'child_process'
 import http from 'http'
 import { logger } from '../../lib/util/logger.js'
 
@@ -29,13 +29,16 @@ import { logger } from '../../lib/util/logger.js'
 // so the grounding-content check would give a false negative over HTTP.
 await runStdioInitializeTest()
 
-const server = spawn('node', ['mcp-server.js'], {
+// Auth phase: confirm `node bin/cli.js auth-status` runs cleanly.
+runAuthStatusTest()
+
+const server = spawn('node', ['bin/cli.js'], {
   env: { ...process.env, GOOGLE_API_ROOT_URL: 'http://localhost:1234', PORT: '3000' },
 })
 
 async function runStdioInitializeTest() {
   return new Promise(resolve => {
-    const stdio = spawn('node', ['mcp-server.js'], {
+    const stdio = spawn('node', ['bin/cli.js'], {
       env: { ...process.env, GCP_STDIO: 'true', GOOGLE_API_ROOT_URL: 'http://localhost:1234' },
       stdio: ['pipe', 'pipe', 'inherit'],
     })
@@ -84,6 +87,30 @@ async function runStdioInitializeTest() {
     // Safety net — if no valid response within 5s, fail.
     setTimeout(() => finish(false), 5000)
   })
+}
+
+function runAuthStatusTest() {
+  logger.info('--- AUTH PHASE ---')
+  const result = spawnSync('node', ['bin/cli.js', 'auth-status'], {
+    encoding: 'utf8',
+    env: { ...process.env, GOOGLE_APPLICATION_CREDENTIALS: '/nonexistent', CEP_LOG_LEVEL: 'SILENT' },
+  })
+  if (result.status !== 0) {
+    logger.error('auth-status failed: exit', result.status, result.stderr)
+    process.exit(1)
+  }
+  for (const expected of ['Auth status:', 'ADC:', 'OAuth flow:']) {
+    if (!result.stdout.includes(expected)) {
+      logger.error(`auth-status output missing expected line: ${expected}`)
+      logger.error(`stdout was:\n${result.stdout}`)
+      process.exit(1)
+    }
+  }
+  if (result.stderr.includes('Error:') || result.stderr.includes('at ')) {
+    logger.error('auth-status stderr contains errors:', result.stderr)
+    process.exit(1)
+  }
+  logger.info('auth-status output OK')
 }
 
 function runToolTest() {


### PR DESCRIPTION
[abandoned]

Originally opened to land the documentation half of the auth-refactor: an Authentication section in `docs/configuration.md` covering the 7-cell auth matrix, a BYO OAuth client guide, a Cloud Run + Gemini Enterprise operator guide recommending OAuth over SA + DWD, an FAQ decision tree, and aligned scope descriptions across the repo. Addressed #93.

Abandoned because the underlying auth-refactor chain was reworked into the OAuth-only design tracked in #167.

Superseded by #173.