### PR TITLE
fix(test/scenarios): seed connectorPolicies and serviceUsage in eval base state

### DIFF
--- a/test/evals/scenarios/base-state.js
+++ b/test/evals/scenarios/base-state.js
@@ -379,5 +379,18 @@ export function getBaseState() {
         },
       },
     },
+
+    // Connector policies. Shape: customerId -> orgUnitId -> schema -> policy[]. Empty by default.
+    connectorPolicies: {},
+
+    // Service Usage state. All APIs ENABLED by default.
+    serviceUsage: {
+      'chromemanagement.googleapis.com': 'ENABLED',
+      'chromepolicy.googleapis.com': 'ENABLED',
+      'admin.googleapis.com': 'ENABLED',
+      'cloudidentity.googleapis.com': 'ENABLED',
+      'licensing.googleapis.com': 'ENABLED',
+      'serviceusage.googleapis.com': 'ENABLED',
+    },
   }
 }

--- a/test/evals/scenarios/base-state.js
+++ b/test/evals/scenarios/base-state.js
@@ -22,6 +22,8 @@ limitations under the License.
  * Scenario mutations in sibling files introduce targeted misconfigurations.
  */
 
+import { SERVICE_NAMES } from '../../../lib/constants.js'
+
 /**
  * Returns a fully-configured "healthy" CEP deployment state.
  * @returns {object} Complete fake server state object.
@@ -383,14 +385,9 @@ export function getBaseState() {
     // Connector policies. Shape: customerId -> orgUnitId -> schema -> policy[]. Empty by default.
     connectorPolicies: {},
 
-    // Service Usage state. All APIs ENABLED by default.
-    serviceUsage: {
-      'chromemanagement.googleapis.com': 'ENABLED',
-      'chromepolicy.googleapis.com': 'ENABLED',
-      'admin.googleapis.com': 'ENABLED',
-      'cloudidentity.googleapis.com': 'ENABLED',
-      'licensing.googleapis.com': 'ENABLED',
-      'serviceusage.googleapis.com': 'ENABLED',
-    },
+    // Service Usage state. Every API in SERVICE_NAMES starts ENABLED so
+    // adding a new service does not silently break eval scenarios that
+    // touch it.
+    serviceUsage: Object.fromEntries(Object.values(SERVICE_NAMES).map(name => [name, 'ENABLED'])),
   }
 }


### PR DESCRIPTION
**Closes:** #112

**Stack:**
- Base: `main`
- Independent of the auth-refactor chain (#103-#111).

**Bug:**
- `test/helpers/fake-api-server.js:439` throws `TypeError` because `state.connectorPolicies` is undefined when an eval scenario writes to it.
- Reproduces on `main` (commit `254c7eb`) and on `feat/auth-rebuild`. Identical stack trace. Pre-existing.

**Root cause:**
- `setState(applyScenario(...))` (in `test/evals/run.js:233`) replaces the fake-server state with `getBaseState()` from `test/evals/scenarios/base-state.js`.
- `getBaseState` had ten top-level keys but two were missing: `connectorPolicies` and `serviceUsage`.
- Any handler that read `state.connectorPolicies[...]` or `state.serviceUsage[...]` after a scenario-driven `setState` threw.

**Fix:**
- Adds `connectorPolicies: {}` and `serviceUsage: { ... 'ENABLED' for each tracked API }` to `getBaseState`.

**Diff stat:**

```
test/evals/scenarios/base-state.js | 13 insertions
1 file changed
```

**CI:**
- Lint: 0 errors
- Unit: pass

**Test plan:**
- [x] Lint clean
- [x] Unit pass

**Related:**
- Auth-refactor PR #101 Phase 0 triage logged this bug. Comment on #106 records it as 8 of 26 eval failures on the chain head.
