### PR TITLE
[abandoned] feat(credential): webOauthFlowCredential factory for Cloud Run + Gemini Enterprise

### DIFF
--- a/lib/util/credential/web_oauth_flow.js
+++ b/lib/util/credential/web_oauth_flow.js
@@ -1,0 +1,186 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file Web-redirect OAuth credential factory for the Cloud Run + Gemini
+ * Enterprise topology. The redirect URI defaults to the Vertex AI Agent
+ * Engine endpoint. The runtime drives the consent flow (no loopback server
+ * here); this factory exposes generateConsentUrl(state) and exchangeCode(code)
+ * so the runtime can fan the OAuth dance through its own UI.
+ *
+ * Token storage is pluggable. The default is in-memory (single-instance
+ * lifetime). A real deployment plugs in the runtime's session-scoped storage.
+ *
+ * Refresh-token policy matches oauth_flow.js: no refresh_token is persisted.
+ * On access-token expiry, the runtime re-consents.
+ *
+ * Reference pattern: ADK + OAuth + Gemini Enterprise
+ * (https://fmind.medium.com/powering-up-your-agent-in-production-with-adk-oauth-and-gemini-enterprise-a52b0716fcba).
+ */
+
+import { OAuth2Client } from 'google-auth-library'
+import { SCOPES_OAUTH } from '../../constants.js'
+
+export const VERTEX_AGENT_ENGINE_REDIRECT_URI = 'https://vertexaisearch.cloud.google.com/oauth-redirect'
+
+/**
+ * Returns a fresh in-memory token storage instance.
+ * @returns {{get: () => Promise<object|null>, set: (tokens: object) => Promise<void>, clear: () => Promise<void>}}
+ */
+export function inMemoryStorage() {
+  let value = null
+  return {
+    async get() {
+      return value
+    },
+    async set(tokens) {
+      value = tokens
+    },
+    async clear() {
+      value = null
+    },
+  }
+}
+
+/**
+ * Web-redirect OAuth credential factory. The runtime drives consent through
+ * its own UI; this factory just generates the consent URL, exchanges the
+ * returned code, and exposes the resulting auth client.
+ *
+ * @param {object} [opts] Configuration options.
+ * @param {string} [opts.clientId] OAuth client id; defaults to CEP_OAUTH_CLIENT_ID env var.
+ * @param {string} [opts.clientSecret] OAuth client secret; defaults to CEP_OAUTH_CLIENT_SECRET env var.
+ * @param {string} [opts.redirectUri] OAuth redirect URI. Defaults to the Vertex AI Agent Engine endpoint.
+ * @param {string[]} [opts.requiredScopes] Scope list; defaults to Object.values(SCOPES_OAUTH).
+ * @param {{get: () => Promise<object|null>, set: (tokens: object) => Promise<void>, clear: () => Promise<void>}} [opts.storage] Token storage. Defaults to a fresh in-memory instance.
+ * @param {(cfg: object) => OAuth2Client} [opts.createOAuth2Client] OAuth2Client factory; defaults to the real constructor. Tests stub it.
+ * @returns {object} The credential object plus generateConsentUrl and exchangeCode hooks.
+ */
+export function webOauthFlowCredential({
+  clientId = process.env.CEP_OAUTH_CLIENT_ID,
+  clientSecret = process.env.CEP_OAUTH_CLIENT_SECRET,
+  redirectUri = VERTEX_AGENT_ENGINE_REDIRECT_URI,
+  requiredScopes = Object.values(SCOPES_OAUTH),
+  storage = inMemoryStorage(),
+  createOAuth2Client = cfg => new OAuth2Client(cfg),
+} = {}) {
+  function newClient() {
+    return createOAuth2Client({ clientId, clientSecret, redirectUri })
+  }
+
+  return {
+    async probe() {
+      const tokens = await storage.get()
+      if (!tokens) {
+        return {
+          ok: false,
+          source: 'web-oauth-flow',
+          principal: null,
+          credentialType: 'custom',
+          scopesKnown: false,
+          missingScopes: requiredScopes,
+          expiry: null,
+        }
+      }
+      const granted = new Set((tokens.scope || '').split(' ').filter(Boolean))
+      const missing = requiredScopes.filter(s => !granted.has(s))
+      const expiry = tokens.expiry_date ? new Date(tokens.expiry_date) : null
+      const isExpired = expiry && expiry.getTime() < Date.now()
+      if (isExpired) {
+        return {
+          ok: false,
+          source: 'web-oauth-flow',
+          principal: null,
+          credentialType: 'custom',
+          scopesKnown: true,
+          missingScopes: missing,
+          expiry,
+        }
+      }
+      return {
+        ok: missing.length === 0,
+        source: 'web-oauth-flow',
+        principal: null,
+        credentialType: 'custom',
+        scopesKnown: true,
+        missingScopes: missing,
+        expiry,
+      }
+    },
+
+    async getClient() {
+      const tokens = await storage.get()
+      if (!tokens) {
+        throw new Error('No web-OAuth tokens in storage. Runtime must complete consent first.')
+      }
+      const client = newClient()
+      client.setCredentials(tokens)
+      return client
+    },
+
+    buildRemediation(probe) {
+      if (!probe || probe.ok) return null
+      if (!probe.scopesKnown && probe.missingScopes.length === requiredScopes.length) {
+        return ['Runtime has not completed consent. Direct the user through the consent flow.']
+      }
+      if (probe.missingScopes.length > 0) {
+        return [
+          `Stored tokens do not cover ${probe.missingScopes.length} required scope(s).`,
+          'Re-consent with the full scope set.',
+        ]
+      }
+      return ['Stored access token has expired. Re-consent.']
+    },
+
+    /**
+     * Generates the OAuth consent URL for the runtime to redirect the user to.
+     * @param {string} [state] Opaque state value the runtime correlates with the redirect.
+     * @returns {string} The consent URL.
+     */
+    generateConsentUrl(state) {
+      const client = newClient()
+      return client.generateAuthUrl({
+        access_type: 'online',
+        prompt: 'consent',
+        scope: requiredScopes,
+        ...(state ? { state } : {}),
+      })
+    },
+
+    /**
+     * Exchanges an authorization code (returned to the redirect URI by Google)
+     * for tokens, strips refresh_token (policy: no refresh persistence),
+     * stores the rest, and returns the access-token shape.
+     * @param {string} code Authorization code from the redirect.
+     * @returns {Promise<object>} The token object minus refresh_token.
+     */
+    async exchangeCode(code) {
+      const client = newClient()
+      const { tokens } = await client.getToken(code)
+      const { refresh_token: _drop, ...persisted } = tokens
+      await storage.set(persisted)
+      return persisted
+    },
+
+    /**
+     * Clears stored tokens (e.g. on session end or revocation).
+     * @returns {Promise<void>} Resolves when the storage is cleared.
+     */
+    async clear() {
+      await storage.clear()
+    },
+  }
+}

--- a/test/local/credential-web-oauth-flow.test.js
+++ b/test/local/credential-web-oauth-flow.test.js
@@ -1,0 +1,158 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  webOauthFlowCredential,
+  inMemoryStorage,
+  VERTEX_AGENT_ENGINE_REDIRECT_URI,
+} from '../../lib/util/credential/web_oauth_flow.js'
+
+/**
+ * Builds a stub OAuth2Client whose generateAuthUrl returns a recordable URL
+ * and whose getToken returns the supplied tokens.
+ * @param {object} [opts] Stub options.
+ * @param {object} [opts.tokenResponse] Token object getToken returns.
+ * @returns {{factory: function, calls: object}} Stub factory and calls record.
+ */
+function stubOAuth2ClientFactory({ tokenResponse } = {}) {
+  const calls = { ctor: [], generateAuthUrl: [], getToken: [], setCredentials: [] }
+  function factory(cfg) {
+    calls.ctor.push(cfg)
+    return {
+      generateAuthUrl(params) {
+        calls.generateAuthUrl.push(params)
+        const u = new URL('https://accounts.google.com/o/oauth2/v2/auth')
+        u.searchParams.set('client_id', cfg.clientId || '')
+        u.searchParams.set('redirect_uri', cfg.redirectUri || '')
+        u.searchParams.set('scope', (params.scope || []).join(' '))
+        if (params.state) u.searchParams.set('state', params.state)
+        return u.toString()
+      },
+      async getToken(code) {
+        calls.getToken.push(code)
+        return { tokens: tokenResponse || { access_token: 'a', expiry_date: Date.now() + 3600_000, scope: 'x' } }
+      },
+      setCredentials(t) {
+        calls.setCredentials.push(t)
+      },
+    }
+  }
+  return { factory, calls }
+}
+
+describe('webOauthFlowCredential', () => {
+  it('When no tokens are stored, then probe returns ok:false with scopesKnown:false', async () => {
+    const cred = webOauthFlowCredential({ clientId: 'c', clientSecret: 's' })
+    const probe = await cred.probe()
+    assert.equal(probe.ok, false)
+    assert.equal(probe.scopesKnown, false)
+    assert.equal(probe.source, 'web-oauth-flow')
+  })
+
+  it('When tokens are stored with all required scopes and not expired, then probe returns ok:true', async () => {
+    const storage = inMemoryStorage()
+    await storage.set({ access_token: 'a', expiry_date: Date.now() + 3600_000, scope: 'a b c' })
+    const cred = webOauthFlowCredential({ clientId: 'c', clientSecret: 's', requiredScopes: ['a', 'b'], storage })
+    const probe = await cred.probe()
+    assert.equal(probe.ok, true)
+    assert.equal(probe.scopesKnown, true)
+    assert.equal(probe.missingScopes.length, 0)
+  })
+
+  it('When tokens are stored but expired, then probe returns ok:false with the expiry', async () => {
+    const storage = inMemoryStorage()
+    await storage.set({ access_token: 'a', expiry_date: Date.now() - 1000, scope: 'a b' })
+    const cred = webOauthFlowCredential({ clientId: 'c', clientSecret: 's', requiredScopes: ['a', 'b'], storage })
+    const probe = await cred.probe()
+    assert.equal(probe.ok, false)
+    assert.ok(probe.expiry instanceof Date)
+  })
+
+  it('When generateConsentUrl is called, then it produces a URL with the Vertex AI redirect by default', () => {
+    const { factory, calls } = stubOAuth2ClientFactory()
+    const cred = webOauthFlowCredential({
+      clientId: 'c',
+      clientSecret: 's',
+      requiredScopes: ['a', 'b'],
+      createOAuth2Client: factory,
+    })
+    const url = cred.generateConsentUrl('s123')
+    assert.equal(calls.ctor[0].redirectUri, VERTEX_AGENT_ENGINE_REDIRECT_URI)
+    assert.deepEqual(calls.generateAuthUrl[0].scope, ['a', 'b'])
+    assert.equal(calls.generateAuthUrl[0].access_type, 'online')
+    assert.equal(calls.generateAuthUrl[0].state, 's123')
+    assert.ok(url.includes('https://accounts.google.com/'))
+  })
+
+  it('When a custom redirectUri is passed, then generateConsentUrl uses it', () => {
+    const { factory, calls } = stubOAuth2ClientFactory()
+    const cred = webOauthFlowCredential({
+      clientId: 'c',
+      clientSecret: 's',
+      redirectUri: 'https://my-runtime.example/oauth-callback',
+      requiredScopes: ['a'],
+      createOAuth2Client: factory,
+    })
+    cred.generateConsentUrl()
+    assert.equal(calls.ctor[0].redirectUri, 'https://my-runtime.example/oauth-callback')
+  })
+
+  it('When exchangeCode is called, then it strips refresh_token and stores the rest', async () => {
+    const storage = inMemoryStorage()
+    const { factory } = stubOAuth2ClientFactory({
+      tokenResponse: {
+        access_token: 'access-1',
+        refresh_token: 'must-not-persist',
+        expiry_date: 12345,
+        scope: 'a b',
+      },
+    })
+    const cred = webOauthFlowCredential({
+      clientId: 'c',
+      clientSecret: 's',
+      storage,
+      createOAuth2Client: factory,
+    })
+    const result = await cred.exchangeCode('auth-code-xyz')
+    assert.equal(result.access_token, 'access-1')
+    assert.equal(result.refresh_token, undefined, 'refresh_token must be stripped from the return value')
+    const stored = await storage.get()
+    assert.equal(stored.refresh_token, undefined, 'refresh_token must not be persisted')
+    assert.equal(stored.access_token, 'access-1')
+  })
+
+  it('When tokens are stored, then getClient returns an OAuth2Client with credentials set', async () => {
+    const storage = inMemoryStorage()
+    await storage.set({ access_token: 'a', expiry_date: Date.now() + 3600_000, scope: 'x' })
+    const { factory, calls } = stubOAuth2ClientFactory()
+    const cred = webOauthFlowCredential({
+      clientId: 'c',
+      clientSecret: 's',
+      storage,
+      createOAuth2Client: factory,
+    })
+    await cred.getClient()
+    assert.equal(calls.setCredentials.length, 1)
+    assert.equal(calls.setCredentials[0].access_token, 'a')
+  })
+
+  it('When no tokens are stored and getClient is called, then it throws a clear error', async () => {
+    const cred = webOauthFlowCredential({ clientId: 'c', clientSecret: 's' })
+    await assert.rejects(() => cred.getClient(), err => err.message.includes('No web-OAuth tokens'))
+  })
+})


### PR DESCRIPTION
[abandoned]

Originally opened to add a `webOauthFlowCredential` factory under `lib/util/credential/` for the Cloud Run + Gemini Enterprise topology, where the redirect URI is `https://vertexaisearch.cloud.google.com/oauth-redirect` and there is no local callback server. Addressed #114.

Abandoned because the auth-refactor chain it stacked on (#106, #107, #108) was abandoned. The OAuth-only auth path now lives in #171.

Superseded by #171.