### PR TITLE
chore: address recent Copilot AI findings and CodeQL prototype-pollution alerts

### DIFF
--- a/mcp-server.js
+++ b/mcp-server.js
@@ -375,17 +375,19 @@ async function main() {
     }
     console.log(dim(`Active Experiments: ${activeExps}`))
 
-    // Maintain session state globally for all server connections
-    const sharedSessionState = {
-      customerId: null,
-      cachedRootOrgUnitId: null,
-      pendingRule: null,
-      history: [],
-    }
-
     if (isStdio) {
+      // Stdio is single-process and single-tenant, so a process-lifetime
+      // sessionState is correct. HTTP mode does not reach this branch and
+      // does not see this object — its handlers create per-request state
+      // via createSessionState() in createMcpPostHandler / createSseHandler.
+      const stdioSessionState = {
+        customerId: null,
+        cachedRootOrgUnitId: null,
+        pendingRule: null,
+        history: [],
+      }
       const stdioTransport = new StdioServerTransport()
-      const server = await getServer(gcpInfo, sharedSessionState)
+      const server = await getServer(gcpInfo, stdioSessionState)
       await server.connect(stdioTransport)
       logger.info(`${TAGS.MCP} Chrome Enterprise Premium MCP server stdio transport connected`)
     } else {

--- a/test/helpers/fake-api-server.js
+++ b/test/helpers/fake-api-server.js
@@ -667,7 +667,7 @@ export function createFakeApp() {
       state.activities.push(...data.items)
     } else if (data.kind === 'licensing#licenseAssignment') {
       const customerId = state.defaultCustomerId
-      if (!isSafeKey(data.productId) || !isSafeKey(data.skuId)) {
+      if (!isSafeKey(customerId) || !isSafeKey(data.productId) || !isSafeKey(data.skuId)) {
         return
       }
       if (!state.licenses[customerId]) {
@@ -682,6 +682,9 @@ export function createFakeApp() {
       state.licenses[customerId][data.productId][data.skuId].push(data)
     } else if (data.kind === 'licensing#licenseAssignmentList') {
       const customerId = state.defaultCustomerId
+      if (!isSafeKey(customerId)) {
+        return
+      }
       state.licenses[customerId] = Object.create(null) // Clear existing
       data.items.forEach(item => {
         if (!isSafeKey(item.productId) || !isSafeKey(item.skuId)) {

--- a/test/local/helpers.test.js
+++ b/test/local/helpers.test.js
@@ -19,8 +19,6 @@ import assert from 'node:assert/strict'
 import esmock from 'esmock'
 import { logger, LogLevel } from '../../lib/util/logger.js'
 
-const LOG_LEVEL_OFF = 4
-
 describe('Helpers', () => {
   describe('callWithRetry', () => {
     let callWithRetry
@@ -71,7 +69,7 @@ describe('Helpers', () => {
     })
 
     test('When QUOTA_PROJECT_NOT_SET error occurs, then it throws a helpful message and does not retry', async () => {
-      logger.setLevel(LOG_LEVEL_OFF) // Suppress expected error logs
+      logger.setLevel(LogLevel.SILENT) // Suppress expected error logs
       try {
         let attempts = 0
         const quotaError = new Error(
@@ -99,7 +97,7 @@ describe('Helpers', () => {
     })
 
     test('When INSUFFICIENT_SCOPES error occurs, then it throws a helpful message and does not retry', async () => {
-      logger.setLevel(LOG_LEVEL_OFF) // Suppress expected error logs
+      logger.setLevel(LogLevel.SILENT) // Suppress expected error logs
       try {
         let attempts = 0
         const scopeError = new Error('Request had insufficient authentication scopes.')


### PR DESCRIPTION
Audited 12 Copilot AI findings (5 files) and 3 open CodeQL prototype-pollution alerts (#22, #23, #24). Most were noise; three were real and have one commit each.

## Real fixes (one commit each)

### 1. `mcp-server.js` — scope `sharedSessionState` to the stdio branch (commit `59dad8f`)

Copilot reported three findings claiming HTTP requests share a single `sharedSessionState`, allowing customerId data to leak between tenants. **The leak does not exist:** `sharedSessionState` was only ever passed to `getServer()` in the `if (isStdio)` branch. HTTP factories `createMcpPostHandler` (line 180) and `createSseHandler` (line 219) each call `createSessionState()` per request. But the variable was declared above the stdio/HTTP split with the comment `// Maintain session state globally for all server connections`, which read like the bug Copilot described. Move the declaration into the stdio branch, rename to `stdioSessionState`, and update the comment to state the actual invariant.

No behavior change. The cosmetic move forecloses the misreading.

### 2. `test/local/helpers.test.js` — drop `LOG_LEVEL_OFF` magic constant (commit `a26bf43`)

Replace `const LOG_LEVEL_OFF = 4` with direct use of `LogLevel.SILENT` (already imported from `../../lib/util/logger.js`). Copilot suggested `LogLevel.OFF`, which does not exist; the right constant is `SILENT`.

### 3. `test/helpers/fake-api-server.js` — guard `customerId` in licenses fixture merge (commit `ece3b95`)

The `licensing#licenseAssignment` and `licensing#licenseAssignmentList` paths in `mergeFixture` checked `productId` and `skuId` via `isSafeKey()` but not `customerId`. The connectorPolicies block (line 448) does check it; add the matching guard. Today `state.licenses` is a `nullProtoMap` so the alerts (#23 line 680, #24 line 694) are not exploitable, but the guard mirrors the documented pattern elsewhere in the file and hardens against future refactors.

## Dismissed as noise (no commit, with rationale)

| Finding | File | Why dismissed |
|---|---|---|
| 1.1 / 1.2 / 1.3 — sharedSessionState leak claims | `mcp-server.js` | The leak does not exist. See commit 1 above. The cosmetic refactor forecloses the misreading without changing behavior. |
| 2.1 — `SHARED_DIAGNOSTIC_RULES` needs JSDoc | `prompts/definitions/shared.js` | Optional documentation. The proposed JSDoc invents constraints not actually contracts in this codebase ("policy text, not end-user UI copy"). |
| 2.2 — escaped backticks → `${'`'}` | `prompts/definitions/shared.js` | Both forms produce identical Markdown output. The proposed change is more verbose, not clearer. |
| 3.1 — `mcpPrompt.messages` safety check | `test/evals/run.js` | Defensive coding inside an eval runner. The MCP SDK contract guarantees `messages[0].content.text`. If the SDK breaks, exploding is fine in test code. |
| 3.2 — duplicated priority filter | `test/evals/run.js` | Not duplicated. Line 117 parses the CLI argument; line 358 checks for the AI-summary trigger. Different operations. |
| 4.2 / 4.3 — `{ concurrency: false }` annotations | `test/local/helpers.test.js` | Node's `node --test` runs tests within a single file sequentially by default. The annotation is a no-op for the alleged race. Cross-file concurrency is real but not what this annotation fixes. |
| 5.1 / 5.2 — minimal mocks in state-isolation test | `test/unit/mcp-server-state-isolation.test.js` | The test's scope is verifying session-state isolation, not Express integration. Adding extensive mocks does not catch additional bugs in that scope. Intentional minimalism. |
| CodeQL #22 — prototype-polluting assignment, line 458 | `test/helpers/fake-api-server.js` | Already guarded by `isSafeKey(customerId)`, `isSafeKey(orgUnitId)`, `isSafeKey(schema)` at line 448. CodeQL does not recognize the `isSafeKey` helper as a sanitizer, so the alert persists despite the guard. Closing it without changing the analysis would require a suppression comment or a `Map`-based refactor; not pursued in this PR. |

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:unit` for `helpers.test.js` — 4/4 pass
- [x] `npm run test:integration:fake` — 11/11 pass (3 skipped, unrelated)