### PR TITLE
feat(scopes): split OAUTH_SCOPES; drop cloud-platform from OAuth-flow consent

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -48,6 +48,14 @@ export const SCOPES = {
 }
 
 /**
+ * Scope set requested by the OAuth-flow consent screen. Narrower than the ADC
+ * default: `cloud-platform` is the catch-all for `gcloud auth application-default
+ * login` users who already have it; OAuth callers ask for `service.management`
+ * instead, which is the only Service Usage scope this server actually needs.
+ */
+export const OAUTH_SCOPES = Object.values(SCOPES).filter(s => s !== SCOPES.CLOUD_PLATFORM)
+
+/**
  * Bundled managed OAuth client. The placeholder string ships in source until
  * Google provisions and allowlists the real client. Until then, set
  * CEP_OAUTH_CLIENT_ID and CEP_OAUTH_CLIENT_SECRET (BYO) for `mcp auth login`

--- a/lib/util/credential/oauth_flow.js
+++ b/lib/util/credential/oauth_flow.js
@@ -24,7 +24,7 @@ import { OAuth2Client } from 'google-auth-library'
 import { TokenCache } from './token_cache.js'
 import { startLoopbackServer } from './loopback_server.js'
 import {
-  SCOPES,
+  OAUTH_SCOPES,
   MANAGED_OAUTH_CLIENT_ID,
   MANAGED_OAUTH_CLIENT_SECRET,
   MANAGED_OAUTH_CLIENT_PLACEHOLDER,
@@ -142,7 +142,7 @@ function mapOAuthError(err, clientId) {
  * @param {string} [opts.clientId] OAuth client id; defaults to env var or bundled managed client.
  * @param {string} [opts.clientSecret] OAuth client secret.
  * @param {string} [opts.cachePath] Token cache path; defaults to TokenCache.defaultPath().
- * @param {string[]} [opts.requiredScopes] The scope set the probe checks against; defaults to Object.values(SCOPES).
+ * @param {string[]} [opts.requiredScopes] The scope set the probe checks against; defaults to OAUTH_SCOPES.
  * @param {string} [opts.authUrl] Override for the OAuth authorization base URL. Defaults to the Google endpoint.
  * @param {string} [opts.tokenUrl] Override for the OAuth token exchange URL. Defaults to the Google endpoint.
  * @returns {import('./index.js').Credential & {permissionsWarning?: boolean}} The credential object.
@@ -151,7 +151,7 @@ export function oauthFlowCredential({
   clientId = process.env.CEP_OAUTH_CLIENT_ID || MANAGED_OAUTH_CLIENT_ID,
   clientSecret = process.env.CEP_OAUTH_CLIENT_SECRET || MANAGED_OAUTH_CLIENT_SECRET,
   cachePath = TokenCache.defaultPath(),
-  requiredScopes = Object.values(SCOPES),
+  requiredScopes = OAUTH_SCOPES,
   authUrl,
   tokenUrl,
 } = {}) {


### PR DESCRIPTION
Splits the consent-screen scope set so OAuth-flow users only ask for what the server actually needs.

Stack: on top of #119. Refile target: closed #103.

## What changes

`lib/constants.js` adds `OAUTH_SCOPES` — the full `SCOPES` set minus `cloud-platform`. `oauthFlowCredential` now defaults `requiredScopes` to `OAUTH_SCOPES`. ADC's default is unchanged.

The asymmetry:

- **ADC** keeps `cloud-platform` (and the rest of `SCOPES`). `gcloud auth application-default login` users already have `cloud-platform` granted in their gcloud config; asking for it here avoids a re-prompt.
- **OAuth flow** drops `cloud-platform` and asks for `service.management` and `service.management.readonly` directly. Those are the only Service Usage scopes the server actually uses, so the consent screen no longer shows the broad "manage your data across all of Google Cloud" `cloud-platform` line.

At runtime both paths reach Service Usage the same way: a token with either `cloud-platform` or `service.management` is accepted by the API. Existing gcloud-ADC users are unaffected; new OAuth users see a narrower consent screen.

## Why

Per Shantanu on PR #101 (r3165167785) and PR #103 (r3166291034).

## Test plan

- [x] `npm run lint`: clean.
- [x] `node test/run-all.js`: 402/402 unit tests are green.
- [x] `node test/local/credential-oauth-flow.test.js`: 7/7. Coverage of the missing-scope branch is unchanged: that test has its own explicit `requiredScopes: [..., cloud-platform]`.