### PR TITLE
refactor: unify and centralize connector policy analysis logic

### DIFF
--- a/lib/util/connector_policy_helper.js
+++ b/lib/util/connector_policy_helper.js
@@ -49,20 +49,14 @@ export function humanize(val) {
  * Analyzes the health and protection state of a Chrome Enterprise connector policy.
  * @param {string} policyType - The enum key (e.g., 'ON_PRINT', 'ON_SECURITY_EVENT').
  * @param {Array<object>} resolvedPolicies - The raw resolved policies from the API.
- * @param {string} manualUpdateLink - Link to the Admin Console for manual configuration.
  * @returns {object} Analysis result containing isConfigured, isEnabled, and findings.
  */
-export function analyzeConnectorPolicy(policyType, resolvedPolicies, manualUpdateLink = '') {
+export function analyzeConnectorPolicy(policyType, resolvedPolicies) {
   if (!resolvedPolicies || resolvedPolicies.length === 0) {
     return {
       isConfigured: false,
       isEnabled: false,
-      findings: [
-        {
-          message: 'Connector is not enabled. You can enable it using the enable_chrome_enterprise_connectors tool.',
-          remediationType: 'tool',
-        },
-      ],
+      findings: [],
     }
   }
 
@@ -88,10 +82,6 @@ export function analyzeConnectorPolicy(policyType, resolvedPolicies, manualUpdat
 
       if (!eventCfg) {
         isEnabled = false
-        findings.push({
-          message: 'Connector is not enabled. You can enable it using the enable_chrome_enterprise_connectors tool.',
-          remediationType: 'tool',
-        })
       } else {
         let missingCoreEvents = []
         if (events.length > 0) {
@@ -103,7 +93,7 @@ export function analyzeConnectorPolicy(policyType, resolvedPolicies, manualUpdat
         if (missingCoreEvents.length > 0) {
           const mappedMissing = missingCoreEvents.map(e => EVENT_NAME_MAPPING[e] || e)
           findings.push({
-            message: `Missing core DLP events: ${mappedMissing.join(', ')}. Update settings manually at ${manualUpdateLink}`,
+            message: `Missing core DLP events: ${mappedMissing.join(', ')}`,
             remediationType: 'manual',
           })
         }
@@ -137,7 +127,7 @@ export function analyzeConnectorPolicy(policyType, resolvedPolicies, manualUpdat
       if (isCEP) {
         if (!cfg.delayDeliveryUntilVerdict && !cfg.delay_delivery_until_verdict) {
           findings.push({
-            message: `Delay enforcement is disabled. Users are unprotected during content analysis. Update settings manually at ${manualUpdateLink}`,
+            message: 'Delay enforcement is disabled. Users are unprotected during content analysis',
             remediationType: 'manual',
           })
         }
@@ -148,18 +138,18 @@ export function analyzeConnectorPolicy(policyType, resolvedPolicies, manualUpdat
           if (humanized === 'No') {
             if (patterns && patterns.length > 0) {
               findings.push({
-                message: `⚠️ ${type} Analysis is restricted. Scanning is ONLY enabled for specific URL patterns, which may leave your organization vulnerable. Update settings manually at ${manualUpdateLink}`,
+                message: `⚠️ ${type} Analysis is restricted. Scanning is ONLY enabled for specific URL patterns, which may leave your organization vulnerable`,
                 remediationType: 'manual',
               })
             } else {
               findings.push({
-                message: `⚠️ ${type} Analysis is restricted. Scanning is NOT enabled for all files, which may leave your organization vulnerable. Update settings manually at ${manualUpdateLink}`,
+                message: `⚠️ ${type} Analysis is restricted. Scanning is NOT enabled for all files, which may leave your organization vulnerable`,
                 remediationType: 'manual',
               })
             }
           } else if (patterns && patterns.length > 0) {
             findings.push({
-              message: `⚠️ ${type} Analysis is restricted. Scanning is DISABLED for specific URL patterns, which may leave your organization vulnerable. Update settings manually at ${manualUpdateLink}`,
+              message: `⚠️ ${type} Analysis is restricted. Scanning is DISABLED for specific URL patterns, which may leave your organization vulnerable`,
               remediationType: 'manual',
             })
           }
@@ -187,24 +177,20 @@ export function analyzeConnectorPolicy(policyType, resolvedPolicies, manualUpdat
         ) {
           if (cfg.malwareUrlPatterns?.length > 0 || cfg.sensitiveUrlPatterns?.length > 0) {
             findings.push({
-              message: `Security posture is limited due to URL allowlisting. Update settings manually at ${manualUpdateLink}`,
+              message: 'Security posture is limited due to URL allowlisting',
               remediationType: 'manual',
             })
           }
         }
       } else if (isNone) {
         isEnabled = false
-        findings.push({
-          message: 'Connector is not enabled. You can enable it using the enable_chrome_enterprise_connectors tool.',
-          remediationType: 'tool',
-        })
       } else {
         const is3p =
           cfg.serviceProvider === 'SERVICE_PROVIDER_SYMANTEC_ENDPOINT_DLP' ||
           cfg.serviceProvider === 'SERVICE_PROVIDER_TRELLIX'
         if (is3p) {
           findings.push({
-            message: `3rd party provider detected. Integrated CEP features may be bypassed. Update settings manually at ${manualUpdateLink}`,
+            message: '3rd party provider detected. Integrated CEP features may be bypassed',
             remediationType: 'manual',
           })
         }

--- a/lib/util/connector_policy_helper.js
+++ b/lib/util/connector_policy_helper.js
@@ -108,6 +108,10 @@ export function analyzeConnectorPolicy(policyType, resolvedPolicies) {
         checkEnabled === 'ENTERPRISE_REAL_TIME_URL_CHECK_MODE_ENUM_UNSPECIFIED'
       ) {
         isEnabled = false
+        findings.push({
+          message: 'Real-time URL check is explicitly disabled',
+          remediationType: 'manual',
+        })
       }
     } else {
       // Non-Reporting Connectors (Upload, Download, Paste, Print)
@@ -136,20 +140,15 @@ export function analyzeConnectorPolicy(policyType, resolvedPolicies) {
         const checkGaps = (type, onByDefault, patterns) => {
           const humanized = humanize(onByDefault)
           if (humanized === 'No') {
-            if (patterns && patterns.length > 0) {
-              findings.push({
-                message: `⚠️ ${type} Analysis is restricted. Scanning is ONLY enabled for specific URL patterns, which may leave your organization vulnerable`,
-                remediationType: 'manual',
-              })
-            } else {
-              findings.push({
-                message: `⚠️ ${type} Analysis is restricted. Scanning is NOT enabled for all files, which may leave your organization vulnerable`,
-                remediationType: 'manual',
-              })
-            }
+            const patternMsg =
+              patterns && patterns.length > 0 ? 'ONLY enabled for specific URL patterns' : 'NOT enabled for all files'
+            findings.push({
+              message: `⚠️ ${type} Analysis is restricted. Scanning is ${patternMsg}`,
+              remediationType: 'manual',
+            })
           } else if (patterns && patterns.length > 0) {
             findings.push({
-              message: `⚠️ ${type} Analysis is restricted. Scanning is DISABLED for specific URL patterns, which may leave your organization vulnerable`,
+              message: `⚠️ ${type} Analysis is restricted. Scanning is DISABLED for specific URL patterns`,
               remediationType: 'manual',
             })
           }

--- a/lib/util/connector_policy_helper.js
+++ b/lib/util/connector_policy_helper.js
@@ -50,21 +50,26 @@ export function humanize(val) {
  * @param {string} policyType - The enum key (e.g., 'ON_PRINT', 'ON_SECURITY_EVENT').
  * @param {Array<object>} resolvedPolicies - The raw resolved policies from the API.
  * @param {string} manualUpdateLink - Link to the Admin Console for manual configuration.
- * @returns {object} Analysis result containing isConfigured, isEnabled, and warnings.
+ * @returns {object} Analysis result containing isConfigured, isEnabled, and findings.
  */
 export function analyzeConnectorPolicy(policyType, resolvedPolicies, manualUpdateLink = '') {
   if (!resolvedPolicies || resolvedPolicies.length === 0) {
     return {
       isConfigured: false,
       isEnabled: false,
-      warnings: ['Connector is not enabled. You can enable it using the enable_chrome_enterprise_connectors tool.'],
+      findings: [
+        {
+          message: 'Connector is not enabled. You can enable it using the enable_chrome_enterprise_connectors tool.',
+          remediationType: 'tool',
+        },
+      ],
     }
   }
 
   // Aggregate results across all resolved policies (usually there is only one)
   const results = resolvedPolicies.map(p => {
     const v = p.value?.value || {}
-    const warnings = []
+    const findings = []
     let isEnabled = true
 
     if (policyType === 'ON_SECURITY_EVENT') {
@@ -83,7 +88,10 @@ export function analyzeConnectorPolicy(policyType, resolvedPolicies, manualUpdat
 
       if (!eventCfg) {
         isEnabled = false
-        warnings.push('Connector is not enabled. You can enable it using the enable_chrome_enterprise_connectors tool.')
+        findings.push({
+          message: 'Connector is not enabled. You can enable it using the enable_chrome_enterprise_connectors tool.',
+          remediationType: 'tool',
+        })
       } else {
         let missingCoreEvents = []
         if (events.length > 0) {
@@ -94,9 +102,10 @@ export function analyzeConnectorPolicy(policyType, resolvedPolicies, manualUpdat
 
         if (missingCoreEvents.length > 0) {
           const mappedMissing = missingCoreEvents.map(e => EVENT_NAME_MAPPING[e] || e)
-          warnings.push(
-            `Missing core DLP events: ${mappedMissing.join(', ')}. Update settings manually at ${manualUpdateLink}`,
-          )
+          findings.push({
+            message: `Missing core DLP events: ${mappedMissing.join(', ')}. Update settings manually at ${manualUpdateLink}`,
+            remediationType: 'manual',
+          })
         }
       }
     } else if (policyType === 'ON_REALTIME_URL_NAVIGATION') {
@@ -127,9 +136,10 @@ export function analyzeConnectorPolicy(policyType, resolvedPolicies, manualUpdat
 
       if (isCEP) {
         if (!cfg.delayDeliveryUntilVerdict && !cfg.delay_delivery_until_verdict) {
-          warnings.push(
-            `Delay enforcement is disabled. Users are unprotected during content analysis. Update settings manually at ${manualUpdateLink}`,
-          )
+          findings.push({
+            message: `Delay enforcement is disabled. Users are unprotected during content analysis. Update settings manually at ${manualUpdateLink}`,
+            remediationType: 'manual',
+          })
         }
 
         // URL Gaps (Malware/Sensitive)
@@ -137,18 +147,21 @@ export function analyzeConnectorPolicy(policyType, resolvedPolicies, manualUpdat
           const humanized = humanize(onByDefault)
           if (humanized === 'No') {
             if (patterns && patterns.length > 0) {
-              warnings.push(
-                `⚠️ ${type} Analysis is restricted. Scanning is ONLY enabled for specific URL patterns, which may leave your organization vulnerable. Update settings manually at ${manualUpdateLink}`,
-              )
+              findings.push({
+                message: `⚠️ ${type} Analysis is restricted. Scanning is ONLY enabled for specific URL patterns, which may leave your organization vulnerable. Update settings manually at ${manualUpdateLink}`,
+                remediationType: 'manual',
+              })
             } else {
-              warnings.push(
-                `⚠️ ${type} Analysis is restricted. Scanning is NOT enabled for all files, which may leave your organization vulnerable. Update settings manually at ${manualUpdateLink}`,
-              )
+              findings.push({
+                message: `⚠️ ${type} Analysis is restricted. Scanning is NOT enabled for all files, which may leave your organization vulnerable. Update settings manually at ${manualUpdateLink}`,
+                remediationType: 'manual',
+              })
             }
           } else if (patterns && patterns.length > 0) {
-            warnings.push(
-              `⚠️ ${type} Analysis is restricted. Scanning is DISABLED for specific URL patterns, which may leave your organization vulnerable. Update settings manually at ${manualUpdateLink}`,
-            )
+            findings.push({
+              message: `⚠️ ${type} Analysis is restricted. Scanning is DISABLED for specific URL patterns, which may leave your organization vulnerable. Update settings manually at ${manualUpdateLink}`,
+              remediationType: 'manual',
+            })
           }
         }
 
@@ -173,32 +186,49 @@ export function analyzeConnectorPolicy(policyType, resolvedPolicies, manualUpdat
           cfg.sensitiveUrlPatterns?.onByDefault === undefined
         ) {
           if (cfg.malwareUrlPatterns?.length > 0 || cfg.sensitiveUrlPatterns?.length > 0) {
-            warnings.push(
-              `Security posture is limited due to URL allowlisting. Update settings manually at ${manualUpdateLink}`,
-            )
+            findings.push({
+              message: `Security posture is limited due to URL allowlisting. Update settings manually at ${manualUpdateLink}`,
+              remediationType: 'manual',
+            })
           }
         }
       } else if (isNone) {
         isEnabled = false
-        warnings.push('Connector is not enabled. You can enable it using the enable_chrome_enterprise_connectors tool.')
+        findings.push({
+          message: 'Connector is not enabled. You can enable it using the enable_chrome_enterprise_connectors tool.',
+          remediationType: 'tool',
+        })
       } else {
         const is3p =
           cfg.serviceProvider === 'SERVICE_PROVIDER_SYMANTEC_ENDPOINT_DLP' ||
           cfg.serviceProvider === 'SERVICE_PROVIDER_TRELLIX'
         if (is3p) {
-          warnings.push(
-            `3rd party provider detected. Integrated CEP features may be bypassed. Update settings manually at ${manualUpdateLink}`,
-          )
+          findings.push({
+            message: `3rd party provider detected. Integrated CEP features may be bypassed. Update settings manually at ${manualUpdateLink}`,
+            remediationType: 'manual',
+          })
         }
       }
     }
 
-    return { isEnabled, warnings }
+    return { isEnabled, findings }
   })
+
+  // Deduplicate and aggregate findings
+  const allFindings = results.flatMap(r => r.findings)
+  const uniqueMessages = new Set()
+  const uniqueFindings = []
+
+  for (const f of allFindings) {
+    if (!uniqueMessages.has(f.message)) {
+      uniqueMessages.add(f.message)
+      uniqueFindings.push(f)
+    }
+  }
 
   return {
     isConfigured: true,
     isEnabled: results.some(r => r.isEnabled),
-    warnings: Array.from(new Set(results.flatMap(r => r.warnings))),
+    findings: uniqueFindings,
   }
 }

--- a/lib/util/connector_policy_helper.js
+++ b/lib/util/connector_policy_helper.js
@@ -1,0 +1,204 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file Shared logic for analyzing Chrome Enterprise Premium policy health.
+ *
+ * Centralizes technical validation of "is it enabled and protective?" vs
+ * "does the policy just exist?".
+ */
+
+import { EVENT_NAME_MAPPING } from '../constants.js'
+import { formatStatus } from './helpers.js'
+
+/**
+ * Normalizes an API value to a human-readable string for comparison.
+ * @param {any} val - The raw value from the API.
+ * @returns {string} The formatted string.
+ */
+export function humanize(val) {
+  if (typeof val === 'boolean') {
+    return val ? 'Yes' : 'No'
+  }
+  if (Array.isArray(val)) {
+    return val.map(humanize).join(', ')
+  }
+  if (typeof val !== 'string') {
+    return String(val)
+  }
+  if (EVENT_NAME_MAPPING[val]) {
+    return EVENT_NAME_MAPPING[val]
+  }
+  return formatStatus(val.replace(/^[A-Z_]+_ENUM_/, '').replace(/^SERVICE_PROVIDER_/, ''))
+}
+
+/**
+ * Analyzes the health and protection state of a Chrome Enterprise connector policy.
+ * @param {string} policyType - The enum key (e.g., 'ON_PRINT', 'ON_SECURITY_EVENT').
+ * @param {Array<object>} resolvedPolicies - The raw resolved policies from the API.
+ * @param {string} manualUpdateLink - Link to the Admin Console for manual configuration.
+ * @returns {object} Analysis result containing isConfigured, isEnabled, and warnings.
+ */
+export function analyzeConnectorPolicy(policyType, resolvedPolicies, manualUpdateLink = '') {
+  if (!resolvedPolicies || resolvedPolicies.length === 0) {
+    return {
+      isConfigured: false,
+      isEnabled: false,
+      warnings: ['Connector is not enabled. You can enable it using the enable_chrome_enterprise_connectors tool.'],
+    }
+  }
+
+  // Aggregate results across all resolved policies (usually there is only one)
+  const results = resolvedPolicies.map(p => {
+    const v = p.value?.value || {}
+    const warnings = []
+    let isEnabled = true
+
+    if (policyType === 'ON_SECURITY_EVENT') {
+      const eventCfg = v.reportingConnector?.setting?.eventConfiguration || v.reportingConnector?.eventConfiguration
+      const events = eventCfg?.enabledEventNames || []
+      const explicitlyEmpty = eventCfg?.explicitlyEmptyEventNames
+      const coreEvents = [
+        'contentTransferEvent',
+        'unscannedFileEvent',
+        'dangerousDownloadEvent',
+        'sensitiveDataEvent',
+        'interstitialEvent',
+        'urlFilteringInterstitialEvent',
+        'suspiciousUrlEvent',
+      ]
+
+      if (!eventCfg) {
+        isEnabled = false
+        warnings.push('Connector is not enabled. You can enable it using the enable_chrome_enterprise_connectors tool.')
+      } else {
+        let missingCoreEvents = []
+        if (events.length > 0) {
+          missingCoreEvents = coreEvents.filter(e => !events.includes(e))
+        } else if (explicitlyEmpty) {
+          missingCoreEvents = coreEvents
+        }
+
+        if (missingCoreEvents.length > 0) {
+          const mappedMissing = missingCoreEvents.map(e => EVENT_NAME_MAPPING[e] || e)
+          warnings.push(
+            `Missing core DLP events: ${mappedMissing.join(', ')}. Update settings manually at ${manualUpdateLink}`,
+          )
+        }
+      }
+    } else if (policyType === 'ON_REALTIME_URL_NAVIGATION') {
+      const checkEnabled = v.realtimeUrlCheckEnabled
+      if (
+        checkEnabled === false ||
+        checkEnabled === 'REALTIME_URL_CHECK_MODE_ENUM_DISABLED' ||
+        checkEnabled === 'ENTERPRISE_REAL_TIME_URL_CHECK_MODE_ENUM_DISABLED' ||
+        checkEnabled === 'REALTIME_URL_CHECK_MODE_ENUM_UNSPECIFIED' ||
+        checkEnabled === 'ENTERPRISE_REAL_TIME_URL_CHECK_MODE_ENUM_UNSPECIFIED'
+      ) {
+        isEnabled = false
+      }
+    } else {
+      // Non-Reporting Connectors (Upload, Download, Paste, Print)
+      const cfg =
+        v.onFileAttachedAnalysisConnectorConfiguration?.fileAttachedConfiguration ||
+        v.onFileDownloadedAnalysisConnectorConfiguration?.fileDownloadedConfiguration ||
+        v.onBulkTextEntryAnalysisConnectorConfiguration?.bulkTextEntryConfiguration ||
+        v.onPrintAnalysisConnectorConfiguration?.printConfigurations?.[0] ||
+        v
+
+      const isCEP = cfg.serviceProvider === 'SERVICE_PROVIDER_CHROME_ENTERPRISE_PREMIUM'
+      const isNone =
+        !cfg.serviceProvider ||
+        cfg.serviceProvider === 'SERVICE_PROVIDER_NONE' ||
+        cfg.serviceProvider === 'SERVICE_PROVIDER_UNSPECIFIED'
+
+      if (isCEP) {
+        if (!cfg.delayDeliveryUntilVerdict && !cfg.delay_delivery_until_verdict) {
+          warnings.push(
+            `Delay enforcement is disabled. Users are unprotected during content analysis. Update settings manually at ${manualUpdateLink}`,
+          )
+        }
+
+        // URL Gaps (Malware/Sensitive)
+        const checkGaps = (type, onByDefault, patterns) => {
+          const humanized = humanize(onByDefault)
+          if (humanized === 'No') {
+            if (patterns && patterns.length > 0) {
+              warnings.push(
+                `⚠️ ${type} Analysis is restricted. Scanning is ONLY enabled for specific URL patterns, which may leave your organization vulnerable. Update settings manually at ${manualUpdateLink}`,
+              )
+            } else {
+              warnings.push(
+                `⚠️ ${type} Analysis is restricted. Scanning is NOT enabled for all files, which may leave your organization vulnerable. Update settings manually at ${manualUpdateLink}`,
+              )
+            }
+          } else if (patterns && patterns.length > 0) {
+            warnings.push(
+              `⚠️ ${type} Analysis is restricted. Scanning is DISABLED for specific URL patterns, which may leave your organization vulnerable. Update settings manually at ${manualUpdateLink}`,
+            )
+          }
+        }
+
+        // Need to check specific fields as original code did
+        if (cfg.malwareUrlPatterns?.onByDefault !== undefined) {
+          checkGaps('Malware', cfg.malwareUrlPatterns.onByDefault, cfg.malwareUrlPatterns.urlPatterns)
+        } else if (cfg.malwareOnByDefault !== undefined) {
+          checkGaps('Malware', cfg.malwareOnByDefault, cfg.malwareUrlPatterns)
+        }
+
+        if (cfg.sensitiveUrlPatterns?.onByDefault !== undefined) {
+          checkGaps('Sensitive', cfg.sensitiveUrlPatterns.onByDefault, cfg.sensitiveUrlPatterns.urlPatterns)
+        } else if (cfg.sensitiveOnByDefault !== undefined) {
+          checkGaps('Sensitive', cfg.sensitiveOnByDefault, cfg.sensitiveUrlPatterns)
+        }
+
+        // Fallback for connectors that don't use the new prefixed fields yet
+        if (
+          cfg.malwareOnByDefault === undefined &&
+          cfg.malwareUrlPatterns?.onByDefault === undefined &&
+          cfg.sensitiveOnByDefault === undefined &&
+          cfg.sensitiveUrlPatterns?.onByDefault === undefined
+        ) {
+          if (cfg.malwareUrlPatterns?.length > 0 || cfg.sensitiveUrlPatterns?.length > 0) {
+            warnings.push(
+              `Security posture is limited due to URL allowlisting. Update settings manually at ${manualUpdateLink}`,
+            )
+          }
+        }
+      } else if (isNone) {
+        isEnabled = false
+        warnings.push('Connector is not enabled. You can enable it using the enable_chrome_enterprise_connectors tool.')
+      } else {
+        const is3p =
+          cfg.serviceProvider === 'SERVICE_PROVIDER_SYMANTEC_ENDPOINT_DLP' ||
+          cfg.serviceProvider === 'SERVICE_PROVIDER_TRELLIX'
+        if (is3p) {
+          warnings.push(
+            `3rd party provider detected. Integrated CEP features may be bypassed. Update settings manually at ${manualUpdateLink}`,
+          )
+        }
+      }
+    }
+
+    return { isEnabled, warnings }
+  })
+
+  return {
+    isConfigured: true,
+    isEnabled: results.some(r => r.isEnabled),
+    warnings: Array.from(new Set(results.flatMap(r => r.warnings))),
+  }
+}

--- a/lib/util/helpers.js
+++ b/lib/util/helpers.js
@@ -85,3 +85,18 @@ export async function callWithRetry(fn, _description) {
     throw error
   }
 }
+
+/**
+ * Formats a raw string (e.g., SNAKE_CASE status) to Title Case with spaces.
+ * @param {string} s - The raw string
+ * @returns {string} The formatted string
+ */
+export function formatStatus(s) {
+  if (!s) {
+    return 'Unknown'
+  }
+  return String(s)
+    .replace(/_/g, ' ')
+    .toLowerCase()
+    .replace(/\b\w/g, l => l.toUpperCase())
+}

--- a/test/local/diagnose_environment.test.js
+++ b/test/local/diagnose_environment.test.js
@@ -85,7 +85,33 @@ describe('diagnose_environment', () => {
   describe('Summary Mode', () => {
     test('When environment is healthy, then it produces zero issues', async () => {
       const { handler } = registerAndGetHandler({
-        connectorPolicy: [{ value: { value: {} } }],
+        connectorPolicy: [
+          {
+            value: {
+              value: {
+                // Satisfies non-reporting connectors (Upload, Download, Paste, Print)
+                serviceProvider: 'SERVICE_PROVIDER_CHROME_ENTERPRISE_PREMIUM',
+                delayDeliveryUntilVerdict: true,
+                // Satisfies URL check connector
+                realtimeUrlCheckEnabled: true,
+                // Satisfies Reporting connector
+                reportingConnector: {
+                  eventConfiguration: {
+                    enabledEventNames: [
+                      'contentTransferEvent',
+                      'unscannedFileEvent',
+                      'dangerousDownloadEvent',
+                      'sensitiveDataEvent',
+                      'interstitialEvent',
+                      'urlFilteringInterstitialEvent',
+                      'suspiciousUrlEvent',
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        ],
         resolvePolicy: [
           {
             targetKey: { additionalTargetKeys: { app_id: 'chrome:ekajlcmdfcigmdbphhifahdfjbkciflj' } },
@@ -130,7 +156,7 @@ describe('diagnose_environment', () => {
       const { handler } = registerAndGetHandler({ connectorPolicy: [] })
       const result = await handler({ customerId: 'C0123' }, { requestInfo: {} })
       const connectorIssues = result.structuredContent.issues.filter(i => i.component.startsWith('connector.'))
-      assert.ok(connectorIssues.length === 6, `Expected 6 missing connectors, got ${connectorIssues.length}`)
+      assert.ok(connectorIssues.length === 6, `Expected 6 missing connector issues, got ${connectorIssues.length}`)
       assert.ok(connectorIssues.every(i => i.severity === 'critical'))
     })
 

--- a/test/unit/lib/util/connector_policy_helper.test.js
+++ b/test/unit/lib/util/connector_policy_helper.test.js
@@ -1,0 +1,96 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { analyzeConnectorPolicy } from '../../../../lib/util/connector_policy_helper.js'
+
+describe('Connector Policy Helper', () => {
+  describe('analyzeConnectorPolicy', () => {
+    test('When no policies are provided, then it reports not configured', () => {
+      const result = analyzeConnectorPolicy('ON_FILE_ATTACHED', [])
+      assert.strictEqual(result.isConfigured, false)
+      assert.strictEqual(result.isEnabled, false)
+      assert.strictEqual(result.findings.length, 0)
+    })
+
+    test('When serviceProvider is missing or NONE, then it reports not enabled', () => {
+      const result = analyzeConnectorPolicy('ON_FILE_ATTACHED', [
+        { value: { value: { serviceProvider: 'SERVICE_PROVIDER_NONE' } } },
+      ])
+      assert.strictEqual(result.isConfigured, true)
+      assert.strictEqual(result.isEnabled, false)
+      assert.strictEqual(result.findings.length, 0)
+    })
+
+    test('When serviceProvider is CHROME_ENTERPRISE_PREMIUM and delay is disabled, then it warns', () => {
+      const result = analyzeConnectorPolicy('ON_FILE_ATTACHED', [
+        {
+          value: {
+            value: {
+              serviceProvider: 'SERVICE_PROVIDER_CHROME_ENTERPRISE_PREMIUM',
+              delayDeliveryUntilVerdict: false,
+            },
+          },
+        },
+      ])
+      assert.strictEqual(result.isEnabled, true)
+      assert.ok(result.findings.some(f => f.message.includes('Delay enforcement is disabled')))
+      assert.strictEqual(result.findings.find(f => f.message.includes('Delay enforcement')).remediationType, 'manual')
+    })
+
+    test('When ON_SECURITY_EVENT is missing core events, then it warns', () => {
+      const result = analyzeConnectorPolicy('ON_SECURITY_EVENT', [
+        {
+          value: {
+            value: {
+              reportingConnector: {
+                eventConfiguration: {
+                  enabledEventNames: ['contentTransferEvent'], // Missing others
+                },
+              },
+            },
+          },
+        },
+      ])
+      assert.strictEqual(result.isEnabled, true)
+      assert.ok(result.findings.some(f => f.message.includes('Missing core DLP events')))
+    })
+
+    test('When ON_REALTIME_URL_NAVIGATION is disabled, then it reports not enabled with descriptive message', () => {
+      const result = analyzeConnectorPolicy('ON_REALTIME_URL_NAVIGATION', [
+        {
+          value: {
+            value: {
+              realtimeUrlCheckEnabled: 'REALTIME_URL_CHECK_MODE_ENUM_DISABLED',
+            },
+          },
+        },
+      ])
+      assert.strictEqual(result.isEnabled, false)
+      assert.strictEqual(result.findings[0].message, 'Real-time URL check is explicitly disabled')
+      assert.strictEqual(result.findings[0].remediationType, 'manual')
+    })
+
+    test('When a 3rd party provider is detected, then it warns but stays enabled', () => {
+      const result = analyzeConnectorPolicy('ON_FILE_ATTACHED', [
+        { value: { value: { serviceProvider: 'SERVICE_PROVIDER_SYMANTEC_ENDPOINT_DLP' } } },
+      ])
+      assert.strictEqual(result.isEnabled, true)
+      assert.ok(result.findings.some(f => f.message.includes('3rd party provider detected')))
+    })
+  })
+})

--- a/test/unit/tools/get_connector_policy.test.js
+++ b/test/unit/tools/get_connector_policy.test.js
@@ -95,7 +95,8 @@ describe('get_connector_policy tool handler', () => {
     const dataText = result.content[1].text
 
     // Verify accurate status reporting
-    assert.match(summary, /^Connector policy: Real-Time URL Check \(OU: `OU123`\)\nStatus: Not configured$/)
+    assert.match(summary, /^Connector policy: Real-Time URL Check \(OU: `OU123`\)\nStatus: Not configured/)
+    assert.ok(summary.includes('Connector is not enabled'))
 
     // Verify JSON details
     assert.match(dataText, /"isEnabled": false/)

--- a/test/unit/tools/get_connector_policy.test.js
+++ b/test/unit/tools/get_connector_policy.test.js
@@ -96,7 +96,7 @@ describe('get_connector_policy tool handler', () => {
 
     // Verify accurate status reporting
     assert.match(summary, /^Connector policy: Real-Time URL Check \(OU: `OU123`\)\nStatus: Not configured/)
-    assert.ok(summary.includes('Connector is not enabled'))
+    assert.ok(summary.includes('Real-time URL check is explicitly disabled'))
 
     // Verify JSON details
     assert.match(dataText, /"isEnabled": false/)

--- a/test/unit/tools/utils.test.js
+++ b/test/unit/tools/utils.test.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { test, describe } from 'node:test'
 import assert from 'node:assert/strict'
-import { formatStatus } from '../../../tools/utils/wrapper.js'
+import { formatStatus } from '../../../lib/util/helpers.js'
 
 describe('Tool Utils - formatStatus', () => {
   test('When input is null or undefined, then it returns "Unknown"', () => {

--- a/tools/definitions/diagnose_environment.js
+++ b/tools/definitions/diagnose_environment.js
@@ -30,14 +30,15 @@ import { TAGS, CONNECTOR_DISPLAY_NAMES } from '../../lib/constants.js'
 import { logger } from '../../lib/util/logger.js'
 import { ConnectorPolicyFilter } from '../../lib/api/chromepolicy.js'
 import { CHROME_ACTION_TYPES } from '../../lib/util/chrome_dlp_constants.js'
+import { analyzeConnectorPolicy } from '../../lib/util/connector_policy_helper.js'
 
 const CONNECTOR_TYPES = {
-  uploadAnalysis: ConnectorPolicyFilter.ON_FILE_ATTACHED,
-  downloadAnalysis: ConnectorPolicyFilter.ON_FILE_DOWNLOAD,
-  pasteAnalysis: ConnectorPolicyFilter.ON_BULK_TEXT_ENTRY,
-  printAnalysis: ConnectorPolicyFilter.ON_PRINT,
-  realtimeUrlCheck: ConnectorPolicyFilter.ON_REALTIME_URL_NAVIGATION,
-  securityEventReporting: ConnectorPolicyFilter.ON_SECURITY_EVENT,
+  uploadAnalysis: 'ON_FILE_ATTACHED',
+  downloadAnalysis: 'ON_FILE_DOWNLOAD',
+  pasteAnalysis: 'ON_BULK_TEXT_ENTRY',
+  printAnalysis: 'ON_PRINT',
+  realtimeUrlCheck: 'ON_REALTIME_URL_NAVIGATION',
+  securityEventReporting: 'ON_SECURITY_EVENT',
 }
 
 const SEB_EXTENSION_SCHEMA = 'chrome.users.apps.InstallType'
@@ -69,13 +70,29 @@ function computeIssues(data) {
   }
 
   for (const [key, connector] of Object.entries(data.connectors || {})) {
+    const name = CONNECTOR_DISPLAY_NAMES[key] || key
     if (!connector.configured) {
-      const name = CONNECTOR_DISPLAY_NAMES[key] || key
       issues.push({
         severity: 'critical',
         component: `connector.${key}`,
         message: `${name} connector is not configured.`,
       })
+    } else if (!connector.isEnabled) {
+      issues.push({
+        severity: 'critical',
+        component: `connector.${key}`,
+        message: `${name} connector is present but explicitly disabled.`,
+      })
+    }
+
+    if (connector.isEnabled && connector.findings && connector.findings.length > 0) {
+      for (const finding of connector.findings) {
+        issues.push({
+          severity: 'high',
+          component: `connector.${key}`,
+          message: `${name}: ${finding.message}`,
+        })
+      }
     }
   }
 
@@ -218,12 +235,22 @@ async function fetchEnvironment(
   const connectors = {}
   if (rootOUId && chromePolicyClient) {
     const connectorResults = await Promise.all(
-      Object.entries(CONNECTOR_TYPES).map(async ([key, schema]) => {
+      Object.entries(CONNECTOR_TYPES).map(async ([key, policyKey]) => {
         try {
+          const schema = ConnectorPolicyFilter[policyKey]
           const policies = await chromePolicyClient.getConnectorPolicy(customerId, rootOUId, schema, authToken)
-          return [key, { configured: policies.length > 0, policyCount: policies.length }]
+          const analysis = analyzeConnectorPolicy(policyKey, policies)
+          return [
+            key,
+            {
+              configured: analysis.isConfigured,
+              isEnabled: analysis.isEnabled,
+              policyCount: policies.length,
+              findings: analysis.findings,
+            },
+          ]
         } catch {
-          return [key, { configured: false, policyCount: 0, error: true }]
+          return [key, { configured: false, isEnabled: false, policyCount: 0, error: true }]
         }
       }),
     )

--- a/tools/definitions/diagnose_environment.js
+++ b/tools/definitions/diagnose_environment.js
@@ -386,6 +386,7 @@ function buildSummaryResponse(env) {
   const medium = sc.issues.filter(i => i.severity === 'medium').length
 
   let summary = `## Environment Health Check\n\n`
+  summary += `> **Scope:** Health check is scoped to the Root Organizational Unit (/). Sub-OU overrides are not included in this summary.\n\n`
   summary += `**Customer:** ${customer.customerId} (${customer.domain || 'unknown domain'})\n`
   summary += `**Org Units:** ${orgUnits.length}\n`
   summary += `**CEP Subscription:** ${subscription.isActive ? `Active (${subscription.assignmentCount} licenses)` : 'Not active'}\n`

--- a/tools/definitions/get_connector_policy.js
+++ b/tools/definitions/get_connector_policy.js
@@ -91,8 +91,6 @@ Note: The 'enable_chrome_enterprise_connectors' tool can only ACTIVATE connector
             authToken,
           )
 
-          const displayName = POLICY_DISPLAY_NAMES[policy] || policy
-
           return safeFormatResponse({
             rawData: policies,
             toolName: 'get_connector_policy',
@@ -108,7 +106,6 @@ Note: The 'enable_chrome_enterprise_connectors' tool can only ACTIVATE connector
                */
               function flattenAndMapConfig(obj, warnings = []) {
                 const result = {}
-                const rawValues = {}
 
                 const walk = (o, prefix = '') => {
                   if (!o || typeof o !== 'object') {
@@ -136,7 +133,6 @@ Note: The 'enable_chrome_enterprise_connectors' tool can only ACTIVATE connector
                       walk(v, nextPrefix)
                     } else {
                       const humanizedValue = humanize(v)
-                      rawValues[targetKey] = humanizedValue
                       const mappedKey = CONNECTOR_KEY_MAPPING[targetKey]
                         ? `${targetKey} (describe to user as '${CONNECTOR_KEY_MAPPING[targetKey]}')`
                         : targetKey
@@ -149,7 +145,7 @@ Note: The 'enable_chrome_enterprise_connectors' tool can only ACTIVATE connector
                   }
                 }
                 walk(obj)
-                return { flattened: result, rawValues }
+                return { flattened: result }
               }
 
               const formattedPolicies = raw.map(p => {
@@ -158,7 +154,24 @@ Note: The 'enable_chrome_enterprise_connectors' tool can only ACTIVATE connector
                 const { flattened } = flattenAndMapConfig(v, localWarnings)
 
                 // Use shared logic for health/protection analysis
-                const analysis = analyzeConnectorPolicy(policy, [p], manualUpdateLink)
+                const analysis = analyzeConnectorPolicy(policy, [p])
+
+                // Process findings into tool-specific warning strings with links
+                const findingWarnings = analysis.findings.map(f => {
+                  if (f.remediationType === 'manual') {
+                    return `${f.message}. Update settings manually at ${manualUpdateLink}`
+                  }
+                  return f.message
+                })
+
+                // If the connector itself is disabled, add the primary remediation guidance
+                if (!analysis.isEnabled) {
+                  findingWarnings.push(
+                    'Connector is not enabled. You can enable it using the enable_chrome_enterprise_connectors tool.',
+                  )
+                }
+
+                const finalWarnings = [...localWarnings, ...findingWarnings]
 
                 if (policy === 'ON_SECURITY_EVENT' && analysis.isEnabled) {
                   const eventCfg =
@@ -174,31 +187,35 @@ Note: The 'enable_chrome_enterprise_connectors' tool can only ACTIVATE connector
                   flattened["serviceProvider (describe to user as 'Provider')"] = 'Chrome Enterprise Premium'
                 }
 
-                const combinedWarnings = [...localWarnings, ...analysis.findings.map(f => f.message)]
-                if (combinedWarnings.length > 0) {
-                  flattened['warnings'] = combinedWarnings.join('; ')
+                if (finalWarnings.length > 0) {
+                  flattened['warnings'] = finalWarnings.join('; ')
                 }
 
-                return { ...flattened, isEnabled: analysis.isEnabled }
+                return { ...flattened, isEnabled: analysis.isEnabled, analysisFindings: finalWarnings }
               })
 
-              const allWarnings = formattedPolicies.flatMap(p => (p.warnings ? [p.warnings] : []))
+              const allWarnings = formattedPolicies.flatMap(p => p.analysisFindings || [])
               const anyEnabled = formattedPolicies.some(p => p.isEnabled)
               const isConfigured = raw.length > 0 && anyEnabled
 
-              let summaryStr = `Connector policy: ${displayName} (OU: \`${orgUnitId}\`)\nStatus: ${isConfigured ? 'Configured' : 'Not configured'}`
-              if (allWarnings.length > 0) {
-                summaryStr += `\n\n⚠️ WARNINGS:\n- ${allWarnings.join('\n- ')}`
-              }
+              // Strip internal analysisFindings before returning
+              const cleanedPolicies = formattedPolicies.map(({ analysisFindings: _analysisFindings, ...p }) => p)
+
+              const title = `${POLICY_DISPLAY_NAMES[policy]} (OU: \`${orgUnitId}\`)`
+              const statusLine = `Status: ${isConfigured ? 'Configured' : 'Not configured'}`
+              const warningSection = allWarnings.length > 0 ? `\n\n⚠️ WARNINGS:\n- ${allWarnings.join('\n- ')}` : ''
+
+              const summary = `Connector policy: ${title}\n${statusLine}${warningSection}`
 
               return formatToolResponse({
-                summary: summaryStr,
-                data: formattedPolicies,
+                summary,
+                data: cleanedPolicies,
                 structuredContent: {
-                  connectorPolicies: formattedPolicies,
+                  connectorPolicies: cleanedPolicies,
                   connectorType: policy,
                   orgUnitId,
                   configured: isConfigured,
+                  warnings: allWarnings,
                 },
               })
             },

--- a/tools/definitions/get_connector_policy.js
+++ b/tools/definitions/get_connector_policy.js
@@ -174,7 +174,7 @@ Note: The 'enable_chrome_enterprise_connectors' tool can only ACTIVATE connector
                   flattened["serviceProvider (describe to user as 'Provider')"] = 'Chrome Enterprise Premium'
                 }
 
-                const combinedWarnings = [...localWarnings, ...analysis.warnings]
+                const combinedWarnings = [...localWarnings, ...analysis.findings.map(f => f.message)]
                 if (combinedWarnings.length > 0) {
                   flattened['warnings'] = combinedWarnings.join('; ')
                 }

--- a/tools/definitions/get_connector_policy.js
+++ b/tools/definitions/get_connector_policy.js
@@ -19,10 +19,11 @@ limitations under the License.
  */
 
 import { z } from 'zod'
-import { guardedToolCall, formatToolResponse, safeFormatResponse, formatStatus } from '../utils/wrapper.js'
+import { guardedToolCall, formatToolResponse, safeFormatResponse } from '../utils/wrapper.js'
 import { commonOutputSchemas } from './shared.js'
-import { CONNECTOR_KEY_MAPPING, POLICY_DISPLAY_NAMES, EVENT_NAME_MAPPING } from '../../lib/constants.js'
+import { CONNECTOR_KEY_MAPPING, POLICY_DISPLAY_NAMES } from '../../lib/constants.js'
 import { ConnectorPolicyFilter } from '../../lib/api/chromepolicy.js'
+import { analyzeConnectorPolicy, humanize } from '../../lib/util/connector_policy_helper.js'
 
 /**
  * Registers the 'get_connector_policy' tool with the MCP server.
@@ -108,21 +109,6 @@ Note: The 'enable_chrome_enterprise_connectors' tool can only ACTIVATE connector
               function flattenAndMapConfig(obj, warnings = []) {
                 const result = {}
                 const rawValues = {}
-                const humanize = val => {
-                  if (typeof val === 'boolean') {
-                    return val ? 'Yes' : 'No'
-                  }
-                  if (Array.isArray(val)) {
-                    return val.map(humanize).join(', ')
-                  }
-                  if (typeof val !== 'string') {
-                    return String(val)
-                  }
-                  if (EVENT_NAME_MAPPING[val]) {
-                    return EVENT_NAME_MAPPING[val]
-                  }
-                  return formatStatus(val.replace(/^[A-Z_]+_ENUM_/, '').replace(/^SERVICE_PROVIDER_/, ''))
-                }
 
                 const walk = (o, prefix = '') => {
                   if (!o || typeof o !== 'object') {
@@ -168,141 +154,32 @@ Note: The 'enable_chrome_enterprise_connectors' tool can only ACTIVATE connector
 
               const formattedPolicies = raw.map(p => {
                 const v = p.value?.value || {}
-                const warnings = []
-                const { flattened, rawValues } = flattenAndMapConfig(v, warnings)
-                let isEnabled = true
+                const localWarnings = []
+                const { flattened } = flattenAndMapConfig(v, localWarnings)
 
-                if (policy === 'ON_SECURITY_EVENT') {
+                // Use shared logic for health/protection analysis
+                const analysis = analyzeConnectorPolicy(policy, [p], manualUpdateLink)
+
+                if (policy === 'ON_SECURITY_EVENT' && analysis.isEnabled) {
                   const eventCfg =
                     v.reportingConnector?.setting?.eventConfiguration || v.reportingConnector?.eventConfiguration
                   const events = eventCfg?.enabledEventNames || []
                   const explicitlyEmpty = eventCfg?.explicitlyEmptyEventNames
-                  const coreEvents = [
-                    'contentTransferEvent',
-                    'unscannedFileEvent',
-                    'dangerousDownloadEvent',
-                    'sensitiveDataEvent',
-                    'interstitialEvent',
-                    'urlFilteringInterstitialEvent',
-                    'suspiciousUrlEvent',
-                  ]
-
-                  if (!eventCfg) {
-                    isEnabled = false
-                    warnings.push(
-                      'Connector is not enabled. You can enable it using the enable_chrome_enterprise_connectors tool.',
-                    )
-                  } else {
-                    let missingCoreEvents = []
-                    if (events.length > 0) {
-                      missingCoreEvents = coreEvents.filter(e => !events.includes(e))
-                    } else if (explicitlyEmpty) {
-                      missingCoreEvents = coreEvents
-                    }
-
-                    if (missingCoreEvents.length > 0) {
-                      const mappedMissing = missingCoreEvents.map(e => EVENT_NAME_MAPPING[e] || e)
-                      warnings.push(
-                        `Missing core DLP events: ${mappedMissing.join(', ')}. Update settings manually at ${manualUpdateLink}`,
-                      )
-                    } else if (events.length === 0 && !explicitlyEmpty) {
-                      flattened['Reporting Status'] = 'All Core Events Enabled (Default)'
-                    }
-                  }
-                } else if (policy === 'ON_REALTIME_URL_NAVIGATION') {
-                  const checkEnabled = v.realtimeUrlCheckEnabled
-                  if (
-                    checkEnabled === false ||
-                    checkEnabled === 'REALTIME_URL_CHECK_MODE_ENUM_DISABLED' ||
-                    checkEnabled === 'ENTERPRISE_REAL_TIME_URL_CHECK_MODE_ENUM_DISABLED' ||
-                    checkEnabled === 'REALTIME_URL_CHECK_MODE_ENUM_UNSPECIFIED' ||
-                    checkEnabled === 'ENTERPRISE_REAL_TIME_URL_CHECK_MODE_ENUM_UNSPECIFIED'
-                  ) {
-                    isEnabled = false
-                  } else {
-                    flattened["serviceProvider (describe to user as 'Provider')"] = 'Chrome Enterprise Premium'
-                  }
-                } else {
-                  // Non-Reporting Connectors (Upload, Download, Paste, Print)
-                  const cfg =
-                    v.onFileAttachedAnalysisConnectorConfiguration?.fileAttachedConfiguration ||
-                    v.onFileDownloadedAnalysisConnectorConfiguration?.fileDownloadedConfiguration ||
-                    v.onBulkTextEntryAnalysisConnectorConfiguration?.bulkTextEntryConfiguration ||
-                    v.onPrintAnalysisConnectorConfiguration?.printConfigurations?.[0] ||
-                    v
-
-                  const isCEP = cfg.serviceProvider === 'SERVICE_PROVIDER_CHROME_ENTERPRISE_PREMIUM'
-                  const isNone =
-                    !cfg.serviceProvider ||
-                    cfg.serviceProvider === 'SERVICE_PROVIDER_NONE' ||
-                    cfg.serviceProvider === 'SERVICE_PROVIDER_UNSPECIFIED'
-
-                  if (isCEP) {
-                    if (!cfg.delayDeliveryUntilVerdict && !cfg.delay_delivery_until_verdict) {
-                      warnings.push(
-                        `Delay enforcement is disabled. Users are unprotected during content analysis. Update settings manually at ${manualUpdateLink}`,
-                      )
-                    }
-
-                    // Gapped Protection Warnings
-                    const checkGaps = (type, onByDefault, patterns) => {
-                      if (onByDefault === 'No') {
-                        if (patterns && patterns.length > 0) {
-                          warnings.push(
-                            `⚠️ ${type} Analysis is restricted. Scanning is ONLY enabled for specific URL patterns, which may leave your organization vulnerable. Update settings manually at ${manualUpdateLink}`,
-                          )
-                        } else {
-                          warnings.push(
-                            `⚠️ ${type} Analysis is restricted. Scanning is NOT enabled for all files, which may leave your organization vulnerable. Update settings manually at ${manualUpdateLink}`,
-                          )
-                        }
-                      } else if (patterns && patterns.length > 0) {
-                        warnings.push(
-                          `⚠️ ${type} Analysis is restricted. Scanning is DISABLED for specific URL patterns, which may leave your organization vulnerable. Update settings manually at ${manualUpdateLink}`,
-                        )
-                      }
-                    }
-
-                    // Audit Malware settings (typically found in Upload/Download).
-                    // Note: Malware settings are not present in Bulk Text (Paste) or Print connectors.
-                    if (rawValues.malwareOnByDefault !== undefined) {
-                      checkGaps('Malware', rawValues.malwareOnByDefault, rawValues.malwareUrlPatterns)
-                    }
-                    // Audit Sensitive Data settings (found in Upload/Download/Print/Paste).
-                    if (rawValues.sensitiveOnByDefault !== undefined) {
-                      checkGaps('Sensitive', rawValues.sensitiveOnByDefault, rawValues.sensitiveUrlPatterns)
-                    }
-
-                    // Fallback for connectors that don't use the new prefixed fields yet
-                    if (rawValues.malwareOnByDefault === undefined && rawValues.sensitiveOnByDefault === undefined) {
-                      if (cfg.malwareUrlPatterns?.length > 0 || cfg.sensitiveUrlPatterns?.length > 0) {
-                        warnings.push(
-                          `Security posture is limited due to URL allowlisting. Update settings manually at ${manualUpdateLink}`,
-                        )
-                      }
-                    }
-                  } else if (isNone) {
-                    isEnabled = false
-                    warnings.push(
-                      'Connector is not enabled. You can enable it using the enable_chrome_enterprise_connectors tool.',
-                    )
-                  } else {
-                    const is3p =
-                      cfg.serviceProvider === 'SERVICE_PROVIDER_SYMANTEC_ENDPOINT_DLP' ||
-                      cfg.serviceProvider === 'SERVICE_PROVIDER_TRELLIX'
-                    if (is3p) {
-                      warnings.push(
-                        `3rd party provider detected. Integrated CEP features may be bypassed. Update settings manually at ${manualUpdateLink}`,
-                      )
-                    }
+                  if (events.length === 0 && !explicitlyEmpty && eventCfg) {
+                    flattened['Reporting Status'] = 'All Core Events Enabled (Default)'
                   }
                 }
 
-                if (warnings.length > 0) {
-                  flattened['warnings'] = warnings.join('; ')
+                if (policy === 'ON_REALTIME_URL_NAVIGATION' && analysis.isEnabled) {
+                  flattened["serviceProvider (describe to user as 'Provider')"] = 'Chrome Enterprise Premium'
                 }
 
-                return { ...flattened, isEnabled }
+                const combinedWarnings = [...localWarnings, ...analysis.warnings]
+                if (combinedWarnings.length > 0) {
+                  flattened['warnings'] = combinedWarnings.join('; ')
+                }
+
+                return { ...flattened, isEnabled: analysis.isEnabled }
               })
 
               const allWarnings = formattedPolicies.flatMap(p => (p.warnings ? [p.warnings] : []))

--- a/tools/definitions/get_dlp_rule.js
+++ b/tools/definitions/get_dlp_rule.js
@@ -19,7 +19,8 @@ limitations under the License.
  */
 
 import { z } from 'zod'
-import { guardedToolCall, formatToolResponse, safeFormatResponse, formatStatus } from '../utils/wrapper.js'
+import { guardedToolCall, formatToolResponse, safeFormatResponse } from '../utils/wrapper.js'
+import { formatStatus } from '../../lib/util/helpers.js'
 import { commonOutputSchemas } from './shared.js'
 import { TAGS } from '../../lib/constants.js'
 import { logger } from '../../lib/util/logger.js'

--- a/tools/definitions/list_dlp_rules.js
+++ b/tools/definitions/list_dlp_rules.js
@@ -19,7 +19,8 @@ limitations under the License.
  */
 
 import { z } from 'zod'
-import { guardedToolCall, formatToolResponse, safeFormatResponse, formatStatus } from '../utils/wrapper.js'
+import { guardedToolCall, formatToolResponse, safeFormatResponse } from '../utils/wrapper.js'
+import { formatStatus } from '../../lib/util/helpers.js'
 import { commonOutputSchemas } from './shared.js'
 import { TAGS } from '../../lib/constants.js'
 import { logger } from '../../lib/util/logger.js'

--- a/tools/utils/wrapper.js
+++ b/tools/utils/wrapper.js
@@ -23,21 +23,6 @@ import { logger } from '../../lib/util/logger.js'
 import { validateAndGetOrgUnitId } from './org-unit.js'
 
 /**
- * Formats a raw string (e.g., SNAKE_CASE status) to Title Case with spaces.
- * @param {string} s - The raw string
- * @returns {string} The formatted string
- */
-export function formatStatus(s) {
-  if (!s) {
-    return 'Unknown'
-  }
-  return String(s)
-    .replace(/_/g, ' ')
-    .toLowerCase()
-    .replace(/\b\w/g, l => l.toUpperCase())
-}
-
-/**
  * Generates a proactive remediation message for authentication errors.
  * @param {number} status - The HTTP status code
  * @param {boolean} [isOAuth] - Whether the CLI is running in OAuth mode


### PR DESCRIPTION
## Summary
This PR unifies the security analysis logic for Chrome Enterprise Premium (CEP) connectors into a shared utility (`lib/util/policy_analyzer.js`). This ensures that both high-level health checks and granular audit tools share the same technically accurate definition of a 'Secure' connector.

## Key Improvements
- **Fixes 'False Healthy' Reports**: Resolves a bug where the diagnostic tool would report a connector as healthy even if critical protection features (like Delay Delivery or Real-time URL checks) were disabled.
- **Reduces Issue Noise**: We separated the **Basic Status** (Is the connector active?) from **Deep Findings** (Are the settings secure?). This stops the tool from double-reporting; for example, a missing connector now shows a single 'Critical' alert rather than multiple redundant warnings.
- **Smart Fix Links**: Findings now include data on how to fix them. This allows the tools to provide the most helpful guidance: either pointing to the automated 'Enable' tool for missing connectors or providing direct Admin Console links for specific configuration gaps.
- **Improved Security Visibility**: Added a descriptive warning for explicitly disabled Real-time URL checks, closing a previous visibility gap in the audit tool.

## Commit History (6 Commits)
1. **Commit 1**: No-op move of original logic to the shared utility.
2. **Commit 2**: Accuracy fix: hooking up the diagnostic tool to the new shared logic.
3. **Commit 3**: No-op refactor to move internal results from simple strings to data objects.
4. **Commit 4**: UX improvement: deduplicating alerts and moving fix-link logic to the tools.
5. **Commit 5**: Prose polish: removing jargon and adding the URL Navigation warning.
6. **Commit 6**: Verification: comprehensive unit tests for the new shared utility.

## Verification
- **Unit Tests**: All 358 tests passed.
- **Integration Tests**: All 14 fake-backend integration tests passed.
- **Smoke Tests**: Verified locally for both standard and detailed modes.