### PR TITLE
chore(ci): expand labeler coverage and add descriptions

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,27 +1,56 @@
+# MCP tool definitions and shared tool utilities
 area:tools:
   - changed-files:
-      - any-glob-to-any-file: 'tools/**'
+      - any-glob-to-any-file: ['tools/**']
 
+# Evaluation framework: cases, scenarios, fixtures, judge, loader, runner
 area:evals:
   - changed-files:
-      - any-glob-to-any-file: 'test/evals/**'
+      - any-glob-to-any-file: ['test/evals/**']
 
+# Unit and integration tests (excludes evals — those get their own label)
 area:tests:
   - changed-files:
-      - any-glob-to-any-file: 'test/**'
+      - any-glob-to-any-file: ['test/local/**', 'test/unit/**', 'test/run-all.js', 'test/helpers/**']
 
+# MCP server entry point and core runtime (transport, lifecycle, lib/)
 area:server:
   - changed-files:
-      - any-glob-to-any-file: 'mcp-server.js'
+      - any-glob-to-any-file: ['mcp-server.js', 'lib/**']
 
+# System prompts, prompt definitions, and knowledge documents
+area:prompts:
+  - changed-files:
+      - any-glob-to-any-file: ['prompts/**', 'lib/knowledge/**']
+
+# GitHub Actions workflows, labeler config, CI/CD pipeline
 area:ci:
   - changed-files:
-      - any-glob-to-any-file: '.github/**'
+      - any-glob-to-any-file: ['.github/**']
 
+# README, contributor guide, doc site, inline doc files
 area:docs:
   - changed-files:
-      - any-glob-to-any-file: ['README.md', 'docs/**', 'CONTRIBUTING.md']
+      - any-glob-to-any-file: ['README.md', 'CONTRIBUTING.md', 'SECURITY.md', 'docs/**', '**/*.md']
 
+# Auth, credentials, token handling, GCP identity, scope enforcement
 area:security:
   - changed-files:
-      - any-glob-to-any-file: ['lib/util/auth*.js', 'lib/util/gcp.js', 'tools/utils/wrapper.js']
+      - any-glob-to-any-file:
+          - 'lib/util/auth*.js'
+          - 'lib/util/gcp.js'
+          - 'lib/util/google-auth-provider.js'
+          - 'lib/util/cel_validator.js'
+          - 'lib/util/feature_flags.js'
+          - 'tools/utils/wrapper.js'
+          - 'SECURITY.md'
+
+# Dependency changes (package.json, lockfile, Dockerfile base image)
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file: ['package.json', 'package-lock.json', 'Dockerfile']
+
+# Gemini extension integration
+area:gemini-extension:
+  - changed-files:
+      - any-glob-to-any-file: ['gemini-extension/**', 'gemini-extension.json']


### PR DESCRIPTION
## Summary
- Fix `area:tests` overlapping with `area:evals` by targeting specific test subdirectories instead of `test/**`
- Widen `area:server` to include `lib/**` alongside `mcp-server.js`
- Expand `area:security` globs to cover `google-auth-provider.js`, `cel_validator.js`, `feature_flags.js`, and `SECURITY.md`
- Add new labels: `area:prompts`, `area:ci`, `area:gemini-extension`, `dependencies`
- Add inline comments describing each label's scope
- Sync all GitHub labels with descriptions and distinct colors (no more generic gray)

## Test plan
- [ ] Open a PR touching only `test/local/` — should get `area:tests` but not `area:evals`
- [ ] Open a PR touching `test/evals/` — should get `area:evals` but not `area:tests`
- [ ] Open a PR touching `prompts/` — should get `area:prompts`
- [ ] Verify `gh label list` shows descriptions and colors for all area labels