### PR TITLE
fix(chrome-management): thread authToken through countBrowserVersions and listCustomerProfiles

### DIFF
--- a/lib/api/interfaces/chrome_management_client.js
+++ b/lib/api/interfaces/chrome_management_client.js
@@ -26,20 +26,22 @@ export class ChromeManagementClient {
    * Counts Chrome browser versions for a specific customer.
    * @param {string} _customerId - The customer ID.
    * @param {string} [_orgUnitId] - Optional organizational unit ID.
+   * @param {string} [_authToken] - Optional OAuth token.
    * @returns {Promise<Array<object>>} - An array of browser version counts.
    * @throws {Error} - If the API call fails.
    */
-  async countBrowserVersions(_customerId, _orgUnitId) {
+  async countBrowserVersions(_customerId, _orgUnitId, _authToken) {
     throw new Error('Not implemented')
   }
 
   /**
    * Lists Chrome browser profiles for a specific customer.
    * @param {string} _customerId - The customer ID.
+   * @param {string} [_authToken] - Optional OAuth token.
    * @returns {Promise<Array<object>>} - An array of customer profiles.
    * @throws {Error} - If the API call fails.
    */
-  async listCustomerProfiles(_customerId) {
+  async listCustomerProfiles(_customerId, _authToken) {
     throw new Error('Not implemented')
   }
 }

--- a/lib/api/real_chrome_management_client.js
+++ b/lib/api/real_chrome_management_client.js
@@ -56,15 +56,16 @@ export class RealChromeManagementClient extends ChromeManagementClient {
    * Counts Chrome browser versions for a specific customer.
    * @param {string} customerId The customer ID.
    * @param {string} [orgUnitId] Optional organizational unit ID.
+   * @param {string} [authToken] Optional OAuth 2.0 access token.
    * @returns {Promise<Array<object>>} An array of browser version counts.
    * @throws {Error} If customerId is missing or the API call fails.
    */
-  async countBrowserVersions(customerId, orgUnitId) {
+  async countBrowserVersions(customerId, orgUnitId, authToken) {
     logger.debug(`${TAGS.API} countBrowserVersions called with customerId: ${customerId}, orgUnitId: ${orgUnitId}`)
     if (!customerId) {
       throw new Error('customerId is required for countBrowserVersions')
     }
-    const client = await this.getClient(null)
+    const client = await this.getClient(authToken)
     try {
       const request = { customer: `customers/${customerId}` }
       if (orgUnitId) {
@@ -83,15 +84,16 @@ export class RealChromeManagementClient extends ChromeManagementClient {
   /**
    * Lists Chrome browser profiles for a specific customer.
    * @param {string} customerId The customer ID.
+   * @param {string} [authToken] Optional OAuth 2.0 access token.
    * @returns {Promise<Array<object>>} An array of customer profiles.
    * @throws {Error} If customerId is missing or the API call fails.
    */
-  async listCustomerProfiles(customerId) {
+  async listCustomerProfiles(customerId, authToken) {
     logger.debug(`${TAGS.API} listCustomerProfiles called with customerId: ${customerId}`)
     if (!customerId) {
       throw new Error('customerId is required for listCustomerProfiles')
     }
-    const client = await this.getClient(null)
+    const client = await this.getClient(authToken)
     try {
       const request = { parent: `customers/${customerId}` }
       const response = await callWithRetry(() => client.customers.profiles.list(request), 'profiles.list')

--- a/test/local/chromemanagement.test.js
+++ b/test/local/chromemanagement.test.js
@@ -168,4 +168,42 @@ describe('Chrome Management API', () => {
       assert.match(result.content[0].text, /API Error/)
     })
   })
+
+  describe('RealChromeManagementClient authToken threading', () => {
+    test('When countBrowserVersions is called with an authToken, then it is forwarded to getClient', async () => {
+      const { RealChromeManagementClient } = await import('../../lib/api/real_chrome_management_client.js')
+      const client = new RealChromeManagementClient()
+      let observedAuth = 'sentinel-not-set'
+      client.getClient = async authToken => {
+        observedAuth = authToken
+        return {
+          customers: {
+            reports: {
+              countChromeVersions: async () => ({ data: { browserVersions: [] } }),
+            },
+          },
+        }
+      }
+      await client.countBrowserVersions('C0123', null, 'TEST_BEARER_TOKEN')
+      assert.strictEqual(observedAuth, 'TEST_BEARER_TOKEN')
+    })
+
+    test('When listCustomerProfiles is called with an authToken, then it is forwarded to getClient', async () => {
+      const { RealChromeManagementClient } = await import('../../lib/api/real_chrome_management_client.js')
+      const client = new RealChromeManagementClient()
+      let observedAuth = 'sentinel-not-set'
+      client.getClient = async authToken => {
+        observedAuth = authToken
+        return {
+          customers: {
+            profiles: {
+              list: async () => ({ data: { chromeBrowserProfiles: [] } }),
+            },
+          },
+        }
+      }
+      await client.listCustomerProfiles('C0123', 'TEST_BEARER_TOKEN')
+      assert.strictEqual(observedAuth, 'TEST_BEARER_TOKEN')
+    })
+  })
 })


### PR DESCRIPTION
Closes #126.

`RealChromeManagementClient.countBrowserVersions` and `listCustomerProfiles` hard-coded `this.getClient(null)` instead of accepting an `authToken` parameter and forwarding it the way every other API client in this repo does. In HTTP/OAuth transport mode that meant these two methods always executed against ADC rather than the caller's bearer — per-user IAM bypassed and audit-log attribution wrong, but only for these two APIs.

## Changes

- Add `authToken` to both method signatures and pass it through `this.getClient(authToken)`.
- Update JSDoc for both.
- Add two regression tests in `test/local/chromemanagement.test.js` that spy on `getClient` and assert the bearer is forwarded.

No call-site changes needed: `tools/definitions/diagnose_environment.js:173`, `tools/definitions/list_customer_profiles.js:67`, and `tools/definitions/count_browser_versions.js:60` already passed the token in the right position — JS arity was silently dropping it.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test:unit` — 354/354 pass (including the 2 new regression tests)