### PR TITLE
refactor: unify stdio session state initialization using factory function

### DIFF
--- a/mcp-server.js
+++ b/mcp-server.js
@@ -380,12 +380,7 @@ async function main() {
       // sessionState is correct. HTTP mode does not reach this branch and
       // does not see this object — its handlers create per-request state
       // via createSessionState() in createMcpPostHandler / createSseHandler.
-      const stdioSessionState = {
-        customerId: null,
-        cachedRootOrgUnitId: null,
-        pendingRule: null,
-        history: [],
-      }
+      const stdioSessionState = createSessionState()
       const stdioTransport = new StdioServerTransport()
       const server = await getServer(gcpInfo, stdioSessionState)
       await server.connect(stdioTransport)


### PR DESCRIPTION
Unifies the initialization of `stdioSessionState` in `mcp-server.js` by using the `createSessionState()` factory function. This prevents duplication and protects against bit rot when the session state structure is updated in the future.

This PR is staged on top of #118.