### PR TITLE
build: launch MCP server via npx for zero-setup execution

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -5,24 +5,20 @@
   "contextFileName": "gemini-extension/GEMINI.md",
   "mcpServers": {
     "chrome-enterprise-premium": {
-      "command": "node",
-      "args": ["${extensionPath}${/}mcp-server.js"],
-      "cwd": "${extensionPath}"
+      "command": "npx",
+      "args": ["-y", "@google/chrome-enterprise-premium-mcp@^1.2.0"]
     }
   },
   "oauth_scopes": [
-    "openid",
-    "https://www.googleapis.com/auth/userinfo.email",
-    "https://www.googleapis.com/auth/chrome.management.policy",
-    "https://www.googleapis.com/auth/chrome.management.reports.readonly",
-    "https://www.googleapis.com/auth/chrome.management.profiles.readonly",
-    "https://www.googleapis.com/auth/admin.reports.audit.readonly",
-    "https://www.googleapis.com/auth/admin.directory.orgunit.readonly",
     "https://www.googleapis.com/auth/admin.directory.customer.readonly",
+    "https://www.googleapis.com/auth/admin.directory.orgunit.readonly",
+    "https://www.googleapis.com/auth/admin.reports.audit.readonly",
     "https://www.googleapis.com/auth/apps.licensing",
+    "https://www.googleapis.com/auth/chrome.management.policy",
+    "https://www.googleapis.com/auth/chrome.management.profiles.readonly",
+    "https://www.googleapis.com/auth/chrome.management.reports.readonly",
     "https://www.googleapis.com/auth/cloud-identity.policies",
     "https://www.googleapis.com/auth/service.management",
-    "https://www.googleapis.com/auth/service.management.readonly",
-    "https://www.googleapis.com/auth/cloud-platform"
+    "https://www.googleapis.com/auth/userinfo.email"
   ]
 }


### PR DESCRIPTION
# What this does

The Gemini CLI extension's manifest (`gemini-extension.json`) now launches the MCP server via `npx` instead of `node`. This makes `gemini extensions install <repo>` work without requiring users to run `npm install` on a fresh machine.

# Why this is needed

`gemini extensions install` clones the repo (or extracts a GitHub Release tarball) into `~/.gemini/extensions/<name>/`, but it does not run `npm install`. When Gemini CLI spawned the manifest's previous `node mcp-server.js`, the server immediately crashed with `MODULE_NOT_FOUND` because `@modelcontextprotocol/sdk`, `express`, `google-auth-library`, and the rest of the dependency tree were never installed.

`npx -y @google/chrome-enterprise-premium-mcp@^1.2.0` resolves this: npx pulls the published npm package, installs its declared dependencies into npm's cache, and executes the `bin` entry. The package is already published, so no new release plumbing is needed on either the extension or the npm side.

# Changes

- **Manifest**: `gemini-extension.json` `command` switched from `node` to `npx`; `args` set to `["-y", "@google/chrome-enterprise-premium-mcp@^1.2.0"]`. `cwd` no longer needed.
- **OAuth scopes**: `oauth_scopes` alphabetized and pared to the 10 production-approved scopes for the Gemini OAuth consent flow. The removed scopes (`openid`, `service.management.readonly`, `cloud-platform`) remain available via ADC for GCP-flavored API paths.

# Update model

Two layers, updated independently:

- **Server code** (the npm package): bug fixes ship via `npm publish`. With `^1.2.0` in the manifest, users pick up new patches/minors on next CLI start. No manifest change required.
- **The extension itself** (manifest, GEMINI.md, oauth_scopes): bump `version` in `gemini-extension.json`, push to default branch (or cut a GitHub Release tagged `latest`), and publish a matching npm version. Users with `--auto-update` see the upgrade prompt; others run `gemini extensions update`.
