### PR TITLE
refactor(test): move stdio-spawning tests out of the unit suite, add CI tripwire

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -70,3 +70,24 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run test:smoke
+
+  test-budget-tripwires:
+    name: 🚧 Test budget tripwires
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Reject subprocess imports in unit-suite test files
+        run: |
+          # Unit-suite test files (*.test.js under test/local/ or test/unit/)
+          # must not spawn subprocesses or speak MCP over stdio. Anything that
+          # does belongs in test/integration/server/ where the cost is honestly
+          # budgeted. Non-.test.js scripts (e.g. test/local/smoke-test.js) are
+          # exempt because they are invoked by their own npm script, not by the
+          # unit runner.
+          hits=$(find test/local test/unit -name '*.test.js' -exec grep -lE 'from .node:child_process|from .child_process|StdioClientTransport' {} + 2>/dev/null)
+          if [ -n "$hits" ]; then
+            echo "::error::The following unit-suite test files spawn subprocesses or import StdioClientTransport. Move them under test/integration/server/:"
+            echo "$hits"
+            exit 1
+          fi
+          echo "OK: no subprocess imports in any *.test.js under test/local/ or test/unit/."

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -84,7 +84,10 @@ jobs:
           # budgeted. Non-.test.js scripts (e.g. test/local/smoke-test.js) are
           # exempt because they are invoked by their own npm script, not by the
           # unit runner.
-          hits=$(find test/local test/unit -name '*.test.js' -exec grep -lE 'from .node:child_process|from .child_process|StdioClientTransport' {} + 2>/dev/null)
+          # `|| true`: grep exits 1 on no-match, which under `bash -e` would
+          # incorrectly fail the step. We want the empty-result case to fall
+          # through to the `[ -n "$hits" ]` check below.
+          hits=$(find test/local test/unit -name '*.test.js' -exec grep -lE 'from .node:child_process|from .child_process|StdioClientTransport' {} + 2>/dev/null || true)
           if [ -n "$hits" ]; then
             echo "::error::The following unit-suite test files spawn subprocesses or import StdioClientTransport. Move them under test/integration/server/:"
             echo "$hits"

--- a/test/integration/server/mcp-server.test.js
+++ b/test/integration/server/mcp-server.test.js
@@ -39,7 +39,16 @@ describe('MCP Server in stdio mode', () => {
     transport = new StdioClientTransport({
       command: 'node',
       args: ['mcp-server.js'],
-      env: { ...process.env, GCP_STDIO: 'true', EXPERIMENT_KNOWLEDGE_SEARCH_ENABLED: 'true' },
+      env: {
+        ...process.env,
+        GCP_STDIO: 'true',
+        EXPERIMENT_KNOWLEDGE_SEARCH_ENABLED: 'true',
+        // The integration runner sets EXPERIMENT_DELETE_TOOL_ENABLED=true, but
+        // the listTools assertion below pins the exact tool set without the
+        // delete_* tools; opt this child process out so the expected list
+        // matches what the parent suite registers.
+        EXPERIMENT_DELETE_TOOL_ENABLED: 'false',
+      },
     })
     client = new Client({
       name: 'test-client',
@@ -102,7 +111,7 @@ describe('MCP Server in stdio mode', () => {
     const NO_ADC_PROBE = 'http://localhost:1'
 
     test('When server starts with custom PORT, then it logs the correct port', () => {
-      const serverPath = path.resolve(__dirname, '../../mcp-server.js')
+      const serverPath = path.resolve(__dirname, '../../../mcp-server.js')
       const result = spawnSync(process.execPath, [serverPath], {
         env: {
           ...process.env,
@@ -120,7 +129,7 @@ describe('MCP Server in stdio mode', () => {
     })
 
     test('When server starts without PORT, then it assigns a random port', () => {
-      const serverPath = path.resolve(__dirname, '../../mcp-server.js')
+      const serverPath = path.resolve(__dirname, '../../../mcp-server.js')
       const result = spawnSync(process.execPath, [serverPath], {
         env: { ...process.env, GCP_STDIO: 'false', CEP_LOG_LEVEL: 'info', GOOGLE_API_ROOT_URL: NO_ADC_PROBE },
         timeout: 12000,
@@ -131,7 +140,7 @@ describe('MCP Server in stdio mode', () => {
     })
 
     test('When server starts with a port that is already in use, then it logs an explicit error and exits', async () => {
-      const serverPath = path.resolve(__dirname, '../../mcp-server.js')
+      const serverPath = path.resolve(__dirname, '../../../mcp-server.js')
       const net = await import('node:net')
 
       const server = net.createServer()
@@ -161,7 +170,7 @@ describe('MCP Server in stdio mode', () => {
     })
 
     test('When server starts with Fake Data URL, then it logs Data Access: Fake Data', () => {
-      const serverPath = path.resolve(__dirname, '../../mcp-server.js')
+      const serverPath = path.resolve(__dirname, '../../../mcp-server.js')
       const result = spawnSync(process.execPath, [serverPath], {
         env: { ...process.env, GOOGLE_API_ROOT_URL: 'http://localhost:8080', GCP_STDIO: 'true', CEP_LOG_LEVEL: 'info' },
         timeout: 12000,

--- a/test/integration/server/prompts.test.js
+++ b/test/integration/server/prompts.test.js
@@ -23,7 +23,7 @@ import { dirname, resolve } from 'path'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
-const SERVER_PATH = resolve(__dirname, '../../mcp-server.js')
+const SERVER_PATH = resolve(__dirname, '../../../mcp-server.js')
 
 describe('MCP Prompts', () => {
   let client

--- a/test/run-integration.js
+++ b/test/run-integration.js
@@ -22,9 +22,9 @@ limitations under the License.
  * Accepts a positional argument ("fake" or "real") that determines the
  * CEP_BACKEND environment variable. Defaults to "fake" when omitted.
  *
- * Discovers `.test.js` files under `test/integration/tools/` using a recursive
- * directory walk so that glob expansion is not required (works on Windows and
- * POSIX).
+ * Discovers `.test.js` files under `test/integration/tools/` and
+ * `test/integration/server/` using a recursive directory walk so that glob
+ * expansion is not required (works on Windows and POSIX).
  *
  * Usage:
  *   node test/run-integration.js fake
@@ -53,10 +53,11 @@ if (backend !== 'fake' && backend !== 'real') {
 
 process.env.CEP_BACKEND = backend
 
-const testFiles = findTestFiles(join(root, 'test', 'integration', 'tools')).sort()
+const integrationDirs = [join(root, 'test', 'integration', 'tools'), join(root, 'test', 'integration', 'server')]
+const testFiles = integrationDirs.flatMap(dir => findTestFiles(dir)).sort()
 
 if (testFiles.length === 0) {
-  console.error('No test files found under test/integration/tools/')
+  console.error('No test files found under test/integration/tools/ or test/integration/server/')
   process.exit(1)
 }
 


### PR DESCRIPTION
## Why

The pre-commit and pre-push gates were taking minutes per commit. The investigation traced the cost to two compounding causes, both of which had been fixed once before and then drifted back in.

## Diagnostic (what was actually slow, and why)

### Cause 1: pre-commit was running the full presubmit on stale branches

`.husky/pre-commit` on `main` is light:

```
npx lint-staged
```

That landed in `5de1c18` ("chore(hooks): move heavy checks to pre-push, keep pre-commit fast", 2026-04-29). On long-lived feature branches that diverged from main before that date, the heavy version still applied:

```
npx lint-staged && npm run presubmit
```

`presubmit` runs prettier-on-the-tree, eslint, the unit suite, the integration suite, and the smoke test. So a single commit on a stale branch took minutes. PRs #83 and #121 were both stuck on the heavy version until I merged main into each of them earlier today.

### Cause 2: two integration tests living in the unit suite

`test/local/mcp-server.test.js` and `test/local/prompts.test.js` use `StdioClientTransport` to spawn `node mcp-server.js` as a child process and round-trip JSON-RPC over its stdio. Per-file wall clock on this 2-core dev machine:

| File | Time | Pattern |
|---|---|---|
| `test/local/mcp-server.test.js` | **33s** for 5 tests | spawns the server in `before()`, four startup-log tests each spawn + spawnSync the server again |
| `test/local/knowledge.test.js` | 16s for 8 tests | mock-based, but heavy module loading at import time |
| `test/local/cloudidentity.test.js` | 6s | API-shape tests |
| `test/local/admin_sdk.test.js` | 4s | API-shape tests |
| `test/local/prompts.test.js` | 0.3s standalone, but adds to the same StdioClientTransport tax | one server spawn |

The `mcp-server.test.js` file was doing integration-grade work under the unit budget. A previous patch (\`9781db5\`, \"skip ADC probe in startup-log tests to eliminate 8s race with 12s spawnSync timeout\") shaved 8s off but stopped at the symptom. The deeper question — \"should this be a unit test at all?\" — was never asked.

## What this PR changes

### 1. Move the stdio-spawning tests out of the unit suite

- \`test/local/mcp-server.test.js\` → \`test/integration/server/mcp-server.test.js\`
- \`test/local/prompts.test.js\` → \`test/integration/server/prompts.test.js\`
- \`test/run-integration.js\` walks the new \`test/integration/server/\` directory in addition to \`test/integration/tools/\`.
- \`mcp-server.test.js\` opts its child process out of \`EXPERIMENT_DELETE_TOOL_ENABLED=true\` (which the integration runner now sets) so the \`listTools\` assertion stays stable.

### 2. CI tripwire to keep this from drifting back

A new \`test-budget-tripwires\` job greps every \`*.test.js\` file under \`test/local/\` and \`test/unit/\` for \`node:child_process\` imports and \`StdioClientTransport\`. Any hit fails the PR with a message naming the offending files. Non-\`.test.js\` scripts (e.g. \`test/local/smoke-test.js\`, invoked by its own npm script) are exempt by filename.

The check is mechanical: it cannot judge whether a particular import is justified, only that it exists. That is the point. The \"unit suite must not spawn subprocesses\" rule has been violated twice in this repo already; a hard CI gate is the only way to prevent the third instance.

## Measurements (this 2-core machine)

| Suite | Before | After |
|---|---|---|
| \`test:unit\` | 1:53 (409 tests) | **1:05** (349 tests) |
| \`test:integration:fake\` | 0:08 (14 tests) | 0:47 (23 tests) |
| \`test:smoke\` | 0:03 | 0:03 |
| Pre-push total (sequential) | ~2:04 | ~1:55 |

Net pre-push cost is roughly the same. The win is honest budgeting and CI parallelism: each suite runs in its own GitHub Actions job, so the longest single job drops from ~1:53 to ~1:05. On a 4-core CI runner, where Node's \`--test\` parallelizes test files across cores, the unit job will be faster still — the wall-clock floor is the slowest single file, which is now \`knowledge.test.js\` at ~16s rather than \`mcp-server.test.js\` at ~33s.

## Follow-ups (not in this PR)

| Item | Why deferred |
|---|---|
| Widen pack-check \`paths:\` to include \`lib/**\`, \`mcp-server.js\`, \`tools/**\`, \`prompts/**\` | The pack-check workflow itself ships in PR #83. Folding the paths fix into PR #83 keeps that PR's diff coherent. |
| Auto-regenerate \`.github/expected-tarball.txt\` on shipped-file changes via lint-staged | Same reason — the snapshot file ships in PR #83. |
| Investigate why \`knowledge.test.js\` is 16s | Probably heavy module-load on import. Out of scope for this cleanup; worth its own issue. |
| Add a tripwire that fails any PR whose \`.husky/pre-commit\` differs from main's | Would have caught the heavy-hook drift on PRs #83 and #121. Worth doing, but a separate small change. |

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm run test:unit\` — 349/349 pass, 1:05
- [x] \`npm run test:integration:fake\` — 23 tests, 20 pass, 3 skipped, 0 fail, 0:47
- [x] \`npm run test:smoke\` — pass
- [x] Tripwire grep returns nothing on this branch