### PR TITLE
refactor(test): extract createMockExecFile helper and inline proto-pollution guard

### DIFF
--- a/test/helpers/fake-api-server.js
+++ b/test/helpers/fake-api-server.js
@@ -26,18 +26,15 @@ import express from 'express'
 import { randomUUID } from 'node:crypto'
 
 /**
- * Reserved prototype keys that must not be set on a plain object via
- * arbitrary fixture input — assigning to any of these would mutate
- * Object.prototype and affect every other object in the process.
- */
-const PROTO_POLLUTING_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
-
-/**
  * @param {string|number|undefined} key
  * @returns {boolean} true when the key is safe to use as a plain-object property.
  */
 function isSafeKey(key) {
-  return key !== undefined && !PROTO_POLLUTING_KEYS.has(String(key))
+  if (key === undefined || key === null) {
+    return false
+  }
+  const strKey = String(key)
+  return strKey !== '__proto__' && strKey !== 'constructor' && strKey !== 'prototype'
 }
 
 /**

--- a/test/local/auth.test.js
+++ b/test/local/auth.test.js
@@ -18,12 +18,28 @@ import assert from 'node:assert/strict'
 import { describe, test, mock } from 'node:test'
 import esmock from 'esmock'
 
+function createMockExecFile(...handlers) {
+  return mock.fn((cmd, args, opts, cb) => {
+    let stdout = ''
+    for (const handler of handlers) {
+      const result = handler(cmd, args, opts)
+      if (result !== undefined && result !== null) {
+        stdout = result
+        break
+      }
+    }
+    cb(null, stdout, '')
+  })
+}
+
 describe('Auth', () => {
   test('When an auth token is provided, then it returns an OAuth2 client', async () => {
     const { getAuthClient } = await esmock('../../lib/util/auth.js', {
       'google-auth-library': {
         OAuth2Client: class {
-          setCredentials() {}
+          setCredentials(credentials) {
+            assert.deepStrictEqual(credentials, { access_token: 'test-token' })
+          }
         },
       },
     })
@@ -32,17 +48,23 @@ describe('Auth', () => {
   })
 
   test('When no auth token is provided, then it returns a GoogleAuth client', async () => {
+    let getClientCalled = false
     const { getAuthClient } = await esmock('../../lib/util/auth.js', {
       'google-auth-library': {
         GoogleAuth: class {
           async getClient() {
-            return {}
+            getClientCalled = true
+            return {
+              getAccessToken: async () => ({ token: 'mock-token' }),
+            }
           }
         },
       },
     })
     const client = await getAuthClient([])
     assert.ok(client)
+    assert.strictEqual(getClientCalled, true)
+    assert.equal(typeof client.getAccessToken, 'function')
   })
 
   test('When ADC credentials are valid, then ensureADCCredentials returns true', async () => {
@@ -71,8 +93,7 @@ describe('Auth', () => {
   })
 
   test('When ADC credentials are missing or invalid, then ensureADCCredentials returns false', async () => {
-    // Mock console.log/error to suppress output during test
-    const consoleLogMock = mock.method(console, 'log', () => {})
+    // Mock console.error to suppress output during test
     const consoleErrorMock = mock.method(console, 'error', () => {})
 
     const { ensureADCCredentials } = await esmock('../../lib/util/auth.js', {
@@ -89,34 +110,37 @@ describe('Auth', () => {
     assert.strictEqual(result, false)
 
     // Restore console mocks
-    consoleLogMock.mock.restore()
     consoleErrorMock.mock.restore()
   })
 
   describe('getAuthErrorMessage', () => {
     test('When a project with the required API enabled is found, then it is suggested', async () => {
-      const mockExecFile = mock.fn((cmd, args, opts, cb) => {
-        let stdout = ''
-        if (cmd === 'gcloud' && args.includes('--version')) {
-          stdout = 'Google Cloud SDK'
-        } else if (cmd === 'gcloud' && args.includes('config') && args.includes('get-value')) {
-          stdout = '(unset)\n'
-        } else if (
-          cmd === 'gcloud' &&
-          args.includes('projects') &&
-          args.includes('list') &&
-          args.includes('--limit=10')
-        ) {
-          stdout = 'proj-1\nproj-2\nproj-3\n'
-        } else if (cmd === 'gcloud' && args.includes('services') && args.includes('list')) {
-          const projectIndex = args.indexOf('--project') + 1
-          const projectId = args[projectIndex]
-          if (projectId === 'proj-2') {
-            stdout = 'admin.googleapis.com\n'
+      const mockExecFile = createMockExecFile(
+        (cmd, args) => {
+          if (cmd === 'gcloud' && args.includes('--version')) {
+            return 'Google Cloud SDK'
           }
-        }
-        cb(null, stdout, '')
-      })
+        },
+        (cmd, args) => {
+          if (cmd === 'gcloud' && args.includes('config') && args.includes('get-value')) {
+            return '(unset)\n'
+          }
+        },
+        (cmd, args) => {
+          if (cmd === 'gcloud' && args.includes('projects') && args.includes('list') && args.includes('--limit=10')) {
+            return 'proj-1\nproj-2\nproj-3\n'
+          }
+        },
+        (cmd, args) => {
+          if (cmd === 'gcloud' && args.includes('services') && args.includes('list')) {
+            const projectIndex = args.indexOf('--project') + 1
+            const projectId = args[projectIndex]
+            if (projectId === 'proj-2') {
+              return 'admin.googleapis.com\n'
+            }
+          }
+        },
+      )
 
       const { getAuthErrorMessage } = await esmock('../../lib/util/auth-error.js', {
         'node:child_process': {
@@ -132,22 +156,23 @@ describe('Auth', () => {
     })
 
     test('When no project has the API enabled, then it falls back to the most recent project', async () => {
-      const mockExecFile = mock.fn((cmd, args, opts, cb) => {
-        let stdout = ''
-        if (cmd === 'gcloud' && args.includes('--version')) {
-          stdout = 'Google Cloud SDK'
-        } else if (cmd === 'gcloud' && args.includes('config') && args.includes('get-value')) {
-          stdout = '(unset)\n'
-        } else if (
-          cmd === 'gcloud' &&
-          args.includes('projects') &&
-          args.includes('list') &&
-          args.includes('--limit=10')
-        ) {
-          stdout = 'proj-1\nproj-2\n'
-        }
-        cb(null, stdout, '')
-      })
+      const mockExecFile = createMockExecFile(
+        (cmd, args) => {
+          if (cmd === 'gcloud' && args.includes('--version')) {
+            return 'Google Cloud SDK'
+          }
+        },
+        (cmd, args) => {
+          if (cmd === 'gcloud' && args.includes('config') && args.includes('get-value')) {
+            return '(unset)\n'
+          }
+        },
+        (cmd, args) => {
+          if (cmd === 'gcloud' && args.includes('projects') && args.includes('list') && args.includes('--limit=10')) {
+            return 'proj-1\nproj-2\n'
+          }
+        },
+      )
 
       const { getAuthErrorMessage } = await esmock('../../lib/util/auth-error.js', {
         'node:child_process': {
@@ -162,15 +187,18 @@ describe('Auth', () => {
     })
 
     test('When no projects are found at all, then it falls back to a generic console URL message', async () => {
-      const mockExecFile = mock.fn((cmd, args, opts, cb) => {
-        let stdout = ''
-        if (cmd === 'gcloud' && args.includes('--version')) {
-          stdout = 'Google Cloud SDK'
-        } else if (cmd === 'gcloud' && args.includes('config') && args.includes('get-value')) {
-          stdout = '(unset)\n'
-        }
-        cb(null, stdout, '')
-      })
+      const mockExecFile = createMockExecFile(
+        (cmd, args) => {
+          if (cmd === 'gcloud' && args.includes('--version')) {
+            return 'Google Cloud SDK'
+          }
+        },
+        (cmd, args) => {
+          if (cmd === 'gcloud' && args.includes('config') && args.includes('get-value')) {
+            return '(unset)\n'
+          }
+        },
+      )
 
       const { getAuthErrorMessage } = await esmock('../../lib/util/auth-error.js', {
         'node:child_process': {
@@ -187,15 +215,18 @@ describe('Auth', () => {
     })
 
     test('When a project is already configured in gcloud, then it uses that project directly', async () => {
-      const mockExecFile = mock.fn((cmd, args, opts, cb) => {
-        let stdout = ''
-        if (cmd === 'gcloud' && args.includes('--version')) {
-          stdout = 'Google Cloud SDK'
-        } else if (cmd === 'gcloud' && args.includes('config') && args.includes('get-value')) {
-          stdout = 'configured-project\n'
-        }
-        cb(null, stdout, '')
-      })
+      const mockExecFile = createMockExecFile(
+        (cmd, args) => {
+          if (cmd === 'gcloud' && args.includes('--version')) {
+            return 'Google Cloud SDK'
+          }
+        },
+        (cmd, args) => {
+          if (cmd === 'gcloud' && args.includes('config') && args.includes('get-value')) {
+            return 'configured-project\n'
+          }
+        },
+      )
 
       const { getAuthErrorMessage } = await esmock('../../lib/util/auth-error.js', {
         'node:child_process': {


### PR DESCRIPTION
Split out from PR #137. The mcp-server banner fix from that PR ships separately under \`fix(mcp-server):\` so this PR stays a pure test-side refactor with no version-bumping prefix.

### Changes

- **\`test/local/auth.test.js\`**: extract a \`createMockExecFile\` helper that takes an ordered list of handler callbacks. Each handler receives \`(cmd, args, opts)\` and returns a stdout string for matching invocations or \`undefined\` to defer to the next handler. The four \`getAuthErrorMessage\` tests use the helper instead of repeating the same \`mock.fn((cmd, args, opts, cb) => { ... })\` skeleton. Two of the auth-token / ADC tests gain assertions on \`setCredentials\` arg shape and on the returned client's \`getAccessToken\` shape.
- **\`test/helpers/fake-api-server.js\`**: replace the \`PROTO_POLLUTING_KEYS\` \`Set\` inside \`isSafeKey\` with three direct string comparisons against the exact keys it guards (\`__proto__\`, \`constructor\`, \`prototype\`); add an explicit \`null\` guard alongside the existing \`undefined\` guard.

### Test plan

- [x] \`npm run lint\` clean
- [x] \`npm run test:unit\` pass
- [x] \`npm run test:integration:fake\` pass
- [x] \`npm run test:smoke\` pass