### PR TITLE
fix(delete_agent_dlp_rule): drop redundant policies.get before delete

### DIFF
--- a/lib/api/interfaces/cloud_identity_client.js
+++ b/lib/api/interfaces/cloud_identity_client.js
@@ -66,6 +66,18 @@ export class CloudIdentityClient {
   }
 
   /**
+   * Deletes a DLP rule policy without server-side validation. Use only when
+   * the caller has already confirmed the policy is a Chrome DLP rule.
+   * @param {string} _policyName - The name of the policy to delete.
+   * @param {string} [_authToken] - Optional OAuth token.
+   * @returns {Promise<object>} - The result of the deletion.
+   * @throws {Error} - If the API call fails.
+   */
+  async deleteDlpRulePreValidated(_policyName, _authToken) {
+    throw new Error('Not implemented')
+  }
+
+  /**
    * Creates a new Detector.
    * @param {string} _customerId - The customer ID.
    * @param {string} _orgUnitId - The organizational unit ID.

--- a/lib/api/real_cloud_identity_client.js
+++ b/lib/api/real_cloud_identity_client.js
@@ -160,6 +160,24 @@ export class RealCloudIdentityClient extends CloudIdentityClient {
   }
 
   /**
+   * Deletes a DLP rule without re-fetching for validation. The caller is
+   * responsible for confirming the policy is a Chrome DLP rule before invoking.
+   * @param {string} policyName The resource name of the policy to delete.
+   * @param {string} [authToken] Optional authentication token.
+   * @returns {Promise<object>} The API response data.
+   */
+  async deleteDlpRulePreValidated(policyName, authToken) {
+    logger.debug(`${TAGS.API} deleteDlpRulePreValidated called with policyName: ${policyName}`)
+    const client = await this.getPolicyClient(authToken)
+    try {
+      const deleteResponse = await callWithRetry(() => client.policies.delete({ name: policyName }), 'policies.delete')
+      return deleteResponse.data
+    } catch (error) {
+      handleApiError(error, TAGS.API, 'deleting Chrome DLP rule')
+    }
+  }
+
+  /**
    * Gets a specific Chrome DLP rule.
    * @param {string} policyName The resource name of the policy to retrieve.
    * @param {string} [authToken] Optional authentication token.

--- a/test/local/cloudidentity.test.js
+++ b/test/local/cloudidentity.test.js
@@ -456,7 +456,7 @@ describe('Cloud Identity API', () => {
          *
          */
         constructor() {
-          this.deleteDlpRule = mockDeleteDlpRule
+          this.deleteDlpRulePreValidated = mockDeleteDlpRule
           this.getDlpRule = mock.fn(async () => ({
             setting: { value: { displayName: '🤖 Test Rule' } },
           }))

--- a/test/local/experiments/delete_tool.test.js
+++ b/test/local/experiments/delete_tool.test.js
@@ -67,7 +67,7 @@ describe('Experiment: DELETE_TOOL_ENABLED', () => {
       const mockDeleteDlpRule = mock.fn(async () => ({}))
       const MockCloudIdentityClient = class {
         constructor() {
-          this.deleteDlpRule = mockDeleteDlpRule
+          this.deleteDlpRulePreValidated = mockDeleteDlpRule
           this.getDlpRule = mock.fn(async () => ({
             setting: { value: { displayName: '🤖 Test Rule' } },
           }))

--- a/test/unit/tools/delete_agent_dlp_rule.test.js
+++ b/test/unit/tools/delete_agent_dlp_rule.test.js
@@ -32,13 +32,40 @@ describe('delete_agent_dlp_rule tool handler', () => {
     return registeredHandler
   }
 
+  test('When rule is agent-created, then deleteDlpRule (with re-validation) is NOT called', async () => {
+    let getCalls = 0
+    let preValidatedCalls = 0
+    let validatedCalls = 0
+    const mockCloudIdentityClient = {
+      getDlpRule: async () => {
+        getCalls++
+        return { setting: { value: { displayName: '🤖 Agent Rule' } } }
+      },
+      deleteDlpRulePreValidated: async () => {
+        preValidatedCalls++
+        return {}
+      },
+      deleteDlpRule: async () => {
+        validatedCalls++
+        return {}
+      },
+    }
+
+    const handler = getHandler(mockCloudIdentityClient)
+    await handler({ policyName: 'policies/akabc123' }, { authToken: 'token-abc' })
+
+    assert.strictEqual(getCalls, 1, 'getDlpRule should be called exactly once (no double policies.get)')
+    assert.strictEqual(preValidatedCalls, 1, 'deleteDlpRulePreValidated should be called once')
+    assert.strictEqual(validatedCalls, 0, 'deleteDlpRule (the re-validating path) should NOT be called')
+  })
+
   test('When rule is agent-created, then it deletes the rule and returns success message', async () => {
     let deleteCalled = false
     const mockCloudIdentityClient = {
       getDlpRule: async () => ({
         setting: { value: { displayName: '🤖 Agent Rule' } },
       }),
-      deleteDlpRule: async () => {
+      deleteDlpRulePreValidated: async () => {
         deleteCalled = true
         return {}
       },
@@ -47,7 +74,7 @@ describe('delete_agent_dlp_rule tool handler', () => {
     const handler = getHandler(mockCloudIdentityClient)
     const result = await handler({ policyName: 'policies/akabc123' }, { authToken: 'token-abc' })
 
-    assert.ok(deleteCalled, 'deleteDlpRule should have been called')
+    assert.ok(deleteCalled, 'deleteDlpRulePreValidated should have been called')
     assert.ok(result.content[0].text.includes('has been successfully deleted'))
     assert.ok(result.content[0].text.includes('policies/akabc123'))
   })
@@ -58,7 +85,7 @@ describe('delete_agent_dlp_rule tool handler', () => {
       getDlpRule: async () => ({
         setting: { value: { displayName: 'Manual Rule' } },
       }),
-      deleteDlpRule: async () => {
+      deleteDlpRulePreValidated: async () => {
         deleteCalled = true
         return {}
       },
@@ -67,7 +94,7 @@ describe('delete_agent_dlp_rule tool handler', () => {
     const handler = getHandler(mockCloudIdentityClient)
     const result = await handler({ policyName: 'policies/akabc123' }, { authToken: 'token-abc' })
 
-    assert.ok(!deleteCalled, 'deleteDlpRule should NOT have been called')
+    assert.ok(!deleteCalled, 'deleteDlpRulePreValidated should NOT have been called')
     assert.ok(result.content[0].text.includes('Admin Console'))
     assert.ok(
       result.content[0].text.includes('policies/akabc123') || result.content[0].text.includes('policies%2Fakabc123'),
@@ -83,7 +110,7 @@ describe('delete_agent_dlp_rule tool handler', () => {
       getDlpRule: async () => {
         throw notFoundError
       },
-      deleteDlpRule: async () => ({}),
+      deleteDlpRulePreValidated: async () => ({}),
     }
 
     const handler = getHandler(mockCloudIdentityClient)
@@ -102,7 +129,7 @@ describe('delete_agent_dlp_rule tool handler', () => {
       getDlpRule: async () => {
         throw notFoundError
       },
-      deleteDlpRule: async () => ({}),
+      deleteDlpRulePreValidated: async () => ({}),
     }
 
     const handler = getHandler(mockCloudIdentityClient)
@@ -121,7 +148,7 @@ describe('delete_agent_dlp_rule tool handler', () => {
       getDlpRule: async () => {
         throw transientError
       },
-      deleteDlpRule: async () => ({}),
+      deleteDlpRulePreValidated: async () => ({}),
     }
 
     const handler = getHandler(mockCloudIdentityClient)

--- a/tools/definitions/delete_agent_dlp_rule.js
+++ b/tools/definitions/delete_agent_dlp_rule.js
@@ -84,7 +84,7 @@ export function registerDeleteAgentDlpRuleTool(server, options, sessionState) {
           const isAgentCreated = displayName.startsWith(AGENT_DISPLAY_NAME_PREFIX)
 
           if (isAgentCreated) {
-            await cloudIdentityClient.deleteDlpRule(policyName, authToken)
+            await cloudIdentityClient.deleteDlpRulePreValidated(policyName, authToken)
             logger.debug(`${TAGS.MCP} Successfully deleted agent-created DLP rule: ${policyName}`)
           }
 


### PR DESCRIPTION
Closes #132.

`delete_agent_dlp_rule` was issuing two `policies.get` calls per successful delete:

1. The tool's own `getDlpRule` to read `setting.value.displayName` and verify the `AGENT_DISPLAY_NAME_PREFIX`.
2. A second `policies.get` inside `_deletePolicyWithValidation`, called via `deleteDlpRule`, to run an orthogonal trigger-based check.

Since the agent only ever creates rules with Chrome triggers, the second validator can never refuse a rule the prefix check approved.

## Changes

- `lib/api/real_cloud_identity_client.js`: add `deleteDlpRulePreValidated(policyName, authToken)` that goes straight to `policies.delete` without the get/validate step.
- `lib/api/interfaces/cloud_identity_client.js`: matching interface stub.
- `tools/definitions/delete_agent_dlp_rule.js`: use `deleteDlpRulePreValidated` since the tool already validated.
- `test/unit/tools/delete_agent_dlp_rule.test.js`: update mocks; add explicit regression test that asserts `deleteDlpRule` (the validated path) is **not** called and `deleteDlpRulePreValidated` **is**, and that `getDlpRule` is called exactly once.
- `test/local/cloudidentity.test.js`, `test/local/experiments/delete_tool.test.js`: update mocks to match the new method.

The original `deleteDlpRule` (with re-validation) stays for any caller that hasn't pre-checked.

## Test plan

- [x] `node --test test/unit/tools/delete_agent_dlp_rule.test.js` — 6/6 pass.
- [x] `node --test test/local/cloudidentity.test.js` — 12/12 pass.
- [x] `node --test test/local/experiments/delete_tool.test.js` — 4/4 pass.
- [x] Pre-push hook (full unit + smoke + integration:fake) — clean.
