### PR TITLE
[abandoned] fix(create_default_dlp_rules): null-guard result.response before reading .name

### DIFF
--- a/test/local/create_default_dlp_rules.test.js
+++ b/test/local/create_default_dlp_rules.test.js
@@ -195,4 +195,43 @@ describe('create_default_dlp_rules Tool', () => {
     assert.strictEqual(result.isError, true)
     assert.ok(result.content[0].text.includes('Authentication required'))
   })
+
+  test('When createDlpRule returns an in-progress LRO (no response field), then the rule lands in failedRules with a clear message', async () => {
+    const mockCreateDlpRule = mock.fn(async () => ({
+      // LRO not done: response is absent, only metadata + name of the operation
+      name: 'operations/abc',
+      done: false,
+    }))
+    const MockCloudIdentityClient = class {
+      constructor() {
+        this.createDlpRule = mockCreateDlpRule
+      }
+    }
+
+    const { registerTools } = await esmock(
+      '../../tools/index.js',
+      {},
+      {
+        '../../lib/api/real_cloud_identity_client.js': {
+          RealCloudIdentityClient: MockCloudIdentityClient,
+        },
+      },
+    )
+    registerTools(server, {
+      gcpCredentialsAvailable: true,
+      apiClients: { cloudIdentity: new MockCloudIdentityClient() },
+    })
+
+    const handler = server.registerTool.mock.calls.find(call => call.arguments[0] === 'create_default_dlp_rules')
+      .arguments[2]
+
+    const result = await handler({ customerId: 'C0123', orgUnitId: 'ou1' }, { requestInfo: {} })
+
+    // No rules should be reported as created — every attempt returned an in-progress LRO.
+    assert.strictEqual(result.structuredContent.successCount, 0)
+    assert.strictEqual(result.structuredContent.failedRules.length, 3)
+    for (const failed of result.structuredContent.failedRules) {
+      assert.match(failed.error, /did not return a completed policy/)
+    }
+  })
 })

--- a/tools/definitions/create_default_dlp_rules.js
+++ b/tools/definitions/create_default_dlp_rules.js
@@ -131,7 +131,12 @@ Rules included:
 
             try {
               const result = await cloudIdentityClient.createDlpRule(customerId, orgUnitId, ruleConfig, authToken)
-              const createdPolicy = result.response
+              const createdPolicy = result?.response
+              if (!createdPolicy?.name) {
+                throw new Error(
+                  `createDlpRule for "${rule.displayName}" did not return a completed policy (operation may still be in progress)`,
+                )
+              }
               ruleResults.push({
                 displayName: rule.displayName,
                 status: 'Created',


### PR DESCRIPTION
[abandoned]

Originally opened to address #133 by null-guarding `result.response` in `tools/definitions/create_default_dlp_rules.js` so an LRO with `done: false` would surface as a typed error instead of a TypeError. Real-world impact was zero since Cloud Identity's DLP rule create completes synchronously today.

Abandoned because the defence-in-depth fix is no longer being pursued in this form.