### PR TITLE
docs: style-pass batch on the docs/ folder against the Google docs style guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,21 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# docs
+# Documentation
 
-Reference documentation for operating and extending the Chrome Enterprise
-Premium MCP server. The root [`README.md`](../README.md) covers installation
-and connecting an MCP client; these docs cover what you need after the server
-is running.
+Reference documentation for operating and extending the Chrome Enterprise Premium MCP server. The root [`README.md`](../README.md) covers installation and connecting an MCP client. These docs cover what you need after the server is running.
 
-- [`configuration.md`](./configuration.md): environment variables and
-  stdio vs. HTTP transport.
-- [`troubleshooting.md`](./troubleshooting.md): auth, permissions, Node.js,
-  and MCP client integration issues with fixes.
-- [`architecture.md`](./architecture.md): code layout, client abstraction,
-  retry behavior, CEL validation.
-- [`faq.md`](./faq.md): license requirements, service accounts, experimental
-  features, and other recurring questions.
+- [`configuration.md`](./configuration.md): Environment variables, stdio and HTTP transport modes, and the per-mechanism authentication matrix.
+- [`troubleshooting.md`](./troubleshooting.md): Authentication, permission, Node.js, and MCP-client integration issues with their fixes.
+- [`architecture.md`](./architecture.md): Code layout, the client abstraction, retry behavior, and CEL validation.
+- [`faq.md`](./faq.md): License requirements, service accounts, experimental features, and other recurring questions.
+- [`auth-bring-your-own-oauth-client.md`](./auth-bring-your-own-oauth-client.md): How to create a Desktop OAuth client and run `mcp auth login`.
+- [`auth-cloud-run-and-gemini-enterprise.md`](./auth-cloud-run-and-gemini-enterprise.md): How to deploy the server behind Cloud Run with Gemini Enterprise.
 
-For contributing changes, see [`../CONTRIBUTING.md`](../CONTRIBUTING.md). For
-the test infrastructure, see [`../test/README.md`](../test/README.md).
+For contributing changes, see [`CONTRIBUTING.md`](../CONTRIBUTING.md). For the test infrastructure, see [`test/README.md`](../test/README.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,26 +37,14 @@ limitations under the License.
 
 ## Key design patterns
 
-- **Client abstraction.** Each Google API has an interface
-  (`lib/api/interfaces/`) and a real implementation (`lib/api/real_*.js`).
-  Tools program against the interface. For tests, we instantiate the same
-  `Real*Client` with a `rootUrl` override and a stub auth client to
-  redirect calls at the in-process fake server. See
-  [`lib/api/README.md`](../lib/api/README.md) for the full pattern.
-- **Structured tool output.** Tools return structured JSON with both
-  machine-readable data and human-readable summaries.
-- **Retry with backoff.** API calls retry on `PERMISSION_DENIED` (gRPC code 7)
-  to handle eventual consistency after enabling APIs.
-- **CEL validation.** DLP rule conditions are validated offline against the
-  Chrome CEL grammar before submission.
+- **Client abstraction.** Each Google API has an interface in `lib/api/interfaces/` and a real implementation in `lib/api/real_*.js`. Tool code calls the interface. For tests, the same `Real*Client` instance receives a `rootUrl` override and a stub auth client to redirect calls at the in-process fake server. For the full pattern, see [`lib/api/README.md`](../lib/api/README.md).
+- **Structured tool output.** Tools return structured JSON with both machine-readable data and a human-readable summary.
+- **Retry with backoff.** API calls retry on `PERMISSION_DENIED` (gRPC code 7) up to seven times to handle eventual consistency after enabling APIs. The first retry waits 15 seconds; subsequent retries use exponential backoff.
+- **CEL validation.** DLP rule conditions are validated offline against the Chrome CEL grammar before submission to Google.
 
 ## Test backends
 
-Tests and evals run against two backends, controlled by `CEP_BACKEND`:
+Tests and evals run against two backends, controlled by the `CEP_BACKEND` environment variable.
 
-- **Fake** (default for presubmit). An in-process Express server,
-  `test/helpers/fake-api-server.js`, that mimics all five Google APIs. The
-  real client classes are redirected at it via `rootUrl + fakeAuth`. No
-  network calls, no credentials needed.
-- **Real** (postsubmit). Calls the live Google APIs using your ADC
-  credentials. Requires authentication and API enablement.
+- **Fake** (default for presubmit). An in-process Express server at `test/helpers/fake-api-server.js` mimics the five Google APIs the server uses. The real client classes target it through a `rootUrl` override and a stub auth client. The fake backend makes no network calls and needs no credentials.
+- **Real** (postsubmit). The real client classes call the live Google APIs using your Application Default Credentials. The real backend requires authentication and the relevant APIs to be enabled.

--- a/docs/auth-cloud-run-and-gemini-enterprise.md
+++ b/docs/auth-cloud-run-and-gemini-enterprise.md
@@ -1,62 +1,54 @@
-# Hosting CEP MCP behind Cloud Run + Gemini Enterprise
+<!--
+Copyright 2026 Google LLC
 
-> **Use OAuth, not service-account + DWD.** OAuth is the recommended
-> auth path for new hosted deployments. Reference pattern: the
-> [ADK + OAuth + Gemini Enterprise article](https://fmind.medium.com/powering-up-your-agent-in-production-with-adk-oauth-and-gemini-enterprise-a52b0716fcba).
-> SA + DWD is the alternative when OAuth is not viable; the SA + DWD
-> setup is at the bottom.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Cloud Run and Gemini Enterprise deployment
+
+For hosted deployments, OAuth is the recommended authentication path. A service account with domain-wide delegation is the alternative when OAuth is not viable; the service account setup is at the end of this page.
 
 ## Recommended: OAuth bearer per request
 
-Two pieces:
+OAuth bearer per request has two parts.
 
-1. **Vertex AI Agent Engine handles OAuth consent.** Register your
-   OAuth client with Agent Engine; the registered redirect URI is
-   `https://vertexaisearch.cloud.google.com/oauth-redirect`. Agent
-   Engine receives the code, exchanges it for tokens, and forwards the
-   user's access token (or ID token) on every tool-call request to
-   your MCP server.
-2. **The MCP server verifies the inbound bearer.** In HTTP mode, set
-   `CEP_BEARER_AUDIENCE` to the OAuth client id you registered. Each
-   inbound request's `Authorization: Bearer <id-token>` is checked
-   against that audience ahead of any forward to Google. Failures get 401. Setup detail at
-   [`configuration.md#authenticating-to-google-apis`](configuration.md#authenticating-to-google-apis).
+The first part is the OAuth-handling layer. Vertex AI Agent Engine handles OAuth consent for you. You register your OAuth client with Agent Engine; the registered redirect URI is `https://vertexaisearch.cloud.google.com/oauth-redirect`. Agent Engine receives the authorization code, exchanges it for tokens, and forwards the user's access token (or ID token) on every tool-call request to your MCP server.
+
+The second part is inbound verification. In HTTP mode, set `CEP_BEARER_AUDIENCE` to the OAuth client ID you registered. The server then checks every inbound request's `Authorization: Bearer <id-token>` against that audience before forwarding to Google. Failures return `401 Unauthorized`. For configuration detail, see [`configuration.md`](configuration.md#authenticate-to-google-apis).
 
 ### Cloud Run setup sketch
 
 ```bash
-# Deploy the server.
 gcloud run deploy cep-mcp \
   --source=. \
   --region=us-central1 \
   --no-allow-unauthenticated \
-  --set-env-vars=GCP_STDIO=false,CEP_BEARER_AUDIENCE=<your-oauth-client-id>
+  --set-env-vars=GCP_STDIO=false,CEP_BEARER_AUDIENCE=YOUR_OAUTH_CLIENT_ID
 ```
 
-Register the OAuth client with Vertex AI Agent Engine via the Agent
-Engine console or CLI. The exact `create-auth` invocation lives in the
-Agent Engine docs; this MCP server needs `client-id`, `client-secret`,
-Google's standard `auth-uri` and `token-uri`, plus a scope list. Scope
-list: `OAUTH_SCOPES` from `lib/constants.js` (which excludes
-`cloud-platform`).
+Replace `YOUR_OAUTH_CLIENT_ID` with the client ID of the OAuth client you registered with Agent Engine.
+
+Register the OAuth client with Vertex AI Agent Engine through the Agent Engine console or its CLI. The exact `create-auth` invocation lives in the Agent Engine documentation. For this MCP server, the registration needs the OAuth client ID, the OAuth client secret, Google's standard authorization and token URIs, and a scope list. The scope list is `OAUTH_SCOPES` from `lib/constants.js`, which is the full `SCOPES` set minus `cloud-platform`.
+
+A reference walkthrough of an end-to-end ADK agent on Vertex AI Agent Engine with OAuth is the third-party blog post [Powering up your agent in production with ADK, OAuth, and Gemini Enterprise](https://fmind.medium.com/powering-up-your-agent-in-production-with-adk-oauth-and-gemini-enterprise-a52b0716fcba).
 
 ## Alternative: service account with domain-wide delegation
 
-For deployments where Agent Engine is unavailable or OAuth consent is
-not viable, SA + DWD is the alternative. Setup is the same as the
-[FAQ entry on service accounts](faq.md#can-i-use-a-service-account-instead-of-user-credentials);
-on Cloud Run, set `GOOGLE_APPLICATION_CREDENTIALS` to wherever the JSON
-key is mounted inside the container.
+For deployments where Agent Engine is unavailable or OAuth consent is not viable, a service account with domain-wide delegation is the alternative. The setup matches the [FAQ entry on service accounts](faq.md#can-i-use-a-service-account-instead-of-user-credentials). On Cloud Run, set `GOOGLE_APPLICATION_CREDENTIALS` to the path inside the container where the JSON key file is mounted.
 
-Caveat: SA + DWD grants the server impersonation rights for any user
-in the domain for the granted scopes. That is a broader trust grant
-than per-user OAuth. Use OAuth above when feasible.
+> [!CAUTION]
+> A service account with domain-wide delegation grants the server impersonation rights for any user in the domain for the granted scopes. The trust grant is broader than per-user OAuth. Choose the OAuth path when feasible.
 
-## Status today
+## Status
 
-The MCP server's bearer pass-through and ID-token verification are
-ready. Vertex AI Agent Engine's `create-auth` API is in private preview
-as of the article's publication; production wiring depends on your
-access. Until Agent Engine is generally available, the loopback OAuth
-flow (`mcp auth login`) is the workstation-only equivalent and is not
-a drop-in for hosted deployments.
+The MCP server's bearer pass-through and ID-token verification are ready in this codebase. Vertex AI Agent Engine's `create-auth` API is in private preview, so production wiring depends on whether the maintainer has access. Until Agent Engine reaches general availability, the loopback OAuth flow (`mcp auth login`) is the workstation-only equivalent and is not a drop-in for hosted deployments.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,13 +16,11 @@ limitations under the License.
 
 # Configuration
 
-The server is configured via environment variables. How you set them depends
-on which transport mode you are using.
+You configure the server with environment variables. How you set them depends on the transport mode.
 
 ## MCP client (stdio mode)
 
-Add variables to the `env` block of your client's settings file. The client
-injects them into the server's environment on startup.
+Add the variables to the `env` block of your MCP client's settings file. The client injects them into the server's environment on startup.
 
 ```json
 {
@@ -41,8 +39,7 @@ injects them into the server's environment on startup.
 
 ## Standalone (HTTP mode)
 
-You can pass variables inline or load them from a `.env` file in your working
-directory. See [`.env.example`](../.env.example) for the full set of options.
+You can pass variables inline on the command line or load them from a `.env` file in your working directory. For the full set of options, see [`.env.example`](../.env.example).
 
 ```bash
 PORT=8080 GCP_STDIO=false npx -y @google/chrome-enterprise-premium-mcp@latest
@@ -50,46 +47,31 @@ PORT=8080 GCP_STDIO=false npx -y @google/chrome-enterprise-premium-mcp@latest
 
 ## Key variables
 
-| Variable                     | Description                                                                                                                                                                                                                                 | Default |
-| :--------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :------ |
-| `GCP_STDIO`                  | `true` for Stdio (local); `false` for HTTP (remote).                                                                                                                                                                                        | `true`  |
-| `PORT`                       | Network port when `GCP_STDIO=false`.                                                                                                                                                                                                        | `0`     |
-| `GOOGLE_CLOUD_QUOTA_PROJECT` | GCP project ID for API quotas.                                                                                                                                                                                                              | -       |
-| `LOG_LEVEL`                  | Verbosity (`error`, `warn`, `info`, `debug`).                                                                                                                                                                                               | `info`  |
-| `CEP_BEARER_AUDIENCE`        | When set in HTTP mode: every inbound request must carry an `Authorization: Bearer <id-token>` whose `aud` claim is in this value (comma-separated for multiple). When unset: ID-token verification is off and a startup warning is printed. | -       |
+| Variable                     | Description                                                                                                                                                                                                                                        | Default |
+| :--------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------ |
+| `GCP_STDIO`                  | `true` for stdio (local), `false` for HTTP (remote).                                                                                                                                                                                               | `true`  |
+| `PORT`                       | Network port when `GCP_STDIO=false`.                                                                                                                                                                                                               | `0`     |
+| `GOOGLE_CLOUD_QUOTA_PROJECT` | Google Cloud project ID for API quotas.                                                                                                                                                                                                            | -       |
+| `LOG_LEVEL`                  | Verbosity. One of `error`, `warn`, `info`, `debug`.                                                                                                                                                                                                | `info`  |
+| `CEP_BEARER_AUDIENCE`        | When set in HTTP mode, every inbound request must carry an `Authorization: Bearer <id-token>` whose `aud` claim is in this value (comma-separated for multiple). When unset, ID-token verification is off and the server prints a startup warning. | -       |
 
 > [!NOTE]
-> When `GCP_STDIO=false` and `PORT` is unset or `0`, the server binds to a
-> random available port. The actual port is logged at startup, e.g.
-> `Chrome Enterprise Premium MCP server listening on port X`.
+> When `GCP_STDIO=false` and `PORT` is unset or `0`, the server binds to a random available port. The actual port is logged at startup, for example: `Chrome Enterprise Premium MCP server listening on port X`.
 
-## Authenticating to Google APIs
+## Authenticate to Google APIs
 
-`lib/util/auth.js#getAuthClient` has three credential sources, in priority
-order: bearer header on the request, Application Default Credentials, OAuth
-token cache. Pick a setup based on environment. For situational guidance by
-deployment shape, see the
-[Which auth path should I use?](faq.md#which-auth-path-should-i-use) FAQ
-entry.
+`lib/util/auth.js#getAuthClient` resolves credentials in this priority order: a bearer header on the request, Application Default Credentials, then the OAuth token cache. Pick a setup based on your environment. For situational guidance by deployment shape, see the [Which auth path should I use?](faq.md#which-auth-path-should-i-use) FAQ entry.
 
 | Setup                      | Transport | Credential source                              | Setup walkthrough                                                                               |
 | :------------------------- | :-------- | :--------------------------------------------- | :---------------------------------------------------------------------------------------------- |
 | `gcloud` ADC (recommended) | stdio     | ADC, full scope set including `cloud-platform` | [Quick Start §1](../README.md#1-authenticate-with-google-cloud)                                 |
 | OAuth login (workstation)  | stdio     | OAuth token cache, narrow scope set            | [`auth-bring-your-own-oauth-client.md`](auth-bring-your-own-oauth-client.md)                    |
-| Bearer pass-through        | HTTP      | per-request `Authorization: Bearer <token>`    | The caller sets the header; the server forwards it to Google verbatim                           |
-| Service account + DWD      | stdio     | service account with domain-wide delegation    | [FAQ entry on service accounts](faq.md#can-i-use-a-service-account-instead-of-user-credentials) |
+| Bearer pass-through        | HTTP      | per-request `Authorization: Bearer <token>`    | The caller sets the header; the server forwards it to Google verbatim.                          |
+| Service account + DWD      | stdio     | Service account with domain-wide delegation    | [FAQ entry on service accounts](faq.md#can-i-use-a-service-account-instead-of-user-credentials) |
 
 > [!IMPORTANT]
-> HTTP-mode default: no network-layer auth. Bind the port to a trusted
-> interface only, or set `CEP_BEARER_AUDIENCE` (HTTP mode only) for
-> per-request ID-token verification.
+> The HTTP-mode default has no network-layer authentication. Bind the listener to a trusted interface only, or set `CEP_BEARER_AUDIENCE` (HTTP mode only) for per-request ID-token verification.
 
 ### Inbound bearer ID-token verification (HTTP mode)
 
-For HTTP-mode deployments behind an OAuth-bearing caller (e.g., Vertex AI
-Agent Engine), set `CEP_BEARER_AUDIENCE` to the OAuth client id whose ID
-token issuance is allowed for this server. With it set, every inbound
-request must carry `Authorization: Bearer <id-token>`, and the token's
-`aud` claim is checked against `CEP_BEARER_AUDIENCE`. Failures get 401
-ahead of any forward to Google. When `CEP_BEARER_AUDIENCE` is unset, the
-check is off and a startup warning is printed.
+For HTTP-mode deployments behind an OAuth-bearing caller, such as Vertex AI Agent Engine, set `CEP_BEARER_AUDIENCE` to the OAuth client ID whose ID-token issuance is allowed for this server. With it set, every inbound request must carry `Authorization: Bearer <id-token>`, and the server checks the token's `aud` claim against `CEP_BEARER_AUDIENCE`. Failures return `401 Unauthorized` ahead of any forward to Google. When `CEP_BEARER_AUDIENCE` is unset, the check is off and the server prints a startup warning.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -30,7 +30,7 @@ The right path depends on your environment.
 
 - **Workstation, gcloud installed, you are a Google Cloud admin for the project:** Application Default Credentials. Run `gcloud auth application-default login` per the [Quick Start](../README.md#1-authenticate-with-google-cloud).
 - **Workstation, no gcloud or you are not a Google Cloud admin:** OAuth login. Run `mcp auth login`. For the setup walkthrough, see [`auth-bring-your-own-oauth-client.md`](auth-bring-your-own-oauth-client.md).
-- **Hosted (Cloud Run, Vertex AI Agent Engine, and similar):** OAuth bearer per request. The caller sets `Authorization: Bearer <id-token>` and the server verifies the token's `aud` claim against `CEP_BEARER_AUDIENCE`. A service account with domain-wide delegation is the alternative; for new hosted deployments, OAuth is preferred because a service account with domain-wide delegation grants the server impersonation rights for any user in the domain.
+- **Hosted on Cloud Run, Vertex AI Agent Engine, or a similar managed environment:** OAuth bearer per request. The caller sets `Authorization: Bearer <id-token>` and the server verifies the token's `aud` claim against `CEP_BEARER_AUDIENCE`. A service account with domain-wide delegation is the alternative. OAuth is preferred for hosted deployments because a service account with domain-wide delegation grants the server impersonation rights for any user in the domain.
 
 For the per-mechanism technical reference (transport, credential source, setup walkthrough), see the [authentication matrix](configuration.md#authenticate-to-google-apis) in `configuration.md`.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -18,64 +18,36 @@ limitations under the License.
 
 ## Do I need a Chrome Enterprise Premium license?
 
-Yes. DLP rules, content detectors, Chrome connectors, and threat protection
-are CEP features. They require an active Chrome Enterprise Premium license
-[assigned to the relevant users](https://docs.cloud.google.com/chrome-enterprise-premium/docs/overview).
-Without it, most tools will return permission errors. A 60-day free trial is
-available from the Admin Console or Cloud Console.
+Yes, you need an active Chrome Enterprise Premium license assigned to the relevant users. DLP rules, content detectors, Chrome connectors, and threat protection are all Chrome Enterprise Premium features. Without the license, most tools return permission errors. A 60-day trial is available; see the [Chrome Enterprise Premium overview](https://docs.cloud.google.com/chrome-enterprise-premium/docs/overview) for the trial and license details.
 
 ## Which Google Workspace edition do I need?
 
-Chrome Enterprise Premium is a paid add-on available with any Google
-Workspace edition. Chrome Enterprise Core (free) provides policy management
-for over 300 policies but does not include DLP, threat protection, or
-Context-Aware Access. See
-[Chrome Enterprise Premium pricing](https://docs.cloud.google.com/chrome-enterprise-premium/docs/overview)
-for current rates.
+Chrome Enterprise Premium is a paid add-on available with any Google Workspace edition. Chrome Enterprise Core, which is included with Google Cloud at no additional cost, provides policy management for over 300 Chrome policies but does not include DLP, threat protection, or Context-Aware Access. For pricing details, see the [Chrome Enterprise Premium overview](https://docs.cloud.google.com/chrome-enterprise-premium/docs/overview).
 
 ## Which auth path should I use?
 
-Three paths, by environment:
+The right path depends on your environment.
 
-- **Workstation, gcloud installed, you're the Cloud admin:** ADC. Run
-  `gcloud auth application-default login` per the
-  [Quick Start](../README.md#1-authenticate-with-google-cloud).
-- **Workstation, no gcloud or not the Cloud admin:** OAuth flow. Run
-  `mcp auth login`. Setup walkthrough at
-  [`docs/auth-bring-your-own-oauth-client.md`](auth-bring-your-own-oauth-client.md).
-- **Hosted (Cloud Run, Vertex AI Agent Engine, etc.):** OAuth bearer
-  on each request. The caller sets `Authorization: Bearer <id-token>`;
-  the server verifies via `CEP_BEARER_AUDIENCE`. SA + DWD is the
-  alternative (see the next entry); for new hosted deployments, OAuth
-  is preferred because SA + DWD grants the server impersonation rights
-  for any user in the domain.
+- **Workstation, gcloud installed, you are a Google Cloud admin for the project:** Application Default Credentials. Run `gcloud auth application-default login` per the [Quick Start](../README.md#1-authenticate-with-google-cloud).
+- **Workstation, no gcloud or you are not a Google Cloud admin:** OAuth login. Run `mcp auth login`. For the setup walkthrough, see [`auth-bring-your-own-oauth-client.md`](auth-bring-your-own-oauth-client.md).
+- **Hosted (Cloud Run, Vertex AI Agent Engine, and similar):** OAuth bearer per request. The caller sets `Authorization: Bearer <id-token>` and the server verifies the token's `aud` claim against `CEP_BEARER_AUDIENCE`. A service account with domain-wide delegation is the alternative; for new hosted deployments, OAuth is preferred because a service account with domain-wide delegation grants the server impersonation rights for any user in the domain.
 
-For the per-mechanism technical reference (transport, credential source,
-setup walkthrough), see the
-[Authentication matrix](configuration.md#authenticating-to-google-apis)
-in `configuration.md`.
+For the per-mechanism technical reference (transport, credential source, setup walkthrough), see the [authentication matrix](configuration.md#authenticate-to-google-apis) in `configuration.md`.
 
 ## Can I use a service account instead of user credentials?
 
-Yes, but the service account must have
-[domain-wide delegation](https://developers.google.com/identity/protocols/oauth2/service-account#delegatingauthority)
-configured in the Admin Console with the required scopes. Set
-`GOOGLE_APPLICATION_CREDENTIALS` to point to the key file.
+Yes. The service account must have [domain-wide delegation](https://developers.google.com/identity/protocols/oauth2/service-account#delegatingauthority) configured in the Admin Console with the required scopes. Set `GOOGLE_APPLICATION_CREDENTIALS` to the path of the service account key file.
 
-## Why do I see "Retrying in 15s..." on first use?
+## Why do I see "Retrying in 15s..." on the first call?
 
-Newly enabled APIs take a few minutes to propagate. The server retries
-automatically. Normal on first run; should resolve within a minute or two.
+Newly enabled APIs take a few minutes to propagate. The server retries `PERMISSION_DENIED` (gRPC code 7) up to seven times automatically; the first retry waits 15 seconds. The behavior is normal on first run and resolves within a minute or two.
 
 ## How do I enable experimental features?
 
-Some tools (e.g., deletion of DLP rules and detectors) are gated behind
-feature flags and disabled by default. Enable them with `EXPERIMENT_`-prefixed
-environment variables:
+Some tools, such as deletion of DLP rules and detectors, are gated behind feature flags and disabled by default. Enable them with `EXPERIMENT_`-prefixed environment variables.
 
 ```bash
 EXPERIMENT_DELETE_TOOL_ENABLED=true npm start
 ```
 
-See [`lib/util/feature_flags.js`](../lib/util/feature_flags.js) for the full
-list.
+For the full list of feature flags, see [`lib/util/feature_flags.js`](../lib/util/feature_flags.js).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -20,81 +20,55 @@ limitations under the License.
 
 ### "Could not load the default credentials"
 
-ADC is not configured. Run the login command from the
-[Quick Start](../README.md#1-authenticate-with-google-cloud). Verify
-credentials exist afterward:
+Your Application Default Credentials are not configured. Run the login command from the [Quick Start](../README.md#1-authenticate-with-google-cloud), then verify the credentials file exists:
 
 ```bash
 cat ~/.config/gcloud/application_default_credentials.json
 ```
 
-If the file does not exist, login did not complete (check for a browser popup
-you may have missed).
+If the file does not exist, the login did not complete; check whether your browser opened a consent tab that you missed.
 
 ### "Request had insufficient authentication scopes"
 
-We created credentials without the required scopes, usually because
-`gcloud auth application-default login` was run without `--scopes`. The
-default scope (`cloud-platform`) does not cover Workspace APIs like Admin SDK
-or Chrome Management. Delete and re-create credentials:
+The credentials lack the required scopes. The most common cause is running `gcloud auth application-default login` without the `--scopes` flag; the default scope (`cloud-platform`) does not cover Workspace APIs such as the Admin SDK or Chrome Management. You cannot add scopes to existing ADC credentials, so delete and re-create them:
 
 ```bash
 rm ~/.config/gcloud/application_default_credentials.json
 ```
 
-Then re-run the full login command from the
-[Quick Start](../README.md#1-authenticate-with-google-cloud). You cannot add
-scopes to existing ADC credentials.
+Then re-run the full login command from the [Quick Start](../README.md#1-authenticate-with-google-cloud).
 
 ### "API requires a quota project, which is not set by default"
 
-Google needs to know which project's API quotas and enablement to use. This
-error appears on the first API call, not at login:
+Google needs to know which project's API quotas and enablement to use. The error appears on the first API call, not at login:
 
 ```bash
 gcloud auth application-default set-quota-project YOUR_PROJECT_ID
 ```
 
-If you are unsure which project to use, run `gcloud projects list` and pick
-the one linked to your Workspace domain.
+Replace `YOUR_PROJECT_ID` with your Google Cloud project ID. If you do not know which project to use, run `gcloud projects list` and pick the one linked to your Workspace domain.
 
 ### "invalid_grant" or "Token has been revoked"
 
-Cached credentials are stale. Common causes: password change, admin revoked
-access, MFA re-enrollment, or token expired after seven days of inactivity.
-Delete `~/.config/gcloud/application_default_credentials.json` and
-re-authenticate.
+Cached credentials are stale. Common causes are a password change, an admin revoking access, MFA re-enrollment, or the token expiring after seven days of inactivity. Delete `~/.config/gcloud/application_default_credentials.json` and re-authenticate.
 
-### `gcloud` is installed but `gcloud auth` fails with "command not found"
+### `gcloud` is installed but `gcloud auth` fails
 
-Your shell can find `gcloud` but not the auth component. Run
-`gcloud components install` or reinstall the Cloud SDK. On macOS with
-Homebrew, `brew install google-cloud-sdk` sometimes does not add auth
-components; use the
-[official installer](https://cloud.google.com/sdk/docs/install) instead.
+Your shell can find a `gcloud` binary but the auth subcommand does not run as expected. Check that `which gcloud` points at the binary you intend, and confirm with `gcloud version` that the install is recent. If the install looks broken, reinstall the Cloud SDK from the [official installer](https://docs.cloud.google.com/sdk/docs/install).
 
 ## Permissions
 
 ### "The caller does not have permission" (403)
 
-This is almost always one of three things:
+The cause is almost always one of three things.
 
-1. **API not enabled.** Run the `gcloud services enable` command from the
-   [Quick Start](../README.md#2-enable-required-apis). Most common cause on
-   first setup.
-2. **Missing Workspace admin role.** Chrome and Admin SDK APIs require a
-   Google Workspace admin role (Super Admin or delegated) configured in the
-   [Admin Console](https://admin.google.com/) > Account > Admin roles. GCP
-   IAM roles alone are not sufficient for Workspace APIs.
-3. **Missing GCP IAM role.** The user needs roles on the GCP project itself
-   (e.g., `roles/browser.admin`, `roles/serviceusage.serviceUsageAdmin`).
+1. **An API is not enabled.** Run the `gcloud services enable` command from the [Quick Start](../README.md#2-enable-required-apis). This is the most common cause on first setup.
+2. **A Workspace admin role is missing.** Chrome Management and Admin SDK APIs require a Google Workspace admin role (Super Admin or delegated) configured in the [Admin Console](https://admin.google.com/) under **Account > Admin roles**. Google Cloud IAM roles alone are not sufficient for Workspace APIs.
+3. **A Google Cloud IAM role is missing.** The user needs roles on the Google Cloud project itself, such as `roles/browser.admin` or `roles/serviceusage.serviceUsageAdmin`.
 
 ### "PERMISSION_DENIED" followed by retries
 
-Normal on first run. The server retries `PERMISSION_DENIED` (gRPC code 7) up
-to seven times with exponential backoff; the first retry waits 15 seconds.
-This handles propagation delay after enabling APIs. If retries exhaust, the
-permission issue is real; check the three items above.
+This is normal on first run. The server retries `PERMISSION_DENIED` (gRPC code 7) up to seven times with exponential backoff; the first retry waits 15 seconds. The behavior handles propagation delay after enabling APIs. If retries exhaust, the permission issue is real; check the three items in the previous section.
 
 ## Node.js
 
@@ -104,40 +78,24 @@ Dependencies are missing. Run `npm install` from the project root.
 
 ### "ExperimentalWarning: ... is an experimental feature"
 
-Harmless. Some Node.js features used by dependencies emit warnings on older
-Node versions. Upgrade to Node 20+ to suppress, or ignore them; they do not
-affect functionality.
+These warnings are harmless. Some Node.js features used by dependencies emit warnings on older Node versions. Upgrade to Node 20 or later to suppress them, or ignore them; they do not affect functionality.
 
 ### Wrong Node version
 
-The server requires Node >= 18. Check with `node --version`. If you use
-[nvm](https://github.com/nvm-sh/nvm), make sure you have run `nvm use 18` (or
-higher) in the project directory. MCP clients launch `node` as a subprocess —
-they use whatever `node` is on the system PATH, which may differ from your
-shell's `nvm`-managed version.
+The server requires Node 18 or later. Check with `node --version`. If you use [nvm](https://github.com/nvm-sh/nvm), run `nvm use 18` (or later) in the project directory. MCP clients launch `node` as a subprocess and use whatever `node` is on the system PATH, which can differ from the version your shell's `nvm` is currently selecting.
 
 ## MCP client integration
 
 ### Tools do not appear in the client
 
-1. **Restart the client** after editing its config file; most clients do not
-   hot-reload MCP config.
-2. **Run the client's MCP-reload command.** In Gemini CLI, type `/mcp` and
-   reload. Some clients pick up new tool registrations only after an explicit
-   reload, even after a restart.
-3. **Use absolute paths.** The `args` path in your config must be absolute.
-   Relative paths resolve from the client's working directory, which is
-   unpredictable.
-4. **Check `node` visibility.** GUI apps (Claude Desktop, VS Code) may not
-   inherit your shell PATH. Try the full path to node:
-   `"command": "/usr/local/bin/node"` (find yours with `which node`).
-5. **Test manually.** Run
-   `npx -y @google/chrome-enterprise-premium-mcp@latest` in a terminal. You
-   should see
-   `[mcp] Chrome Enterprise Premium MCP server stdio transport connected` on
-   stderr. If you see errors, fix those first.
+Try these in order.
+
+1. **Restart the client** after editing its config file. Most clients do not hot-reload MCP configuration.
+2. **Run the client's MCP-reload command.** In Gemini CLI, type `/mcp` and reload. Some clients pick up new tool registrations only after an explicit reload, even after a restart.
+3. **Use absolute paths.** The `args` path in your config must be absolute. Relative paths resolve from the client's working directory, which is unpredictable.
+4. **Check that the client can find `node`.** GUI apps such as Claude Desktop and VS Code may not inherit your shell PATH. Try the full path to node, for example `"command": "/usr/local/bin/node"`. Find yours with `which node`.
+5. **Test the server manually.** Run `npx -y @google/chrome-enterprise-premium-mcp@latest` in a terminal. You should see `[mcp] Chrome Enterprise Premium MCP server stdio transport connected` on standard error. If you see errors, fix those first.
 
 ### Server starts but immediately exits
 
-Check stderr output. Common causes: missing `.env` values the server expects,
-or a port conflict if you accidentally ran in HTTP mode (`GCP_STDIO=false`).
+Check standard-error output. The most common causes are missing `.env` values that the server expects, or a port conflict if you ran the server in HTTP mode (`GCP_STDIO=false`) by accident.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -82,7 +82,7 @@ These warnings are harmless. Some Node.js features used by dependencies emit war
 
 ### Wrong Node version
 
-The server requires Node 18 or later. Check with `node --version`. If you use [nvm](https://github.com/nvm-sh/nvm), run `nvm use 18` (or later) in the project directory. MCP clients launch `node` as a subprocess and use whatever `node` is on the system PATH, which can differ from the version your shell's `nvm` is currently selecting.
+The server requires Node 18 or later. Check with `node --version`. If you use [nvm](https://github.com/nvm-sh/nvm), run `nvm use 18` (or later) in the project directory. MCP clients launch `node` as a subprocess and use whatever `node` is on the system PATH, which can differ from the version your shell's `nvm` selects.
 
 ## MCP client integration
 
@@ -91,10 +91,10 @@ The server requires Node 18 or later. Check with `node --version`. If you use [n
 Try these in order.
 
 1. **Restart the client** after editing its config file. Most clients do not hot-reload MCP configuration.
-2. **Run the client's MCP-reload command.** In Gemini CLI, type `/mcp` and reload. Some clients pick up new tool registrations only after an explicit reload, even after a restart.
+2. **Run the client's MCP-reload command.** Some clients pick up tool registrations only after an explicit reload, even after a restart. Consult your client's documentation for the reload command.
 3. **Use absolute paths.** The `args` path in your config must be absolute. Relative paths resolve from the client's working directory, which is unpredictable.
-4. **Check that the client can find `node`.** GUI apps such as Claude Desktop and VS Code may not inherit your shell PATH. Try the full path to node, for example `"command": "/usr/local/bin/node"`. Find yours with `which node`.
-5. **Test the server manually.** Run `npx -y @google/chrome-enterprise-premium-mcp@latest` in a terminal. You should see `[mcp] Chrome Enterprise Premium MCP server stdio transport connected` on standard error. If you see errors, fix those first.
+4. **Check that the client can find `node`.** Graphical-interface clients might not inherit your shell PATH. Try the full path to node, for example `"command": "/usr/local/bin/node"`. Find yours with `which node`.
+5. **Test the server manually.** Run `npx -y @google/chrome-enterprise-premium-mcp@latest` in a terminal. The server prints `[mcp] Chrome Enterprise Premium MCP server stdio transport connected` on standard error. If you see errors, fix those first.
 
 ### Server starts but immediately exits
 


### PR DESCRIPTION
Style-pass + factual-accuracy pass on every file in `docs/` except `auth-bring-your-own-oauth-client.md`, which is in PR #143.

## Per-file commits

- `f798afc` `docs(readme)`: index now uses sentence-case title, complete-sentence bullets, and lists every file in the directory (the BYO and Cloud Run docs were missing).
- `5dd0a0d` `docs(architecture)`: replaced first-person "we" with named actor; the retry-policy paragraph now states the actual numbers ("up to seven times", "first retry waits 15 seconds"); spelled out "Application Default Credentials".
- `ecd1e8f` `docs(configuration)`: heading "Authenticating to Google APIs" → "Authenticate to Google APIs" (verb base form); `e.g.,` → `such as`; `401` → `401 Unauthorized`; tightened first-person framing.
- `3270dc1` `docs(faq)`: `should resolve` → `resolves`; `e.g.` → `such as`; matched Google's official wording on the 60-day trial; cleaned the auth-path bullets.
- `b0c89e6` `docs(troubleshooting)`: removed misleading Homebrew-specific guidance (gcloud auth is a core subcommand, not a separately installable component); folded cute fragments ("Harmless.", "Normal on first run.") into sentences; clarified Node-version messaging (requirement 18+, suppression 20+).
- `28f5411` `docs(auth-cloud-run...)`: title is sentence-case noun phrase; license header added; time-anchored phrasing removed; "Use OAuth above" directional language gone; HTTP status code formatted with name.
- `3037de9` `docs: remove specific app names; drop time-anchored words`: removed third-party app names (a CLI tool, two desktop clients) and the words `currently` and `new` per the style guide's banned-time-anchor list and the team's preference not to name specific third-party apps.

## Factual claims verified before changes

| Claim | Verified against | Status |
|---|---|---|
| Retry: up to seven times, first retry 15 s | `lib/constants.js#DEFAULT_CONFIG` | confirmed |
| `CEP_BEARER_AUDIENCE` checked at the inbound boundary | `mcp-server.js:394` | confirmed |
| `OAUTH_SCOPES` is `SCOPES` minus `cloud-platform` | `lib/constants.js`, PR #120 (merged 2026-05-04) | confirmed |
| 60-day trial of Chrome Enterprise Premium | https://docs.cloud.google.com/chrome-enterprise-premium/docs/overview | confirmed |
| Chrome Enterprise Core supports over 300 policies | Google Cloud Blog | confirmed |
| Node engine requirement | `package.json#engines.node = ">=18.0.0"` | confirmed |
| `cloud.google.com` 301-redirects to `docs.cloud.google.com` for these paths | Live HTTP fetch | confirmed |

## What's not changed

- The Apache license headers stay verbatim in every file (the only "may" hits in the docs are inside the license boilerplate).
- File paths, env-var names, and code examples are unchanged.
- The third-party Medium link in `auth-cloud-run-and-gemini-enterprise.md` is kept; it is the only end-to-end ADK + OAuth + Vertex AI Agent Engine walkthrough I could find. It is labeled in-line as a third-party blog post.

## Test plan

- [x] `npx prettier --check docs/` is clean.
- [x] `grep -nE "\bvia\b|\bcurrently\b|...|in order to|utilize" docs/*.md | grep -v "license boilerplate"` returns no hits.
- [x] No specific third-party app names appear in any doc except the `@google/chrome-enterprise-premium-mcp` package itself, Google products in scope (Vertex AI Agent Engine, Cloud Run, Gemini Enterprise, Workspace Admin Console), and the third-party Medium link explicitly marked as such.

## Related

PR #143 already covers `docs/auth-bring-your-own-oauth-client.md` with the same style pass plus the modern Auth Platform Clients flow. Merge order: either PR can land first; they touch different files.