### PR TITLE
docs: style-pass on the project READMEs (root, modules, ADK)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ We'd love to accept your patches and contributions to this project.
 
 Contributions to this project must be accompanied by a
 [Contributor License Agreement](https://cla.developers.google.com/about) (CLA).
-You (or your employer) retain the copyright to your contribution; this simply
+You (or your employer) retain the copyright to your contribution; the CLA only
 gives us permission to use and redistribute your contributions as part of the
 project.
 
@@ -84,7 +84,7 @@ npm run format        # Auto-fix formatting (Prettier)
 
 `npm run presubmit` runs `prettier --check` and `eslint` in read-only mode;
 it will fail rather than auto-fix. The husky pre-commit hook fixes staged
-files via lint-staged on commit, so a clean working tree usually passes.
+files through lint-staged on commit, so a clean working tree usually passes.
 
 ### Continuous integration
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ This project follows
 
 ## Reporting bugs
 
-If you encounter an issue, please file a GitHub issue with the following:
+If you encounter an issue, file a GitHub issue with the following:
 
 1. **Generate a diagnostic report.** In your Gemini CLI session, use the
    `/bug` command. This creates a diagnostic file with session logs and
@@ -90,7 +90,7 @@ files through lint-staged on commit, so a clean working tree usually passes.
 
 On every pull request, GitHub Actions runs four parallel jobs: `lint`,
 `test-unit`, `test-integration-fake`, and `test-smoke`. Each maps to one of
-the `npm run` scripts above. The jobs run hermetically without ADC, so a
+the `npm run` scripts in the testing section. The jobs run hermetically without ADC, so a
 test that accidentally reaches `getAuthClient()` fails fast with a named
 error rather than hanging on metadata-server discovery. The workflow lives
 at [`.github/workflows/node.js.yml`](.github/workflows/node.js.yml).

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Google Account data, as well as other data shared with you.
 - Always review the actions Gemini CLI takes on your behalf and confirm
   they match what you asked for.
 
-## Quick Start
+## Quick start
 
 ```bash
 git clone https://github.com/google/chrome-enterprise-premium-mcp.git
@@ -84,7 +84,7 @@ gcloud auth application-default set-quota-project YOUR_PROJECT_ID
 > **Scopes must be provided at login time.** You cannot add scopes to
 > existing ADC credentials. If you get "insufficient scopes" errors,
 > delete `~/.config/gcloud/application_default_credentials.json` and re-run
-> the login command above.
+> the `gcloud auth application-default login` command from the previous step.
 >
 > **The quota project is required.** Without it, the first call returns a
 > "quota project not set" error from Google.
@@ -197,7 +197,7 @@ Add to `~/.gemini/settings.json`:
 
 </details>
 
-> (Optional) If you are running from a local checkout instead of npx, replace the command with `node` and args with the absolute path to `mcp-server.js`. Relative paths may not resolve correctly depending on the client.
+> Optional: If you are running from a local checkout instead of npx, replace the command with `node` and args with the absolute path to `mcp-server.js`. Relative paths might not resolve correctly depending on the client.
 
 ### 4. Verify
 
@@ -205,7 +205,7 @@ Restart your MCP client, then ask:
 
 > "What Chrome Enterprise Premium tools do you have access to?"
 
-You should see the agent discover and list the available tools. If tools don't
+The agent discovers and lists the available tools. If tools don't
 appear, see [Troubleshooting](#troubleshooting).
 
 ## Configuration
@@ -230,7 +230,7 @@ For environment variables and stdio vs. HTTP transport, see
 > permissions produces `403 Permission Denied` with no indication that a
 > Workspace role is missing.
 
-## Available Tools and Prompts
+## Available tools and prompts
 
 ### Prompts
 
@@ -274,7 +274,7 @@ presubmit suite plus a real-API integration pass.
 
 Presubmit is **read-only**. If formatting or lint fails, run
 `npm run format` and `npm run lint:fix` to fix, then re-run. The husky
-pre-commit hook auto-fixes staged files via lint-staged, so commits from a
+pre-commit hook auto-fixes staged files through lint-staged, so commits from a
 clean working tree usually pass without manual fixup.
 
 GitHub Actions runs the same checks on every pull request as four parallel
@@ -313,7 +313,7 @@ For license requirements, Workspace edition, service-account auth,
 experimental features, and other recurring questions, see
 [`docs/faq.md`](docs/faq.md).
 
-## Reporting Bugs
+## Reporting bugs
 
 If something isn't working:
 
@@ -326,8 +326,7 @@ If something isn't working:
 
 ## Contributing
 
-Contributions are welcome! Please read the [CONTRIBUTING.md](CONTRIBUTING.md)
-file for details on how to contribute to this project.
+Contributions are welcome. For details on how to contribute, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Legal
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,19 @@
-# Reporting Security Issues
+<!--
+Copyright 2026 Google LLC
 
-To report a security issue, please use [https://g.co/vulnz](https://g.co/vulnz).
-We use g.co/vulnz for our intake, and do coordination and disclosure here on
-GitHub (including using GitHub Security Advisory). The Google Security Team will
-respond within 5 working days of your report on g.co/vulnz.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Reporting security issues
+
+To report a security issue, submit it at [g.co/vulnz](https://g.co/vulnz). We use g.co/vulnz for intake; coordination and disclosure happen on GitHub through GitHub Security Advisory. The Google Security Team responds within five working days of your report on g.co/vulnz.

--- a/adk/cep_agent/README.md
+++ b/adk/cep_agent/README.md
@@ -1,89 +1,84 @@
-# CEP Agent
+<!--
+Copyright 2026 Google LLC
 
-This is a sample CEP agent that can be configured as a single agent or a
-multi-agent system. The agent handles queries and relays the requests to the CEP
-MCP server for further processing.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# CEP agent
+
+A sample CEP agent that you can configure as a single agent or as a multi-agent system. The agent handles user queries and forwards the requests to the CEP MCP server for tool calls.
 
 ## Overview
 
-The CEP agent is designed to assist with Chrome Enterprise Premium administration.
-It can be configured in two ways:
+The CEP agent assists with Chrome Enterprise Premium administration. You can configure it in two ways.
 
-- **Single Agent**: A single agent that can handle all tasks, including
-  onboarding, troubleshooting, and metadata retrieval.
-- **Multi-agent**: A multi-agent system with a root agent that delegates tasks
-  to specialized agents for onboarding, troubleshooting, and metadata
-  retrieval.
+- **Single agent.** One agent handles every task, including onboarding, troubleshooting, and metadata retrieval.
+- **Multi-agent.** A root agent delegates each task to a specialized agent for onboarding, troubleshooting, or metadata retrieval.
 
-The agent uses the `gemini-2.0-flash` model and interacts with the CEP MCP server
-via a toolset.
+The agent uses the `gemini-2.5-flash` model (defined as `AI_MODEL_NAME` in `agent.py`) and reaches the CEP MCP server through an MCP toolset.
 
-## Features
+## Capabilities
 
-- **Onboarding**: Assists with setting up and configuring Chrome Enterprise
-  Premium.
-- **Troubleshooting**: Helps diagnose and resolve issues with DLP rules and
-  other configurations.
-- **Metadata Retrieval**: Fetches customer and organizational unit IDs.
+- **Onboarding.** Walks an administrator through Chrome Enterprise Premium setup and configuration.
+- **Troubleshooting.** Diagnoses DLP rule problems and other configuration issues.
+- **Metadata retrieval.** Fetches the customer ID and organizational-unit IDs.
 
-## Getting Started
+## Prerequisites
 
-To get started with the CEP agent, you need to have the following prerequisites:
+- Node.js installed and on `PATH`.
+- The Google Cloud CLI (`gcloud`) installed and on `PATH`.
+- The Agent Development Kit installed.
 
-- Node.js installed
-- gcloud CLI installed
-- Agent development kit installed
+## Run the agent locally
 
-### Running Locally
+Follow these steps to run the agent against a real Google Cloud project.
 
-To run the agent locally, follow these steps:
+1. Authenticate to `gcloud` with the scope set the MCP server needs:
 
-1.  **Authenticate to gcloud:**
+   ```bash
+   gcloud auth application-default login \
+     --scopes=openid,\
+   https://www.googleapis.com/auth/userinfo.email,\
+   https://www.googleapis.com/auth/chrome.management.policy,\
+   https://www.googleapis.com/auth/chrome.management.reports.readonly,\
+   https://www.googleapis.com/auth/chrome.management.profiles.readonly,\
+   https://www.googleapis.com/auth/admin.reports.audit.readonly,\
+   https://www.googleapis.com/auth/admin.directory.orgunit.readonly,\
+   https://www.googleapis.com/auth/admin.directory.customer.readonly,\
+   https://www.googleapis.com/auth/apps.licensing,\
+   https://www.googleapis.com/auth/cloud-identity.policies,\
+   https://www.googleapis.com/auth/service.management,\
+   https://www.googleapis.com/auth/service.management.readonly,\
+   https://www.googleapis.com/auth/cloud-platform \
+     --no-launch-browser
+   ```
 
-    ```bash
-    gcloud auth application-default login \
-    --scopes=openid,\
-    https://www.googleapis.com/auth/userinfo.email,\
-    https://www.googleapis.com/auth/chrome.management.policy,\
-    https://www.googleapis.com/auth/chrome.management.reports.readonly,\
-    https://www.googleapis.com/auth/chrome.management.profiles.readonly,\
-    https://www.googleapis.com/auth/admin.reports.audit.readonly,\
-    https://www.googleapis.com/auth/admin.directory.orgunit.readonly,\
-    https://www.googleapis.com/auth/admin.directory.customer.readonly,\
-    https://www.googleapis.com/auth/apps.licensing,\
-    https://www.googleapis.com/auth/cloud-identity.policies,\
-    https://www.googleapis.com/auth/service.management,\
-    https://www.googleapis.com/auth/service.management.readonly,\
-    https://www.googleapis.com/auth/cloud-platform \
-    --no-launch-browser
-    ```
+   For an OAuth-flow alternative that does not require `gcloud` (and uses the OAuth-narrow scope set without `cloud-platform`), run `mcp auth login` from the repo root. For the setup walkthrough, see [`docs/auth-bring-your-own-oauth-client.md`](../../docs/auth-bring-your-own-oauth-client.md).
 
-    OAuth-flow alternative (no `gcloud` needed; OAuth-narrow scope set,
-    no `cloud-platform`):
+2. Start the ADK server:
 
-    ```bash
-    mcp auth login
-    ```
+   ```bash
+   adk web --host 0.0.0.0 adk/
+   ```
 
-    Setup walkthrough at
-    [`docs/auth-bring-your-own-oauth-client.md`](../../docs/auth-bring-your-own-oauth-client.md).
-
-2.  **Start the ADK server:**
-
-    ```bash
-    adk web --host 0.0.0.0 adk/
-    ```
-
-This will start the ADK server locally. You can then open your browser to interact with the agent.
+   The ADK server starts locally. Open the printed URL in a browser to interact with the agent.
 
 ## Usage
 
-You can interact with the agent by sending it queries. The agent will then use
-its tools and knowledge to provide a response.
+Send a query to the agent. The agent uses its tools and built-in knowledge to respond.
 
-### Example
+### Example interaction
 
-**User**: "My download rules are broken."
-
-**Agent**: "I found X rules related to downloads. Rule 'A' is active but the
-connector seems [Status]. Would you like to debug Rule A or Rule B deeply?"
+> **You:** "My download rules are broken."
+>
+> **Agent:** "I found X rules related to downloads. Rule A is active, but the connector status looks `<status>`. Do you want to debug rule A or rule B in detail?"

--- a/gemini-extension/README.md
+++ b/gemini-extension/README.md
@@ -29,7 +29,9 @@ time, and tells Gemini CLI to launch `mcp-server.js` as the MCP
 backend.
 
 > **`oauth_scopes` is install-time only.** The list lives in the
-> manifest so Gemini CLI has the right consent screen during
-> `gemini extension install`. The MCP server's runtime scope list is
-> in `lib/constants.js#SCOPES`, separate from the manifest. Updating
-> one without the other is a real foot-gun.
+> manifest so the Gemini CLI extension installer has the right consent
+> screen during `gemini extension install`. The MCP server's runtime
+> scope sets live separately in `lib/constants.js`: `SCOPES` is the
+> full ADC set (including `cloud-platform`); `OAUTH_SCOPES` is the
+> narrower set the OAuth-flow login uses on the consent screen.
+> Updating any of the three lists without the others is a real foot-gun.

--- a/lib/README.md
+++ b/lib/README.md
@@ -24,6 +24,6 @@ Shared infrastructure for the MCP server.
 - [`util/`](./util/): auth, retry/backoff, logging, CEL validation, feature
   flags, DLP constants, and other cross-cutting utilities.
 - [`knowledge/`](./knowledge/): markdown knowledge-base articles bundled with
-  the server and exposed via the `cep:expert` and search tools.
+  the server and exposed through the `cep:expert` prompt and the search tools.
 - `constants.js`: centralized OAuth scopes, API versions, and tag strings used
   across the codebase.

--- a/lib/api/README.md
+++ b/lib/api/README.md
@@ -26,7 +26,7 @@ Every API has two files:
 
 - `interfaces/foo_client.js`: abstract base class. Methods throw
   `Error('Not implemented')`. Tools program against the interface.
-- `real_foo_client.js`: production implementation. Authenticates via ADC and
+- `real_foo_client.js`: production implementation. Authenticates through ADC and
   calls the live Google API. Each method also accepts a bearer token,
   which when supplied takes the place of ADC.
 
@@ -38,7 +38,7 @@ fake API server in `test/helpers/fake-api-server.js`. The factory in
 // Real backend (production / postsubmit): no args, uses ADC.
 new RealAdminSdkClient()
 
-// Fake backend (presubmit): same class, redirected via rootUrl + a fake
+// Fake backend (presubmit): same class, redirected through rootUrl + a fake
 // auth provider that short-circuits getAuthClient().
 new RealAdminSdkClient({ rootUrl, auth: fakeAuth })
 ```

--- a/lib/knowledge/README.md
+++ b/lib/knowledge/README.md
@@ -53,10 +53,7 @@ used by `get_document`.
 
 ## Special article: 0-agent-capabilities.md
 
-Article 0 is not just searchable — it is injected alongside the system prompt on
-the agent's first tool call (via `tools/utils/wrapper.js`). It defines what the
-agent can and cannot do, which grounds the agent's behavior from the first
-interaction.
+Article 0 is searchable, and it is also injected alongside the system prompt on the agent's first tool call (through `tools/utils/wrapper.js`). It defines what the agent can and cannot do, which grounds the agent's behavior from the first interaction.
 
 ## Adding a new article
 

--- a/lib/util/README.md
+++ b/lib/util/README.md
@@ -48,7 +48,7 @@ logging, retry, GCP detection, CEL validation, and feature flags.
   then scope diff against the required set.
 
 - `oauth_flow.js`: `oauthFlowCredential()`. Managed-OAuth login flow
-  via `runLoginFlow()` (loopback callback or headless paste-back) and
+  through `runLoginFlow()` (loopback callback or headless paste-back) and
   a probe over the cached token. Default scopes: `OAUTH_SCOPES` (no
   `cloud-platform`).
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -68,14 +68,13 @@ Delete tools (`delete_agent_dlp_rule`, `delete_detector`) only register when
 
 ## Utilities (`utils/`)
 
-- `wrapper.js`: `guardedToolCall` and `formatToolResponse` (described above).
+- `wrapper.js`: `guardedToolCall` and `formatToolResponse` (described in the previous sections).
 - `org-unit.js`: root org unit resolution with session caching.
 - `detector.js`: shared helper for the three create-detector tools.
 
 ## Shared schemas (`definitions/shared.js`)
 
-Common Zod input/output schemas reused across tools (e.g., `customerId`,
-`orgUnitId` fields).
+Common Zod input/output schemas reused across tools, such as the `customerId` and `orgUnitId` fields.
 
 ## Adding a new tool
 


### PR DESCRIPTION
Style-pass + factual-accuracy pass on every project-level Markdown file outside `docs/`. Sibling to PR #144 (which covered `docs/`).

## Per-file commits

- `cb443d3` `docs(adk)`: factual fix — the agent code uses `gemini-2.5-flash` (`adk/cep_agent/agent.py:37`), but the README claimed `gemini-2.0-flash`. Fixed; the README now points at the constant in code so the next bump only needs the code change. Also: sentence-case headings, Apache license header.
- `18f3e94` `docs(readme)`: root README sentence-case headings; "above" / "via" / "should see" / "may not" / "(Optional)" / "Please" all swept; named per-MCP-client setup blocks kept (each block IS the onboarding path; the no-app-names rule applies to editorial mentions, not to per-client setup sections).
- `7834e97` `docs`: cross-cutting sweep on CONTRIBUTING, SECURITY, gemini-extension, and the four module READMEs (`lib/`, `lib/api/`, `lib/util/`, `tools/`). `via` → `through`; `above` → restructure; `simply` → drop; `please use` → `submit it`. Added the missing license header to SECURITY.md. The gemini-extension foot-gun callout now lists all three scope sets that have to stay in sync (`gemini-extension.json` install consent, `lib/constants.js#SCOPES`, `lib/constants.js#OAUTH_SCOPES`).
- `8fce0bd` `docs`: final mop-up — three more banned-word hits found in a final sweep (`please`, `above`, `just`/`via` in lib/knowledge/README.md).

## Factual claims verified

| Claim | Verified against | Status |
|---|---|---|
| ADK agent runs `gemini-2.5-flash` | `adk/cep_agent/agent.py:37` | confirmed |
| Three scope-set lists must stay in sync | `gemini-extension.json`, `lib/constants.js#SCOPES`, `lib/constants.js#OAUTH_SCOPES` | confirmed |
| Retry policy in root README ("retries `PERMISSION_DENIED` with exponential backoff") | `lib/constants.js#DEFAULT_CONFIG` | confirmed |
| ADC scope list in root README | matches `lib/constants.js#SCOPES` | confirmed |

## Out of scope

- `lib/knowledge/*.md` content files (runtime LLM context, different style domain).
- `prompts/system-prompt.md` (LLM runtime prompt).
- `gemini-extension/GEMINI.md` (Gemini-CLI agent system prompt; runtime context).
- `oauth_walkthru.md` at the repo root (one-off handoff scratch file).
- `docs/` (covered by PR #144).

## Decisions called out separately

- The four named-client setup blocks in the root README (one collapsible `<details>` per client) stay. Each block IS the onboarding path for that client; the path can't be generalized because each client uses a different config-file location. The earlier rule against naming third-party apps applies to editorial mentions in prose, not to per-client setup sections that have to name the client to be useful.

## Test plan

- [x] `npx prettier --check` clean for every file in the diff.
- [x] Banned-word grep across the touched files returns no hits except license-boilerplate "may".