### PR TITLE
feat: implement Least Privilege by removing broad cloud-platform scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,24 +55,23 @@ https://www.googleapis.com/auth/admin.directory.customer.readonly,\
 https://www.googleapis.com/auth/apps.licensing,\
 https://www.googleapis.com/auth/cloud-identity.policies,\
 https://www.googleapis.com/auth/service.management,\
-https://www.googleapis.com/auth/service.management.readonly,\
-https://www.googleapis.com/auth/cloud-platform
+https://www.googleapis.com/auth/service.management.readonly
 ```
 
 These scopes map to the underlying APIs:
 
-| Scope                                                                 | API                                                                             | Used for                                                           |
-| :-------------------------------------------------------------------- | :------------------------------------------------------------------------------ | :----------------------------------------------------------------- |
-| `openid`, `userinfo.email`                                            | OpenID Connect                                                                  | Identifies the principal in startup banner output                  |
-| `chrome.management.policy`                                            | [Chrome Policy](https://developers.google.com/chrome/policy)                    | Reading and writing connector policies, extension install policies |
-| `chrome.management.reports.readonly`                                  | [Chrome Management](https://developers.google.com/chrome/management)            | Browser version counts                                             |
-| `chrome.management.profiles.readonly`                                 | [Chrome Management](https://developers.google.com/chrome/management)            | Listing managed browser profiles                                   |
-| `admin.reports.audit.readonly`                                        | [Admin SDK Reports](https://developers.google.com/admin-sdk/reports)            | Chrome activity logs                                               |
-| `admin.directory.orgunit.readonly`                                    | [Admin SDK Directory](https://developers.google.com/admin-sdk/directory)        | Organizational unit hierarchy                                      |
-| `admin.directory.customer.readonly`                                   | [Admin SDK Directory](https://developers.google.com/admin-sdk/directory)        | Customer ID resolution                                             |
-| `apps.licensing`                                                      | [Enterprise License Manager](https://developers.google.com/admin-sdk/licensing) | CEP subscription and per-user license checks                       |
-| `cloud-identity.policies`                                             | [Cloud Identity](https://cloud.google.com/identity/docs)                        | DLP rules and content detectors (CRUD)                             |
-| `service.management`, `service.management.readonly`, `cloud-platform` | [Service Usage](https://cloud.google.com/service-usage/docs)                    | Checking and enabling required APIs                                |
+| Scope                                               | API                                                                             | Used for                                                           |
+| :-------------------------------------------------- | :------------------------------------------------------------------------------ | :----------------------------------------------------------------- |
+| `openid`, `userinfo.email`                          | OpenID Connect                                                                  | Identifies the principal in startup banner output                  |
+| `chrome.management.policy`                          | [Chrome Policy](https://developers.google.com/chrome/policy)                    | Reading and writing connector policies, extension install policies |
+| `chrome.management.reports.readonly`                | [Chrome Management](https://developers.google.com/chrome/management)            | Browser version counts                                             |
+| `chrome.management.profiles.readonly`               | [Chrome Management](https://developers.google.com/chrome/management)            | Listing managed browser profiles                                   |
+| `admin.reports.audit.readonly`                      | [Admin SDK Reports](https://developers.google.com/admin-sdk/reports)            | Chrome activity logs                                               |
+| `admin.directory.orgunit.readonly`                  | [Admin SDK Directory](https://developers.google.com/admin-sdk/directory)        | Organizational unit hierarchy                                      |
+| `admin.directory.customer.readonly`                 | [Admin SDK Directory](https://developers.google.com/admin-sdk/directory)        | Customer ID resolution                                             |
+| `apps.licensing`                                    | [Enterprise License Manager](https://developers.google.com/admin-sdk/licensing) | CEP subscription and per-user license checks                       |
+| `cloud-identity.policies`                           | [Cloud Identity](https://cloud.google.com/identity/docs)                        | DLP rules and content detectors (CRUD)                             |
+| `service.management`, `service.management.readonly` | [Service Usage](https://cloud.google.com/service-usage/docs)                    | Checking and enabling required APIs                                |
 
 Then set a quota project (identifies which GCP project's API enablement and
 quotas to use):

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -22,7 +22,6 @@
     "https://www.googleapis.com/auth/apps.licensing",
     "https://www.googleapis.com/auth/cloud-identity.policies",
     "https://www.googleapis.com/auth/service.management",
-    "https://www.googleapis.com/auth/service.management.readonly",
-    "https://www.googleapis.com/auth/cloud-platform"
+    "https://www.googleapis.com/auth/service.management.readonly"
   ]
 }

--- a/lib/api/real_service_usage_client.js
+++ b/lib/api/real_service_usage_client.js
@@ -46,7 +46,7 @@ export class RealServiceUsageClient extends ServiceUsageClient {
     return createApiClient(
       google.serviceusage,
       API_VERSIONS.SERVICE_USAGE,
-      [SCOPES.SERVICE_USAGE, SCOPES.SERVICE_USAGE_READONLY, SCOPES.CLOUD_PLATFORM],
+      [SCOPES.SERVICE_USAGE, SCOPES.SERVICE_USAGE_READONLY],
       authToken,
       this.apiOptions,
     )

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -44,7 +44,6 @@ export const SCOPES = {
   CLOUD_IDENTITY_POLICIES: 'https://www.googleapis.com/auth/cloud-identity.policies',
   SERVICE_USAGE: 'https://www.googleapis.com/auth/service.management',
   SERVICE_USAGE_READONLY: 'https://www.googleapis.com/auth/service.management.readonly',
-  CLOUD_PLATFORM: 'https://www.googleapis.com/auth/cloud-platform',
 }
 
 export const API_VERSIONS = {


### PR DESCRIPTION
This PR refactors the Service Usage API client and related constants to implement the Principle of Least Privilege. We discovered that the broad 'cloud-platform' (Full Access) scope is not strictly required for checking or enabling APIs; the narrower 'service.management' scopes are sufficient.

Key changes:
- Removed 'CLOUD_PLATFORM' from 'lib/constants.js'
- Updated 'RealServiceUsageClient' to only request 'service.management' scopes
- Removed the broad scope from 'gemini-extension.json'
- Cleaned up 'README.md' scope list
- Verified 'Smart Verification' in 'mcp-server.js' still accepts 'cloud-platform' if already provided by the user.

This change improves security and simplifies the documentation for OAuth flow setup.