### PR TITLE
feat(evals): scheduled workflow with transient-error classification

### DIFF
--- a/.github/workflows/agent-evals.yml
+++ b/.github/workflows/agent-evals.yml
@@ -1,0 +1,52 @@
+name: Agent Evals
+
+# No PR trigger in v1; cron + manual only. Revisit once drift detection has
+# enough clean signal to be trusted on the critical path.
+on:
+  schedule:
+    - cron: '0 11 * * *' # 11:00 UTC; off-peak for the Gemini API
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  evals:
+    name: 🤖 Agent evals
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      CEP_BACKEND: fake
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+
+      - name: Run evals
+        run: |
+          mkdir -p results
+          node test/evals/run.js --output results/eval-latest.json
+
+      - name: Upload eval results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-results
+          path: results/
+          retention-days: 30
+
+      # Drift detection only runs once a baseline is checked in. Before then,
+      # the workflow just produces and uploads results.
+      - name: Diff vs baseline
+        if: always() && hashFiles('results/eval-baseline.json') != ''
+        run: |
+          node scripts/eval-diff.js results/eval-baseline.json results/eval-latest.json \
+            | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/agent-evals.yml
+++ b/.github/workflows/agent-evals.yml
@@ -13,6 +13,7 @@ concurrency:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   evals:
@@ -30,7 +31,11 @@ jobs:
           cache: npm
       - run: npm ci
 
+      # The runner exits 1 on any FAIL. We let it; the diff step is what
+      # decides whether the workflow goes red, so the runner's own exit code
+      # must not abort the rest of the job.
       - name: Run evals
+        continue-on-error: true
         run: |
           mkdir -p results
           node test/evals/run.js --output results/eval-latest.json
@@ -46,7 +51,59 @@ jobs:
       # Drift detection only runs once a baseline is checked in. Before then,
       # the workflow just produces and uploads results.
       - name: Diff vs baseline
-        if: always() && hashFiles('results/eval-baseline.json') != ''
+        id: diff
+        if: hashFiles('results/eval-baseline.json') != ''
         run: |
+          set +e
           node scripts/eval-diff.js results/eval-baseline.json results/eval-latest.json \
+            | tee diff-output.txt \
             | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      # Open a single tracking issue (or update the existing one) when the
+      # diff reports a regression. INCONCLUSIVE runs exit 0 from the diff and
+      # therefore do not trigger this step.
+      - name: Open or update drift tracking issue
+        if: steps.diff.outputs.exit_code == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TITLE='Eval drift detected'
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          BODY_FILE=$(mktemp)
+          {
+            echo "The daily Agent Evals cron detected a pass-rate regression beyond the 5% threshold."
+            echo
+            echo "**Run:** [${{ github.run_id }}]($RUN_URL)"
+            echo "**Triggered by:** ${{ github.event_name }}"
+            echo
+            echo '```'
+            cat diff-output.txt
+            echo '```'
+            echo
+            echo "Download \`results/eval-latest.json\` from the run's artifacts for the full per-case detail."
+          } > "$BODY_FILE"
+
+          EXISTING=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --label auto:evals \
+            --search "\"$TITLE\" in:title" \
+            --json number \
+            --jq '.[0].number')
+
+          if [ -n "$EXISTING" ]; then
+            echo "Updating existing issue #$EXISTING"
+            gh issue comment "$EXISTING" --repo "${{ github.repository }}" --body-file "$BODY_FILE"
+          else
+            echo "Opening new drift issue"
+            gh issue create \
+              --repo "${{ github.repository }}" \
+              --title "$TITLE" \
+              --label auto:evals \
+              --body-file "$BODY_FILE"
+          fi
+
+      - name: Fail on regression
+        if: steps.diff.outputs.exit_code == '1'
+        run: exit 1

--- a/scripts/eval-diff.js
+++ b/scripts/eval-diff.js
@@ -1,0 +1,238 @@
+/* eslint-disable n/no-process-exit */
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file Compares two eval JSON outputs (baseline vs. current) and exits
+ * non-zero when the pass rate has regressed beyond the threshold.
+ *
+ * Usage: node scripts/eval-diff.js <baseline.json> <current.json> [--threshold <pct>]
+ *
+ * Exit codes: 0 = within threshold or no baseline; 1 = regression; 2 = bad input.
+ */
+
+import fs from 'node:fs'
+
+const DEFAULT_THRESHOLD_PCT = 5
+
+const USAGE =
+  'Usage: node scripts/eval-diff.js <baseline.json> <current.json> [--threshold <pct>]\n' +
+  `Default threshold: ${DEFAULT_THRESHOLD_PCT}%`
+
+/**
+ * Parses positional args and an optional `--threshold <pct>` flag from argv.
+ * @param {string[]} argv - argv slice excluding the node binary and script path.
+ * @returns {{ baseline: string, current: string, threshold: number } | { help: true } | { error: string }} parsed CLI shape.
+ */
+function parseCli(argv) {
+  if (argv.includes('--help') || argv.includes('-h')) {
+    return { help: true }
+  }
+
+  let threshold = DEFAULT_THRESHOLD_PCT
+  const positionals = []
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--threshold') {
+      const next = argv[++i]
+      if (next === undefined) {
+        return { error: `--threshold requires a value` }
+      }
+      threshold = Number.parseFloat(next)
+      if (!Number.isFinite(threshold) || threshold < 0) {
+        return { error: `invalid --threshold: ${next}` }
+      }
+    } else if (arg.startsWith('--threshold=')) {
+      threshold = Number.parseFloat(arg.slice('--threshold='.length))
+      if (!Number.isFinite(threshold) || threshold < 0) {
+        return { error: `invalid --threshold: ${arg}` }
+      }
+    } else if (arg.startsWith('-')) {
+      return { error: `unknown flag: ${arg}` }
+    } else {
+      positionals.push(arg)
+    }
+  }
+
+  if (positionals.length !== 2) {
+    return { error: `expected 2 positional args (baseline, current), got ${positionals.length}` }
+  }
+  return { baseline: positionals[0], current: positionals[1], threshold }
+}
+
+/**
+ * Reads and validates an eval result JSON file. Returns null when the file
+ * does not exist (a no-baseline-yet state is not an error).
+ * @param {string} filepath - Absolute or relative path to the JSON file.
+ * @returns {object | null} Parsed JSON object, or null if the file is absent.
+ */
+function readEvalJson(filepath) {
+  let raw
+  try {
+    raw = fs.readFileSync(filepath, 'utf8')
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return null
+    }
+    throw err
+  }
+  const data = JSON.parse(raw)
+  if (!data.summary || typeof data.summary.passRate !== 'number') {
+    throw new Error(`${filepath}: missing summary.passRate (file may be from an older runner)`)
+  }
+  return data
+}
+
+/**
+ * Formats a number as a fixed-precision percentage string (e.g. `92.0%`).
+ * @param {number} n - The percentage value.
+ * @returns {string} Formatted percentage with one decimal place.
+ */
+function fmtPct(n) {
+  return `${n.toFixed(1)}%`
+}
+
+/**
+ * Returns cases that were clean in the baseline but have failures in the
+ * current run. Useful for surfacing concentrated regressions even when the
+ * overall pass rate is within threshold.
+ * @param {object} baseline - Parsed baseline eval JSON.
+ * @param {object} current  - Parsed current eval JSON.
+ * @returns {{ id: string, category: string }[]} Flipped cases by ID + category.
+ */
+function flippedCases(baseline, current) {
+  const baselineById = new Map(baseline.evaluations.map(e => [e.id, e]))
+  const flips = []
+  for (const cur of current.evaluations) {
+    const base = baselineById.get(cur.id)
+    if (!base) {
+      continue
+    }
+    if (base.failed === 0 && cur.failed > 0) {
+      flips.push({ id: cur.id, category: cur.category })
+    }
+  }
+  return flips
+}
+
+/**
+ * CLI entry point.
+ * @returns {void}
+ */
+function main() {
+  const cli = parseCli(process.argv.slice(2))
+  if ('help' in cli) {
+    console.log(USAGE)
+    process.exit(0)
+  }
+  if ('error' in cli) {
+    console.error(`eval-diff: ${cli.error}\n${USAGE}`)
+    process.exit(2)
+  }
+
+  const { baseline: baselinePath, current: currentPath, threshold } = cli
+
+  let baseline
+  let current
+  try {
+    baseline = readEvalJson(baselinePath)
+    current = readEvalJson(currentPath)
+  } catch (err) {
+    console.error(`eval-diff: ${err.message}`)
+    process.exit(2)
+  }
+
+  if (!current) {
+    console.error(`eval-diff: current results file not found: ${currentPath}`)
+    process.exit(2)
+  }
+
+  if (current.summary.inconclusive) {
+    console.log(
+      `Skipping comparison: the current run hit too many transient errors ` +
+        `(infrastructure / network / quota failures) to be trusted. Rerun the workflow.`,
+    )
+    process.exit(0)
+  }
+
+  if (!baseline) {
+    console.log(
+      `No baseline file at ${baselinePath} yet, so there is nothing to compare against.\n` +
+        `Pass rate this run: ${fmtPct(current.summary.passRate)}.`,
+    )
+    process.exit(0)
+  }
+
+  if (baseline.summary.inconclusive) {
+    console.log(
+      `Skipping comparison: the baseline file was recorded from an inconclusive run ` +
+        `(too many transient errors). Refresh the baseline before comparing again.`,
+    )
+    process.exit(0)
+  }
+
+  const delta = current.summary.passRate - baseline.summary.passRate
+  const regressed = delta < 0 && Math.abs(delta) > threshold
+
+  console.log(`Comparing eval results against baseline:`)
+  console.log(`  Baseline pass rate:  ${fmtPct(baseline.summary.passRate)}` + summarizeCounts(baseline.summary))
+  console.log(`  Current pass rate:   ${fmtPct(current.summary.passRate)}` + summarizeCounts(current.summary))
+  const direction = delta > 0 ? 'improvement' : delta < 0 ? 'regression' : 'no change'
+  console.log(`  Change:              ${fmtSignedPct(delta)} (${direction})`)
+  console.log(`  Threshold:           ${fmtPct(threshold)} drop allowed before failing`)
+
+  const flips = flippedCases(baseline, current)
+  if (flips.length > 0) {
+    console.log(`\nCases that were clean in the baseline but failed this run:`)
+    for (const f of flips) {
+      console.log(`  - ${f.id} (${f.category})`)
+    }
+  }
+
+  if (regressed) {
+    console.log(
+      `\nREGRESSION: pass rate dropped by ${fmtPct(Math.abs(delta))}, which exceeds the ${fmtPct(threshold)} threshold.`,
+    )
+    process.exit(1)
+  }
+  console.log(`\nWithin threshold. No regression.`)
+  process.exit(0)
+}
+
+/**
+ * Renders a one-line summary of a run's counts: passed / failed / transient.
+ * @param {{ passed: number, failed: number, transient: number, total: number }} s - Summary counts from the eval JSON.
+ * @returns {string} Human-readable count summary, prefixed with two spaces.
+ */
+function summarizeCounts(s) {
+  const decisive = s.passed + s.failed
+  const tail = s.transient > 0 ? `, ${s.transient} transient error${s.transient === 1 ? '' : 's'} excluded` : ''
+  return `  (${s.passed} of ${decisive} runs passed${tail})`
+}
+
+/**
+ * Formats a signed percentage delta for display (e.g. "+0.5%", "-10.0%").
+ * @param {number} pct - Signed percentage value.
+ * @returns {string} Formatted string with explicit sign.
+ */
+function fmtSignedPct(pct) {
+  if (pct === 0) {
+    return '0.0%'
+  }
+  return `${pct > 0 ? '+' : '−'}${Math.abs(pct).toFixed(1)}%`
+}
+
+main()

--- a/test/evals/analyze-flaky.js
+++ b/test/evals/analyze-flaky.js
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */ import fs from 'fs'
+import { Status } from './lib/transient.js'
 
 const data = JSON.parse(fs.readFileSync('results/stability-check.json', 'utf-8'))
 const flaky = data.evaluations.filter(e => !e.isStable)
@@ -23,7 +24,8 @@ const missingStrings = {}
 let judgeFailsOnly = 0
 
 for (const e of flaky) {
-  const failedRuns = e.runs.filter(r => !r.passed)
+  // Only true FAILs analyse here; TRANSIENT runs are infrastructure, not model output.
+  const failedRuns = e.runs.filter(r => r.status === Status.FAIL)
   for (const r of failedRuns) {
     if (r.deterministic.failures.length === 0 && !r.judge.passed) {
       judgeFailsOnly++

--- a/test/evals/lib/judge.js
+++ b/test/evals/lib/judge.js
@@ -22,6 +22,7 @@ limitations under the License.
  */
 
 import { GoogleGenerativeAI } from '@google/generative-ai'
+import { isTransient } from './transient.js'
 
 const MODEL_NAME = 'gemini-3.1-flash-lite-preview'
 
@@ -76,6 +77,11 @@ REASONING: <A single concise sentence explaining the verdict.>`
 
       return { passed: isPassed, reasoning }
     } catch (err) {
+      // Re-throw transient errors so the runner's retry wrapper can see them;
+      // non-transient errors stay swallowed as a judge FAIL with reasoning.
+      if (isTransient(err)) {
+        throw err
+      }
       return { passed: false, reasoning: `Judge error: ${err.message}` }
     }
   }

--- a/test/evals/lib/reporter.js
+++ b/test/evals/lib/reporter.js
@@ -20,321 +20,20 @@ limitations under the License.
 
 import fs from 'node:fs'
 import path from 'node:path'
+import { Status } from './transient.js'
 
-// ANSI color helpers (no dependency needed)
-const RESET = '\x1b[0m'
-const GREEN = '\x1b[32m'
-const RED = '\x1b[31m'
-const DIM = '\x1b[2m'
-const BOLD = '\x1b[1m'
+const ANSI = Object.freeze({
+  reset: '\x1b[0m',
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  yellow: '\x1b[33m',
+  dim: '\x1b[2m',
+  bold: '\x1b[1m',
+})
 
-/**
- * Prints a summary table to the console.
- * @param {EvalResult[]} results
- * @param {{ verbose: boolean }} options
- */
-export function printConsole(results, { verbose = false } = {}) {
-  const line = '═'.repeat(60)
-  console.log(`\n${BOLD}CEP MCP Evals${RESET}`)
-  console.log(line)
-  console.log()
-
-  // Group by ID
-  const byId = {}
-  for (const r of results) {
-    if (!byId[r.id]) {
-      byId[r.id] = { id: r.id, category: r.category, prompt: r.prompt, runs: [] }
-    }
-    byId[r.id].runs.push(r)
-  }
-
-  for (const id of Object.keys(byId).sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))) {
-    const e = byId[id]
-    const passed = e.runs.filter(r => r.passed).length
-    const total = e.runs.length
-    const isStable = passed === total
-
-    // Status depends on stability: if all passed, it's green. If some passed, yellow? We use green/red based on 100% pass rate.
-    const status = isStable ? `${GREEN}PASS (${passed}/${total})${RESET}` : `${RED}FAIL (${passed}/${total})${RESET}`
-    const title = e.prompt.length > 50 ? e.prompt.slice(0, 47) + '...' : e.prompt
-
-    // Average duration
-    const avgDurationMs = e.runs.reduce((sum, r) => sum + r.durationMs, 0) / total
-    const duration = `${DIM}${(avgDurationMs / 1000).toFixed(1)}s/run${RESET}`
-    console.log(`  ${e.id.padEnd(5)} ${status.padEnd(30)}  ${title.padEnd(52)} ${duration}`)
-
-    if (!isStable) {
-      // Print failures for the first failed run to avoid spam
-      const failedRuns = e.runs.filter(r => !r.passed)
-      if (failedRuns.length > 0) {
-        const firstFail = failedRuns[0]
-        console.log(`  ${' '.repeat(5)}       ${DIM}(Showing first failure, Run ${firstFail.runIndex})${RESET}`)
-        const reasons = [
-          ...firstFail.deterministic.failures,
-          ...(firstFail.judge.passed ? [] : [`Judge: ${firstFail.judge.reasoning}`]),
-        ]
-        for (const reason of reasons) {
-          console.log(`  ${' '.repeat(5)}       ${RED}${reason}${RESET}`)
-        }
-
-        if (verbose) {
-          if (firstFail.toolCalls?.length > 0) {
-            console.log(
-              `  ${' '.repeat(5)}       ${DIM}Tools: ${firstFail.toolCalls.map(tc => tc.name).join(', ')}${RESET}`,
-            )
-          }
-          if (firstFail.responseText) {
-            const preview = firstFail.responseText.split('\n').slice(0, 5).join('\n')
-            console.log(`  ${' '.repeat(5)}       ${DIM}Response:${RESET}`)
-            for (const ln of preview.split('\n')) {
-              console.log(`  ${' '.repeat(5)}       ${DIM}  ${ln}${RESET}`)
-            }
-            if (firstFail.responseText.split('\n').length > 5) {
-              console.log(
-                `  ${' '.repeat(5)}       ${DIM}  ... (${firstFail.responseText.split('\n').length} lines total)${RESET}`,
-              )
-            }
-          }
-        }
-      }
-    }
-  }
-
-  // Category breakdown
-  console.log()
-  const { totalRuns, passedRuns, pct } = getSummaryStats(results)
-
-  const color = passedRuns === totalRuns ? GREEN : RED
-  console.log(`${BOLD}Results: ${color}${passedRuns}/${totalRuns} runs passed (${pct}%)${RESET}`)
-
-  const categories = [...new Set(results.map(r => r.category))].sort()
-  for (const cat of categories) {
-    const catResults = results.filter(r => r.category === cat)
-    const catPassed = catResults.filter(r => r.passed).length
-    const catPct = ((catPassed / catResults.length) * 100).toFixed(1)
-    const catColor = catPassed === catResults.length ? GREEN : RED
-    console.log(`  ${cat.padEnd(20)} ${catColor}${catPassed}/${catResults.length} (${catPct}%)${RESET}`)
-  }
-  console.log()
-}
-
-/**
- * Writes results to a file. Chooses format based on file extension:
- * .md -> Markdown, .json -> JSON.
- * @param {EvalResult[]} results
- * @param {string} filepath
- */
-export function writeResults(results, filepath) {
-  fs.mkdirSync(path.dirname(filepath), { recursive: true })
-
-  if (filepath.endsWith('.md')) {
-    writeMarkdown(results, filepath)
-  } else {
-    writeJson(results, filepath)
-  }
-  console.log(`Results written to ${filepath}`)
-}
-
-/**
- * Calculates basic summary statistics from evaluation results.
- * @param {EvalResult[]} results
- * @returns {{ totalRuns: number, passedRuns: number, pct: string }}
- */
-function getSummaryStats(results) {
-  const totalRuns = results.length
-  const passedRuns = results.filter(r => r.passed).length
-  const pct = totalRuns > 0 ? ((passedRuns / totalRuns) * 100).toFixed(1) : '0.0'
-  return { totalRuns, passedRuns, pct }
-}
-
-/**
- * Writes a Markdown report.
- * @param {EvalResult[]} results
- * @param {string} filepath
- */
-function writeMarkdown(results, filepath) {
-  const { totalRuns, passedRuns, pct } = getSummaryStats(results)
-
-  const lines = []
-  lines.push(`# CEP MCP Eval Results`)
-  lines.push('')
-  lines.push(`**Date:** ${new Date().toISOString()}`)
-  lines.push(
-    `**Total Runs:** ${totalRuns} | **Passed Runs:** ${passedRuns} | **Failed Runs:** ${totalRuns - passedRuns} | **Pass Rate:** ${pct}%`,
-  )
-  lines.push('')
-
-  // Category table
-  const categories = [...new Set(results.map(r => r.category))].sort()
-  lines.push(`## Results by Category`)
-  lines.push('')
-  lines.push(`| Category | Passed Runs | Total Runs | Rate |`)
-  lines.push(`|----------|-------------|------------|------|`)
-  for (const cat of categories) {
-    const catResults = results.filter(r => r.category === cat)
-    const catPassed = catResults.filter(r => r.passed).length
-    const catPct = ((catPassed / catResults.length) * 100).toFixed(1)
-    lines.push(`| ${cat} | ${catPassed} | ${catResults.length} | ${catPct}% |`)
-  }
-  lines.push('')
-
-  // Detailed results
-  lines.push(`## Stability by Eval Case`)
-  lines.push('')
-
-  // Group by ID
-  const byId = {}
-  for (const r of results) {
-    if (!byId[r.id]) {
-      byId[r.id] = {
-        id: r.id,
-        category: r.category,
-        prompt: r.prompt,
-        totalRuns: 0,
-        passedRuns: 0,
-        runs: [],
-      }
-    }
-    byId[r.id].totalRuns++
-    if (r.passed) {
-      byId[r.id].passedRuns++
-    }
-    byId[r.id].runs.push(r)
-  }
-
-  lines.push(`| ID | Category | Pass Rate | Passed / Total |`)
-  lines.push(`|----|----------|-----------|----------------|`)
-  for (const id of Object.keys(byId).sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))) {
-    const e = byId[id]
-    const rate = ((e.passedRuns / e.totalRuns) * 100).toFixed(1)
-    lines.push(`| **${id}** | ${e.category} | ${rate}% | ${e.passedRuns} / ${e.totalRuns} |`)
-  }
-  lines.push('')
-
-  lines.push(`## Detailed Run Failures`)
-  lines.push('')
-
-  for (const id of Object.keys(byId).sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))) {
-    const e = byId[id]
-    const failedRuns = e.runs.filter(r => !r.passed)
-    if (failedRuns.length > 0) {
-      lines.push(`### ${id} — ${e.passedRuns}/${e.totalRuns} Passed`)
-      lines.push(`**Prompt:** ${e.prompt}`)
-      lines.push('')
-      for (const r of failedRuns) {
-        lines.push(`#### Run ${r.runIndex || '?'}`)
-        if (r.toolCalls?.length > 0) {
-          lines.push(`**Tools:** ${r.toolCalls.map(tc => tc.name).join(', ')}`)
-        }
-        if (r.deterministic.failures.length > 0) {
-          lines.push(`**Failures:**`)
-          for (const f of r.deterministic.failures) {
-            lines.push(`- ${f}`)
-          }
-        }
-        if (
-          r.judge?.reasoning &&
-          r.judge.reasoning !== 'skipped (--no-judge)' &&
-          r.judge.reasoning !== 'skipped (dry run)'
-        ) {
-          lines.push(`**Judge:** ${r.judge.reasoning}`)
-        }
-        if (r.responseText) {
-          const preview = r.responseText.split('\n').slice(0, 10).join('\n')
-          lines.push('')
-          lines.push(`<details><summary>Response preview</summary>`)
-          lines.push('')
-          lines.push('```')
-          lines.push(preview)
-          if (r.responseText.split('\n').length > 10) {
-            lines.push(`... (${r.responseText.split('\n').length} lines total)`)
-          }
-          lines.push('```')
-          lines.push('')
-          lines.push(`</details>`)
-        }
-        lines.push('')
-      }
-      lines.push('---')
-      lines.push('')
-    }
-  }
-
-  fs.writeFileSync(filepath, lines.join('\n'))
-}
-
-/**
- * Writes structured JSON results to a file.
- * @param {EvalResult[]} results
- * @param {string} filepath
- */
-function writeJson(results, filepath) {
-  const totalRuns = results.length
-  const passedRuns = results.filter(r => r.passed).length
-
-  // Category breakdown
-  const byCategory = {}
-  for (const r of results) {
-    if (!byCategory[r.category]) {
-      byCategory[r.category] = { total: 0, passed: 0 }
-    }
-    byCategory[r.category].total++
-    if (r.passed) {
-      byCategory[r.category].passed++
-    }
-  }
-
-  // Group by ID
-  const byId = {}
-  for (const r of results) {
-    if (!byId[r.id]) {
-      byId[r.id] = {
-        id: r.id,
-        category: r.category,
-        prompt: r.prompt,
-        totalRuns: 0,
-        passedRuns: 0,
-        runs: [],
-      }
-    }
-    byId[r.id].totalRuns++
-    if (r.passed) {
-      byId[r.id].passedRuns++
-    }
-    byId[r.id].runs.push({
-      passed: r.passed,
-      deterministic: r.deterministic,
-      judge: r.judge,
-      toolsCalled: r.toolCalls?.map(tc => tc.name) || [],
-      responseText: r.responseText,
-      durationMs: r.durationMs,
-      runIndex: r.runIndex,
-    })
-  }
-
-  const output = {
-    timestamp: new Date().toISOString(),
-    summary: {
-      totalRuns,
-      passedRuns,
-      failedRuns: totalRuns - passedRuns,
-      passRate: totalRuns > 0 ? parseFloat(((passedRuns / totalRuns) * 100).toFixed(1)) : 0,
-    },
-    byCategory,
-    evaluations: Object.values(byId).map(e => ({
-      id: e.id,
-      category: e.category,
-      prompt: e.prompt,
-      totalRuns: e.totalRuns,
-      passedRuns: e.passedRuns,
-      passRate: e.totalRuns > 0 ? parseFloat(((e.passedRuns / e.totalRuns) * 100).toFixed(1)) : 0,
-      isStable: e.passedRuns === e.totalRuns,
-      runs: e.runs,
-    })),
-  }
-
-  fs.writeFileSync(filepath, JSON.stringify(output, null, 2) + '\n')
-}
+const TITLE_MAX = 50
+const TITLE_TRUNCATE_AT = 47
+const RESPONSE_PREVIEW_LINES = { console: 5, markdown: 10 }
 
 /**
  * @typedef {object} EvalResult
@@ -342,10 +41,389 @@ function writeJson(results, filepath) {
  * @property {string} category
  * @property {string} prompt
  * @property {boolean} passed
- * @property {{ passed: boolean, failures: string[] }} deterministic
- * @property {{ passed: boolean, reasoning: string }} judge
+ * @property {string} status                       PASS | FAIL | TRANSIENT
+ * @property {{ source: string, message: string } | null} transient
+ * @property {{ passed: boolean, failures: string[], skipped?: boolean }} deterministic
+ * @property {{ passed: boolean, reasoning: string, skipped?: boolean }} judge
  * @property {{ name: string, args: object }[]} toolCalls
  * @property {string} responseText
  * @property {number} durationMs
  * @property {number} runIndex
  */
+
+/**
+ * @typedef {object} ReportOptions
+ * @property {boolean} [verbose]
+ * @property {boolean} [inconclusive]   Set when transient share exceeds the runner's ceiling.
+ */
+
+/**
+ * Counts results by status. Used for both summaries and per-case stability.
+ * @param {EvalResult[]} results
+ * @returns {{ passed: number, failed: number, transient: number, total: number, passRate: number }}
+ *   passRate is PASS / (PASS + FAIL); transients are excluded from the denominator.
+ */
+function countByStatus(results) {
+  let passed = 0
+  let failed = 0
+  let transient = 0
+  for (const r of results) {
+    if (r.status === Status.PASS) {
+      passed++
+    } else if (r.status === Status.TRANSIENT) {
+      transient++
+    } else {
+      failed++
+    }
+  }
+  const decisive = passed + failed
+  const passRate = decisive > 0 ? passed / decisive : 0
+  return { passed, failed, transient, total: results.length, passRate }
+}
+
+function truncate(text, max = TITLE_MAX, ellipsis = TITLE_TRUNCATE_AT) {
+  return text.length > max ? text.slice(0, ellipsis) + '...' : text
+}
+
+/**
+ * Renders a per-case outcome in plain English (e.g. "3 of 5 runs passed,
+ * 2 failed, 1 transient error"). Drops zero-count categories.
+ * @param {{ passed: number, failed: number, transient: number, total: number }} c
+ * @returns {string}
+ */
+function formatOutcome(c) {
+  const parts = [`${c.passed} of ${c.total} runs passed`]
+  if (c.failed > 0) {
+    parts.push(`${c.failed} failed`)
+  }
+  if (c.transient > 0) {
+    parts.push(`${c.transient} transient error${c.transient === 1 ? '' : 's'}`)
+  }
+  return parts.join(', ')
+}
+
+function statusColor(status) {
+  if (status === Status.PASS) {
+    return ANSI.green
+  }
+  if (status === Status.TRANSIENT) {
+    return ANSI.yellow
+  }
+  return ANSI.red
+}
+
+/**
+ * Groups runs by eval ID and keeps order by ID.
+ * @param {EvalResult[]} results
+ */
+function groupById(results) {
+  const byId = {}
+  for (const r of results) {
+    if (!byId[r.id]) {
+      byId[r.id] = { id: r.id, category: r.category, prompt: r.prompt, runs: [] }
+    }
+    byId[r.id].runs.push(r)
+  }
+  return byId
+}
+
+/**
+ * Prints a summary table to the console.
+ * @param {EvalResult[]} results
+ * @param {ReportOptions} [options]
+ */
+export function printConsole(results, { verbose = false, inconclusive = false } = {}) {
+  const line = '═'.repeat(60)
+  console.log(`\n${ANSI.bold}CEP MCP Evals${ANSI.reset}`)
+  console.log(line)
+  console.log()
+
+  const byId = groupById(results)
+  const multiRun = Object.values(byId).some(e => e.runs.length > 1)
+
+  for (const id of Object.keys(byId).sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))) {
+    const e = byId[id]
+    const counts = countByStatus(e.runs)
+    const allPass = counts.passed === counts.total
+    const anyFail = counts.failed > 0
+    const caseStatus = anyFail ? Status.FAIL : allPass ? Status.PASS : Status.TRANSIENT
+    const color = statusColor(caseStatus)
+
+    const statusWord = `${color}${caseStatus}${ANSI.reset}`
+    const breakdown = multiRun
+      ? `${ANSI.dim}(${counts.passed} of ${counts.total} runs passed${counts.transient > 0 ? `, ${counts.transient} transient error${counts.transient === 1 ? '' : 's'}` : ''})${ANSI.reset}`
+      : ''
+    const title = truncate(e.prompt)
+    const avgDurationMs = e.runs.reduce((sum, r) => sum + r.durationMs, 0) / counts.total
+    const duration = `${ANSI.dim}${(avgDurationMs / 1000).toFixed(1)}s${multiRun ? '/run' : ''}${ANSI.reset}`
+    console.log(
+      `  ${e.id.padEnd(5)} ${statusWord.padEnd(13)} ${title.padEnd(52)} ${duration}${breakdown ? `  ${breakdown}` : ''}`,
+    )
+
+    const failedRuns = e.runs.filter(r => r.status === Status.FAIL)
+    if (failedRuns.length > 0) {
+      const firstFail = failedRuns[0]
+      console.log(`  ${' '.repeat(5)}       ${ANSI.dim}(showing first failure, run ${firstFail.runIndex})${ANSI.reset}`)
+      const reasons = [
+        ...firstFail.deterministic.failures,
+        ...(firstFail.judge.passed ? [] : [`Judge: ${firstFail.judge.reasoning}`]),
+      ]
+      for (const reason of reasons) {
+        console.log(`  ${' '.repeat(5)}       ${ANSI.red}${reason}${ANSI.reset}`)
+      }
+      if (verbose) {
+        printVerboseFailure(firstFail)
+      }
+    }
+
+    const transientRuns = e.runs.filter(r => r.status === Status.TRANSIENT)
+    if (transientRuns.length > 0 && failedRuns.length === 0) {
+      const t = transientRuns[0].transient
+      console.log(`  ${' '.repeat(5)}       ${ANSI.yellow}transient (${t.source}): ${t.message}${ANSI.reset}`)
+    }
+  }
+
+  console.log()
+  const overall = countByStatus(results)
+  const summaryColor = overall.failed === 0 ? ANSI.green : ANSI.red
+  const pct = (overall.passRate * 100).toFixed(1)
+  const scored = overall.passed + overall.failed
+  console.log(
+    `${ANSI.bold}Results: ${summaryColor}${overall.passed} of ${scored} runs passed (${pct}% pass rate)${ANSI.reset}`,
+  )
+  if (overall.transient > 0) {
+    const word = overall.transient === 1 ? 'error was' : 'errors were'
+    console.log(
+      `${ANSI.dim}         ${overall.transient} transient ${word} retried, then excluded from the pass rate.${ANSI.reset}`,
+    )
+  }
+  if (inconclusive) {
+    console.log(
+      `${ANSI.bold}${ANSI.yellow}Run is INCONCLUSIVE: too many transient errors to trust the pass rate.${ANSI.reset}`,
+    )
+  }
+
+  const categories = [...new Set(results.map(r => r.category))].sort()
+  for (const cat of categories) {
+    const catResults = results.filter(r => r.category === cat)
+    const catCounts = countByStatus(catResults)
+    const catScored = catCounts.passed + catCounts.failed
+    const catPct = (catCounts.passRate * 100).toFixed(1)
+    const catColor = catCounts.failed === 0 ? ANSI.green : ANSI.red
+    const transientSuffix =
+      catCounts.transient > 0
+        ? `${ANSI.dim}; ${catCounts.transient} transient error${catCounts.transient === 1 ? '' : 's'}${ANSI.reset}`
+        : ''
+    console.log(
+      `  ${cat.padEnd(20)} ${catColor}${catCounts.passed} of ${catScored} passed (${catPct}%)${ANSI.reset}${transientSuffix}`,
+    )
+  }
+  console.log()
+}
+
+function printVerboseFailure(r) {
+  if (r.toolCalls?.length > 0) {
+    console.log(`  ${' '.repeat(5)}       ${ANSI.dim}Tools: ${r.toolCalls.map(tc => tc.name).join(', ')}${ANSI.reset}`)
+  }
+  if (r.responseText) {
+    const lines = r.responseText.split('\n')
+    const preview = lines.slice(0, RESPONSE_PREVIEW_LINES.console).join('\n')
+    console.log(`  ${' '.repeat(5)}       ${ANSI.dim}Response:${ANSI.reset}`)
+    for (const ln of preview.split('\n')) {
+      console.log(`  ${' '.repeat(5)}       ${ANSI.dim}  ${ln}${ANSI.reset}`)
+    }
+    if (lines.length > RESPONSE_PREVIEW_LINES.console) {
+      console.log(`  ${' '.repeat(5)}       ${ANSI.dim}  ... (${lines.length} lines total)${ANSI.reset}`)
+    }
+  }
+}
+
+/**
+ * Writes results to a file. Format chosen by extension: `.md` or `.json`.
+ * @param {EvalResult[]} results
+ * @param {string} filepath
+ * @param {ReportOptions} [options]
+ */
+export function writeResults(results, filepath, options = {}) {
+  fs.mkdirSync(path.dirname(filepath), { recursive: true })
+
+  if (filepath.endsWith('.md')) {
+    writeMarkdown(results, filepath, options)
+  } else {
+    writeJson(results, filepath, options)
+  }
+  console.log(`Results written to ${filepath}`)
+}
+
+/**
+ * @param {EvalResult[]} results
+ * @param {string} filepath
+ * @param {ReportOptions} options
+ */
+function writeMarkdown(results, filepath, { inconclusive = false } = {}) {
+  const overall = countByStatus(results)
+  const pct = (overall.passRate * 100).toFixed(1)
+  const scored = overall.passed + overall.failed
+
+  const lines = []
+  lines.push(`# CEP MCP Eval Results`)
+  lines.push('')
+  lines.push(`**Date:** ${new Date().toISOString()}`)
+  lines.push('')
+  lines.push(
+    `> **What "transient error" means:** an infrastructure / network / quota failure ` +
+      `(e.g. a Gemini 503 or 429). The runner retries with backoff and, if it still ` +
+      `fails, records the case as a transient error rather than a real failure. ` +
+      `Transient errors are **excluded from the pass rate**.`,
+  )
+  lines.push('')
+  if (inconclusive) {
+    lines.push(
+      `> ⚠️ **Run is INCONCLUSIVE.** Too many transient errors to trust the pass rate. ` +
+        `Do not compare it against a baseline; rerun the workflow.`,
+    )
+    lines.push('')
+  }
+  lines.push(`## Summary`)
+  lines.push('')
+  lines.push(`- **${overall.passed} of ${scored} runs passed** (${pct}% pass rate).`)
+  lines.push(`- **${overall.failed}** failed.`)
+  lines.push(`- **${overall.transient}** hit a transient error (excluded from the pass rate).`)
+  lines.push('')
+
+  const categories = [...new Set(results.map(r => r.category))].sort()
+  lines.push(`## Results by category`)
+  lines.push('')
+  lines.push(`| Category | Passed | Failed | Transient errors | Pass rate |`)
+  lines.push(`|----------|--------|--------|------------------|-----------|`)
+  for (const cat of categories) {
+    const c = countByStatus(results.filter(r => r.category === cat))
+    lines.push(`| ${cat} | ${c.passed} | ${c.failed} | ${c.transient} | ${(c.passRate * 100).toFixed(1)}% |`)
+  }
+  lines.push('')
+
+  lines.push(`## Per-case results`)
+  lines.push('')
+  lines.push(`| ID | Category | Outcome | Pass rate |`)
+  lines.push(`|----|----------|---------|-----------|`)
+  const byId = groupById(results)
+  for (const id of Object.keys(byId).sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))) {
+    const e = byId[id]
+    const c = countByStatus(e.runs)
+    lines.push(`| **${id}** | ${e.category} | ${formatOutcome(c)} | ${(c.passRate * 100).toFixed(1)}% |`)
+  }
+  lines.push('')
+
+  lines.push(`## Detailed failures`)
+  lines.push('')
+  for (const id of Object.keys(byId).sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))) {
+    const e = byId[id]
+    const failedRuns = e.runs.filter(r => r.status === Status.FAIL)
+    if (failedRuns.length === 0) {
+      continue
+    }
+    const c = countByStatus(e.runs)
+    lines.push(`### ${id}: ${formatOutcome(c)}`)
+    lines.push(`**Prompt:** ${e.prompt}`)
+    lines.push('')
+    for (const r of failedRuns) {
+      lines.push(`#### Run ${r.runIndex}`)
+      if (r.toolCalls?.length > 0) {
+        lines.push(`**Tools:** ${r.toolCalls.map(tc => tc.name).join(', ')}`)
+      }
+      if (r.deterministic.failures.length > 0) {
+        lines.push(`**Failures:**`)
+        for (const f of r.deterministic.failures) {
+          lines.push(`- ${f}`)
+        }
+      }
+      if (r.judge?.reasoning && !r.judge.skipped) {
+        lines.push(`**Judge:** ${r.judge.reasoning}`)
+      }
+      if (r.responseText) {
+        const responseLines = r.responseText.split('\n')
+        const preview = responseLines.slice(0, RESPONSE_PREVIEW_LINES.markdown).join('\n')
+        lines.push('')
+        lines.push(`<details><summary>Response preview</summary>`)
+        lines.push('')
+        lines.push('```')
+        lines.push(preview)
+        if (responseLines.length > RESPONSE_PREVIEW_LINES.markdown) {
+          lines.push(`... (${responseLines.length} lines total)`)
+        }
+        lines.push('```')
+        lines.push('')
+        lines.push(`</details>`)
+      }
+      lines.push('')
+    }
+    lines.push('---')
+    lines.push('')
+  }
+
+  fs.writeFileSync(filepath, lines.join('\n'))
+}
+
+/**
+ * @param {EvalResult[]} results
+ * @param {string} filepath
+ * @param {ReportOptions} options
+ */
+function writeJson(results, filepath, { inconclusive = false } = {}) {
+  const overall = countByStatus(results)
+
+  const byCategory = {}
+  for (const cat of new Set(results.map(r => r.category))) {
+    const c = countByStatus(results.filter(r => r.category === cat))
+    byCategory[cat] = {
+      passed: c.passed,
+      failed: c.failed,
+      transient: c.transient,
+      total: c.total,
+      passRate: parseFloat((c.passRate * 100).toFixed(1)),
+    }
+  }
+
+  const byId = groupById(results)
+  const evaluations = Object.values(byId).map(e => {
+    const c = countByStatus(e.runs)
+    return {
+      id: e.id,
+      category: e.category,
+      prompt: e.prompt,
+      passed: c.passed,
+      failed: c.failed,
+      transient: c.transient,
+      total: c.total,
+      passRate: parseFloat((c.passRate * 100).toFixed(1)),
+      isStable: c.failed === 0 && c.transient === 0,
+      runs: e.runs.map(r => ({
+        runIndex: r.runIndex,
+        status: r.status,
+        passed: r.passed,
+        transient: r.transient,
+        deterministic: r.deterministic,
+        judge: r.judge,
+        toolsCalled: r.toolCalls?.map(tc => tc.name) || [],
+        responseText: r.responseText,
+        durationMs: r.durationMs,
+      })),
+    }
+  })
+
+  const output = {
+    timestamp: new Date().toISOString(),
+    summary: {
+      passed: overall.passed,
+      failed: overall.failed,
+      transient: overall.transient,
+      total: overall.total,
+      passRate: parseFloat((overall.passRate * 100).toFixed(1)),
+      inconclusive,
+    },
+    byCategory,
+    evaluations,
+  }
+
+  fs.writeFileSync(filepath, JSON.stringify(output, null, 2) + '\n')
+}

--- a/test/evals/lib/transient.js
+++ b/test/evals/lib/transient.js
@@ -1,0 +1,154 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file Transient-error classification for the eval runner.
+ *
+ * Distinguishes infrastructure / quota / network failures (which should be
+ * retried and, if persistent, recorded as TRANSIENT and not counted toward
+ * pass-rate) from genuine model-output failures (FAIL).
+ */
+
+/** Per-run terminal classification. Used in result.status. */
+export const Status = Object.freeze({
+  PASS: 'PASS',
+  FAIL: 'FAIL',
+  TRANSIENT: 'TRANSIENT',
+})
+
+/** Where a transient failure originated, used in result.transient.source. */
+export const TransientSource = Object.freeze({
+  AGENT: 'agent',
+  JUDGE: 'judge',
+})
+
+const TRANSIENT_MESSAGE_PATTERNS = [
+  /\b503\b/,
+  /\b429\b/,
+  /\b408\b/,
+  /service unavailable/i,
+  /too many requests/i,
+  /rate ?limit/i,
+  /resource[ _]?exhausted/i,
+  /deadline[ _]?exceeded/i,
+  /\bunavailable\b/i,
+  /\bquota\b/i,
+  /\btimed? ?out\b/i,
+  /aborted/i,
+  /socket hang up/i,
+]
+
+const TRANSIENT_CODES = new Set([
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ECONNABORTED',
+  'ETIMEDOUT',
+  'EAI_AGAIN',
+  'ENOTFOUND',
+  'EPIPE',
+  'UND_ERR_SOCKET',
+  'UND_ERR_CONNECT_TIMEOUT',
+])
+
+/**
+ * Returns true if the error looks like a transient infrastructure, quota, or
+ * network failure rather than a real model-output or programming error.
+ *
+ * Inspects HTTP status, error code, message text, and `err.cause` recursively.
+ * @param {unknown} err
+ * @returns {boolean}
+ */
+export function isTransient(err) {
+  if (!err || typeof err !== 'object') {
+    return false
+  }
+
+  const status = err.status ?? err.statusCode ?? err.response?.status
+  if (typeof status === 'number') {
+    if (status === 408 || status === 429) {
+      return true
+    }
+    if (status >= 500 && status < 600) {
+      return true
+    }
+  }
+
+  const code = err.code ?? err.cause?.code
+  if (typeof code === 'string' && TRANSIENT_CODES.has(code)) {
+    return true
+  }
+
+  const message = typeof err.message === 'string' ? err.message : String(err)
+  for (const pat of TRANSIENT_MESSAGE_PATTERNS) {
+    if (pat.test(message)) {
+      return true
+    }
+  }
+
+  if (err.cause && err.cause !== err) {
+    return isTransient(err.cause)
+  }
+
+  return false
+}
+
+/**
+ * Default retry knobs for the transient-retry helper.
+ */
+export const RETRY_DEFAULTS = Object.freeze({
+  maxRetries: 3,
+  baseDelayMs: 2000,
+  maxJitterMs: 750,
+})
+
+/**
+ * Invokes an async function with bounded retry on transient errors.
+ *
+ * Non-transient errors are re-thrown immediately so callers can handle real
+ * failures without ever waiting on a retry. After exhausting retries on a
+ * transient error, returns `{ ok: false, transient: true, error }` rather
+ * than throwing; the runner uses that to record TRANSIENT status.
+ * @template T
+ * @param {() => Promise<T>} fn
+ * @param {{ maxRetries?: number, baseDelayMs?: number, maxJitterMs?: number, sleep?: (ms: number) => Promise<void> }} [opts]
+ * @returns {Promise<{ ok: true, value: T } | { ok: false, transient: true, error: Error, attempts: number }>}
+ */
+export async function withTransientRetry(fn, opts = {}) {
+  const { maxRetries, baseDelayMs, maxJitterMs } = { ...RETRY_DEFAULTS, ...opts }
+  const sleep =
+    opts.sleep ??
+    (ms =>
+      new Promise(r => {
+        setTimeout(r, ms)
+      }))
+
+  let lastErr
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return { ok: true, value: await fn() }
+    } catch (err) {
+      if (!isTransient(err)) {
+        throw err
+      }
+      lastErr = err
+      if (attempt < maxRetries) {
+        const delay = baseDelayMs * 2 ** attempt + Math.floor(Math.random() * maxJitterMs)
+        await sleep(delay)
+      }
+    }
+  }
+  return { ok: false, transient: true, error: lastErr, attempts: maxRetries + 1 }
+}

--- a/test/evals/run.js
+++ b/test/evals/run.js
@@ -56,12 +56,17 @@ import { runChecks, checkForbidden, checkRequired } from './lib/assertions.js'
 import { createJudge } from './lib/judge.js'
 import { createEvalAgent } from './lib/agent.js'
 import { printConsole, writeResults } from './lib/reporter.js'
+import { withTransientRetry, Status, TransientSource } from './lib/transient.js'
 import { startFakeServer } from '../helpers/fake-api-server.js'
 import { applyScenario } from './scenarios/index.js'
 import { createIntegrationHarness, teardownIntegrationHarness } from '../helpers/integration/tools/harness.js'
 import { FeatureFlags } from '../../lib/util/feature_flags.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+// If more than this share of runs end as TRANSIENT, mark the whole run
+// INCONCLUSIVE so downstream drift detection skips the comparison.
+const TRANSIENT_RUN_CEILING = 0.2
 
 /** CLI argument parsing */
 
@@ -144,8 +149,10 @@ async function main() {
         category: evalCase.category,
         prompt: evalCase.prompt,
         passed: deterministic.passed,
+        status: deterministic.passed ? Status.PASS : Status.FAIL,
+        transient: null,
         deterministic,
-        judge: { passed: true, reasoning: 'skipped (dry run)' },
+        judge: { passed: true, reasoning: 'dry-run skip', skipped: true },
         toolCalls: [],
         responseText: evalCase.goldenResponse,
         durationMs: 0,
@@ -243,33 +250,58 @@ async function main() {
 
       let responseText = ''
       let toolCalls = []
+      /** @type {{ source: string, message: string } | null} */
+      let transient = null
 
       try {
-        const result = await agent.query(promptText)
-        responseText = result.responseText
-        toolCalls = result.toolCalls
+        const agentOutcome = await withTransientRetry(() => agent.query(promptText))
+        if (agentOutcome.ok) {
+          responseText = agentOutcome.value.responseText
+          toolCalls = agentOutcome.value.toolCalls
+        } else {
+          transient = { source: TransientSource.AGENT, message: agentOutcome.error.message }
+        }
       } catch (err) {
         responseText = `Agent error: ${err.message}`
       }
 
       const actualToolNames = toolCalls.map(tc => tc.name)
-      const deterministic = runChecks(responseText, actualToolNames, evalCase)
+      const deterministic = transient
+        ? { passed: false, failures: [], skipped: true }
+        : runChecks(responseText, actualToolNames, evalCase)
 
       let judgeResult
-      if (judgeFn) {
+      if (transient) {
+        judgeResult = { passed: false, reasoning: 'judge skipped: agent transient', skipped: true }
+      } else if (judgeFn) {
         const rubric = evalCase.judgeInstructions || globalConfig.defaultJudgeRubric
-        judgeResult = await judgeFn({ responseText, goldenResponse: evalCase.goldenResponse, rubric })
+        const judgeOutcome = await withTransientRetry(() =>
+          judgeFn({ responseText, goldenResponse: evalCase.goldenResponse, rubric }),
+        )
+        if (judgeOutcome.ok) {
+          judgeResult = judgeOutcome.value
+        } else {
+          transient = { source: TransientSource.JUDGE, message: judgeOutcome.error.message }
+          judgeResult = { passed: false, reasoning: `judge transient: ${judgeOutcome.error.message}`, skipped: true }
+        }
       } else {
-        judgeResult = { passed: true, reasoning: 'skipped (--no-judge)' }
+        judgeResult = { passed: true, reasoning: '--no-judge', skipped: true }
       }
 
-      const passed = deterministic.passed && judgeResult.passed
+      const status = transient
+        ? Status.TRANSIENT
+        : deterministic.passed && judgeResult.passed
+          ? Status.PASS
+          : Status.FAIL
+      const passed = status === Status.PASS
 
       const result = {
         id: evalCase.id,
         category: evalCase.category,
         prompt: evalCase.prompt,
         passed,
+        status,
+        transient,
         deterministic,
         judge: judgeResult,
         toolCalls,
@@ -284,23 +316,24 @@ async function main() {
       const r = result
       const G = '\x1b[32m'
       const R = '\x1b[31m'
+      const Y = '\x1b[33m'
       const D = '\x1b[2m'
       const RST = '\x1b[0m'
-      const status = r.passed ? `${G}PASS${RST}` : `${R}FAIL${RST}`
+      const statusColor = r.status === Status.PASS ? G : r.status === Status.TRANSIENT ? Y : R
+      const statusLabel = `${statusColor}${r.status}${RST}`
       const title = r.prompt.length > 50 ? r.prompt.slice(0, 47) + '...' : r.prompt
       const sec = `${D}${(r.durationMs / 1000).toFixed(1)}s${RST}`
       const runStr = numRuns > 1 ? ` [Run ${run + 1}/${numRuns}]` : ''
-      console.log(`  ${r.id.padEnd(5)} ${status}  ${(title + runStr).padEnd(52)} ${sec}`)
-      if (!r.passed && r.deterministic.failures.length > 0) {
+      console.log(`  ${r.id.padEnd(5)} ${statusLabel}  ${(title + runStr).padEnd(52)} ${sec}`)
+      if (r.transient) {
+        console.log(`  ${' '.repeat(5)}       ${Y}${r.transient.source}: ${r.transient.message}${RST}`)
+      }
+      if (r.status === Status.FAIL && r.deterministic.failures.length > 0) {
         for (const f of r.deterministic.failures) {
           console.log(`  ${' '.repeat(5)}       ${R}${f}${RST}`)
         }
       }
-      if (
-        r.judge.reasoning &&
-        r.judge.reasoning !== 'skipped (--no-judge)' &&
-        r.judge.reasoning !== 'skipped (dry run)'
-      ) {
+      if (r.status !== Status.TRANSIENT && r.judge.reasoning && !r.judge.skipped) {
         console.log(`  ${' '.repeat(5)}       ${D}Judge: ${r.judge.reasoning}${RST}`)
       }
       if (verbose && r.toolCalls.length > 0) {
@@ -347,12 +380,14 @@ async function main() {
   // Sort results by ID for consistent output
   results.sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true }))
 
-  // Output — auto-enable verbose if there are failures
-  const hasFailures = results.some(r => !r.passed)
-  printConsole(results, { verbose: verbose || hasFailures })
+  // Output: auto-enable verbose if there are real failures (not transients)
+  const hasFailures = results.some(r => r.status === Status.FAIL)
+  const transientCount = results.filter(r => r.status === Status.TRANSIENT).length
+  const inconclusive = results.length > 0 && transientCount / results.length > TRANSIENT_RUN_CEILING
+  printConsole(results, { verbose: verbose || hasFailures, inconclusive })
 
   if (args.output) {
-    writeResults(results, args.output)
+    writeResults(results, args.output, { inconclusive })
 
     // Automatically generate AI failure summary for CI runs
     if (Array.isArray(priority) && priority.some(p => p === 'P0') && hasFailures) {
@@ -365,7 +400,7 @@ async function main() {
           baseUrl ? { baseUrl } : undefined,
         )
 
-        const failedResults = results.filter(r => !r.passed)
+        const failedResults = results.filter(r => r.status === Status.FAIL)
         const failureDetails = failedResults
           .map(
             r =>


### PR DESCRIPTION
Implements the blocking checklist on #148.

## What this does

Adds a daily GitHub Actions workflow that runs `npm run eval` against Gemini, uploads `results/` as a CI artifact, and fails the workflow when the pass rate regresses by more than 5 percentage points against a checked-in baseline. On regression, the workflow opens (or updates) a tracking issue labeled `auto:evals` so the failure is visible without watching the Actions tab.

It also reworks the runner so a Gemini 503/429/quota/network blip is no longer counted as a model failure: it gets retried with backoff, and if it still doesn't recover, the case is classified `TRANSIENT` and excluded from the pass-rate denominator.

## What happens when the cron fires

Each day at 11:00 UTC (and on every `workflow_dispatch` click):

1. GitHub Actions checks out `main`, runs `npm ci`, runs `node test/evals/run.js --output results/eval-latest.json`. Roughly 5 to 10 minutes for 25 cases.
2. `results/` is uploaded as a workflow artifact with 30-day retention. Anyone with read access can download the JSON to inspect any run.
3. If `results/eval-baseline.json` exists in the repo, `scripts/eval-diff.js` compares the two and prints its output to the Actions step summary panel.
4. **On regression** (pass rate dropped more than 5%): the workflow searches for an open issue titled `Eval drift detected` with the `auto:evals` label. If one exists it adds a comment with the run link and the diff output; otherwise it opens a new one. The workflow then exits 1 (red).
5. **On INCONCLUSIVE** (transient share above 20%): the diff prints a "skipping comparison" message and exits 0. No issue is opened. The workflow stays green.

The auto-issue uses a stable title so consecutive failures pile into one tracking thread instead of spawning duplicates. Close the issue when the regression is resolved; the next regression opens a fresh one.

**What does *not* happen yet:** drift detection is a no-op until someone commits `results/eval-baseline.json`. The first 2 or 3 cron runs are intentionally just artifact dumps so we can confirm stable output before picking a baseline.

## Sample output

**Console** (`npm run eval`, after the change):

```
  i01   PASS         I purchased 500 CEP licenses. Are my users auto...   12.8s
  m01   FAIL         Create a DLP rule that warns users when they tr...   9.1s
              expected tool not called: "create_chrome_dlp_rule"
              Judge: The agent failed to execute the requested task.

Results: 1 of 2 runs passed (50.0% pass rate)
  inspection           1 of 1 passed (100.0%)
  mutation             0 of 1 passed (0.0%)
```

**Drift script** (`node scripts/eval-diff.js results/eval-baseline.json results/eval-latest.json`):

```
Comparing eval results against baseline:
  Baseline pass rate:  100.0%  (20 of 20 runs passed)
  Current pass rate:   90.0%   (18 of 20 runs passed)
  Change:              −10.0% (regression)
  Threshold:           5.0% drop allowed before failing

Cases that were clean in the baseline but failed this run:
  - i03 (inspection)
  - m02 (mutation)

REGRESSION: pass rate dropped by 10.0%, which exceeds the 5.0% threshold.
```

When transient share crosses 20% the run is marked inconclusive and the diff is skipped:

```
Skipping comparison: the current run hit too many transient errors
(infrastructure / network / quota failures) to be trusted.
Rerun the workflow.
```

## Files

- `.github/workflows/agent-evals.yml` (new). Daily cron at 11:00 UTC + `workflow_dispatch`. `npm ci`, runs the suite to `results/eval-latest.json`, uploads `results/` as an artifact, runs `eval-diff.js` against `results/eval-baseline.json` if it exists, and on diff exit 1 opens or updates an issue labeled `auto:evals` with title `Eval drift detected`. The runner step is `continue-on-error: true`; the diff step's exit code is the authoritative signal.
- `test/evals/lib/transient.js` (new). `isTransient(err)` matches 5xx/429/408 status, codes (`ECONNRESET`, `ETIMEDOUT`, `EAI_AGAIN`, …), and the message patterns from `[GoogleGenerativeAI Error]`. `withTransientRetry()` retries up to 3 times with `2000ms × 2^attempt` backoff plus jitter.
- `test/evals/run.js`. Wraps `agent.query()` and `judgeFn()` with the retry helper. Each result now carries `status: 'PASS' | 'FAIL' | 'TRANSIENT'` and a `transient: { source, message } | null`. Pass rate is `PASS / (PASS + FAIL)`. New const `TRANSIENT_RUN_CEILING = 0.2` near the top.
- `scripts/eval-diff.js` (new). Reads two JSONs. Exits 0 when no baseline, when within threshold, or when either side is `inconclusive: true`. Exits 1 on regression beyond the threshold.
- `test/evals/lib/reporter.js`. JSON gains `summary.passed/failed/transient/total/inconclusive` and per-case `passed/failed/transient/total/passRate/isStable`. Markdown leads with a one-line callout explaining "transient error" and switches to "1 of 2 runs passed" prose.
- `test/evals/lib/judge.js`. Re-throws on transient instead of swallowing, so the runner's wrapper can see and retry.
- `test/evals/analyze-flaky.js`. One-line filter so transient runs are not counted as "judge fails only".

## Deferred to follow-up PRs

- Commit `results/eval-baseline.json` after 2 or 3 clean runs (turns drift detection on).
- PR trigger on agent-affecting paths (`tools/**`, `prompts/**`, `lib/knowledge/**`, `lib/util/wrapper.js`, `mcp-server.js`).

## Test plan

- [x] `npm run lint` clean.
- [x] `npm run test:unit`: 421/421 pass.
- [x] `npm run test:integration:fake`: 11/11 pass; smoke passes.
- [x] `node test/evals/run.js --dry-run --id i01,m01 --output /tmp/eval.json`: produces the new JSON shape; same with `.md`.
- [x] `scripts/eval-diff.js` against four scenarios (identical, no-baseline, simulated 10% regression, INCONCLUSIVE): exits 0/0/1/0.
- [x] One real two-case Gemini run exercises the agent + judge retry wrappers: no transients fired, wrappers flow through cleanly, exit code 1 on FAIL, JSON output validates.
- [ ] Auto-issue creation can only be exercised post-merge (workflow needs to be on `main` for `workflow_dispatch`). Plan: trigger via `gh workflow run agent-evals.yml --ref main` after merge, with a deliberately bad baseline checked in temporarily, to confirm the issue opens; then revert.