### PR TITLE
[abandoned] Revert "chore(deps): bump axios in the npm_and_yarn group across 1 directory"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "zod": "^3.25.76"
       },
       "bin": {
-        "chrome-enterprise-premium-mcp": "bin/cli.js"
+        "chrome-enterprise-premium-mcp": "mcp-server.js"
       },
       "devDependencies": {
         "@commitlint/cli": "^20.5.3",
@@ -904,10 +904,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
-      "license": "MIT",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",


### PR DESCRIPTION
[abandoned]

Originally opened to revert #149, pinning `axios` back to `1.15.0` while broader Dependabot/CLA handling for this repo was sorted out.

Abandoned because the revert is no longer needed.