### PR TITLE
chore(test): move cli.test.js into test/integration/server/

### DIFF
--- a/test/integration/server/cli.test.js
+++ b/test/integration/server/cli.test.js
@@ -25,7 +25,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
-const CLI = path.resolve(__dirname, '../../bin/cli.js')
+const CLI = path.resolve(__dirname, '../../../bin/cli.js')
 
 describe('bin/cli.js', () => {
   describe('auth-status', () => {
@@ -44,7 +44,7 @@ describe('bin/cli.js', () => {
 
 describe('runLoginCommand', () => {
   it('When login is invoked and runLoginFlow succeeds, then it prints the cached message and exits 0', async () => {
-    const { runLoginCommand } = await import('../../lib/util/credential/cli_commands.js')
+    const { runLoginCommand } = await import('../../../lib/util/credential/cli_commands.js')
 
     const runLoginFlow = mock.fn(async () => {})
     const credentialFactory = mock.fn(() => ({ runLoginFlow }))
@@ -72,7 +72,7 @@ describe('runLoginCommand', () => {
 
 describe('runLoginCommand BYO notice', () => {
   it('When source is managed, then no notice prints', async () => {
-    const { runLoginCommand } = await import('../../lib/util/credential/cli_commands.js')
+    const { runLoginCommand } = await import('../../../lib/util/credential/cli_commands.js')
 
     const runLoginFlow = mock.fn(async () => {})
     const credentialFactory = mock.fn(() => ({ runLoginFlow }))
@@ -101,7 +101,7 @@ describe('runLoginCommand BYO notice', () => {
   })
 
   it('When source is custom and no marker exists, then notice prints and marker is created', async () => {
-    const { runLoginCommand } = await import('../../lib/util/credential/cli_commands.js')
+    const { runLoginCommand } = await import('../../../lib/util/credential/cli_commands.js')
     const fs = await import('node:fs/promises')
     const os = await import('node:os')
     const path = await import('node:path')
@@ -137,7 +137,7 @@ describe('runLoginCommand BYO notice', () => {
   })
 
   it('When source is custom and marker exists, then notice does not print', async () => {
-    const { runLoginCommand } = await import('../../lib/util/credential/cli_commands.js')
+    const { runLoginCommand } = await import('../../../lib/util/credential/cli_commands.js')
     const fs = await import('node:fs/promises')
     const os = await import('node:os')
     const path = await import('node:path')


### PR DESCRIPTION
The "🚧 Test budget tripwires" job has been failing on every open PR because `test/local/cli.test.js` imports `spawnSync` from `node:child_process`, which the rule added in #139 rejects under `test/local/` and `test/unit/`. PR #140 moved `mcp-server.test.js` and `prompts.test.js` into `test/integration/server/` for the same reason but missed `cli.test.js`.

This PR moves the file and fixes the relative-import paths.

## Changes

- `git mv test/local/cli.test.js test/integration/server/cli.test.js`
- Inside the file, one extra `../` level on the existing relative paths:
  - `'../../bin/cli.js'` → `'../../../bin/cli.js'`
  - `'../../lib/util/credential/cli_commands.js'` → `'../../../lib/util/credential/cli_commands.js'` (4 occurrences)

No assertions, no behavior, no other code paths changed.

## Test plan

- [x] `npm run lint` clean.
- [x] `npm run test:unit` passes (cli tests no longer in the unit bucket, as intended).
- [x] `npm run test:integration:fake` runs 25/28 (3 skipped, 0 failed); cli suite is picked up by `test/run-integration.js` via its existing recursive walk over `test/integration/server/`.
- [x] Tripwire grep `find test/local test/unit -name '*.test.js' -exec grep -lE 'from .node:child_process|from .child_process|StdioClientTransport' {} +` returns no hits.

## Unblocks

- PR #154 (`chore/commit-eval-baseline`)
- Any other open or future PR against `main`.
