### PR TITLE
fix(mcp-server): well-formed JSON-RPC errors on transport endpoints

### DIFF
--- a/mcp-server.js
+++ b/mcp-server.js
@@ -437,13 +437,11 @@ export async function runServer() {
 
       app.get('/mcp', async (_req, res) => {
         logger.info(`${TAGS.MCP} Received GET MCP request`)
-        res.writeHead(405).end(
-          JSON.stringify({
-            jsonrpc: '2.0',
-            error: { code: -32000, message: 'Method not allowed.' },
-            id: null,
-          }),
-        )
+        res.status(405).json({
+          jsonrpc: '2.0',
+          error: { code: -32000, message: 'Method not allowed.' },
+          id: null,
+        })
       })
 
       const sseTransports = {}
@@ -463,7 +461,11 @@ export async function runServer() {
           // response body and trip the reflected-XSS detector regardless of
           // the response content type.
           logger.warn(`${TAGS.MCP} /messages: no transport found for sessionId: ${String(sessionId)}`)
-          res.status(400).send('No transport found for the provided sessionId')
+          res.status(400).json({
+            jsonrpc: '2.0',
+            error: { code: -32000, message: 'No transport found for the provided sessionId.' },
+            id: null,
+          })
         }
       })
 

--- a/test/integration/server/cli.test.js
+++ b/test/integration/server/cli.test.js
@@ -27,6 +27,21 @@ import { fileURLToPath } from 'node:url'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const CLI = path.resolve(__dirname, '../../../bin/cli.js')
 
+async function captureConsoleLogs(fn) {
+  const lines = []
+  const origLog = console.log
+  console.log = msg => {
+    lines.push(msg)
+  }
+  try {
+    await fn()
+  } finally {
+    // eslint-disable-next-line require-atomic-updates
+    console.log = origLog
+  }
+  return lines
+}
+
 describe('bin/cli.js', () => {
   describe('auth-status', () => {
     it('When invoked with auth-status and ADC absent, then it prints the ADC line and an OAuth flow line', () => {
@@ -50,19 +65,9 @@ describe('runLoginCommand', () => {
     const credentialFactory = mock.fn(() => ({ runLoginFlow }))
     const configResolver = mock.fn(() => ({ source: 'managed', clientId: '', clientSecret: '' }))
 
-    const lines = []
-
-    const origLog = console.log
-
-    console.log = msg => {
-      lines.push(msg)
-    }
-    try {
+    const lines = await captureConsoleLogs(async () => {
       await runLoginCommand({ credentialFactory, configResolver })
-    } finally {
-      // eslint-disable-next-line require-atomic-updates
-      console.log = origLog
-    }
+    })
 
     assert.equal(credentialFactory.mock.calls.length, 1)
     assert.equal(runLoginFlow.mock.calls.length, 1)
@@ -82,19 +87,9 @@ describe('runLoginCommand BYO notice', () => {
       clientSecret: '',
     }))
 
-    const lines = []
-
-    const origLog = console.log
-
-    console.log = msg => {
-      lines.push(msg)
-    }
-    try {
+    const lines = await captureConsoleLogs(async () => {
       await runLoginCommand({ credentialFactory, configResolver })
-    } finally {
-      // eslint-disable-next-line require-atomic-updates
-      console.log = origLog
-    }
+    })
 
     const noticePresent = lines.some(l => /Custom OAuth client detected/i.test(l))
     assert.equal(noticePresent, false)
@@ -107,33 +102,26 @@ describe('runLoginCommand BYO notice', () => {
     const path = await import('node:path')
 
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cep-mcp-test-'))
-    const noticePath = path.join(tmpDir, 'byo-notice.shown')
-
-    const runLoginFlow = mock.fn(async () => {})
-    const credentialFactory = mock.fn(() => ({ runLoginFlow }))
-    const configResolver = mock.fn(() => ({
-      source: 'custom',
-      clientId: 'test',
-      clientSecret: 'test',
-    }))
-
-    const lines = []
-
-    const origLog = console.log
-
-    console.log = msg => {
-      lines.push(msg)
-    }
     try {
-      await runLoginCommand({ credentialFactory, noticePath, configResolver })
+      const noticePath = path.join(tmpDir, 'byo-notice.shown')
+
+      const runLoginFlow = mock.fn(async () => {})
+      const credentialFactory = mock.fn(() => ({ runLoginFlow }))
+      const configResolver = mock.fn(() => ({
+        source: 'custom',
+        clientId: 'test',
+        clientSecret: 'test',
+      }))
+
+      const lines = await captureConsoleLogs(async () => {
+        await runLoginCommand({ credentialFactory, noticePath, configResolver })
+      })
+
+      const noticePresent = lines.some(l => /Custom OAuth client detected/i.test(l))
+      assert.equal(noticePresent, true)
     } finally {
-      // eslint-disable-next-line require-atomic-updates
-      console.log = origLog
       await fs.rm(tmpDir, { recursive: true, force: true })
     }
-
-    const noticePresent = lines.some(l => /Custom OAuth client detected/i.test(l))
-    assert.equal(noticePresent, true)
   })
 
   it('When source is custom and marker exists, then notice does not print', async () => {
@@ -143,36 +131,29 @@ describe('runLoginCommand BYO notice', () => {
     const path = await import('node:path')
 
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cep-mcp-test-'))
-    const noticePath = path.join(tmpDir, 'byo-notice.shown')
-
-    // Pre-create marker
-    await fs.mkdir(path.dirname(noticePath), { recursive: true })
-    await fs.writeFile(noticePath, new Date().toISOString())
-
-    const runLoginFlow = mock.fn(async () => {})
-    const credentialFactory = mock.fn(() => ({ runLoginFlow }))
-    const configResolver = mock.fn(() => ({
-      source: 'custom',
-      clientId: 'test',
-      clientSecret: 'test',
-    }))
-
-    const lines = []
-
-    const origLog = console.log
-
-    console.log = msg => {
-      lines.push(msg)
-    }
     try {
-      await runLoginCommand({ credentialFactory, noticePath, configResolver })
+      const noticePath = path.join(tmpDir, 'byo-notice.shown')
+
+      // Pre-create marker
+      await fs.mkdir(path.dirname(noticePath), { recursive: true })
+      await fs.writeFile(noticePath, new Date().toISOString())
+
+      const runLoginFlow = mock.fn(async () => {})
+      const credentialFactory = mock.fn(() => ({ runLoginFlow }))
+      const configResolver = mock.fn(() => ({
+        source: 'custom',
+        clientId: 'test',
+        clientSecret: 'test',
+      }))
+
+      const lines = await captureConsoleLogs(async () => {
+        await runLoginCommand({ credentialFactory, noticePath, configResolver })
+      })
+
+      const noticePresent = lines.some(l => /Custom OAuth client detected/i.test(l))
+      assert.equal(noticePresent, false)
     } finally {
-      // eslint-disable-next-line require-atomic-updates
-      console.log = origLog
       await fs.rm(tmpDir, { recursive: true, force: true })
     }
-
-    const noticePresent = lines.some(l => /Custom OAuth client detected/i.test(l))
-    assert.equal(noticePresent, false)
   })
 })


### PR DESCRIPTION
## Summary

Two HTTP transport endpoints respond in shapes that violate what an MCP client expects on a JSON-RPC channel:

- `GET /mcp` writes a JSON-RPC envelope via `res.writeHead(405).end(JSON.stringify(...))`, which never sets `Content-Type: application/json`. A strict client (or a fronting proxy that sniffs by header rather than body) refuses to parse the body or mislabels the response.
- `POST /messages` with a stale `sessionId` returns `text/html` and the bare string `"No transport found for the provided sessionId"` via `res.send`. Every sibling endpoint on the same router returns a `{jsonrpc, error, id}` envelope. A client wired to parse JSON-RPC failures on its transport throws on this one response shape and surfaces an opaque parse error instead of the actual cause.

Each handler now calls `res.status(...).json(...)` with a standard `-32000` envelope, matching the existing patterns near `mcp-server.js:197`.

## Bonus: test helper extraction

Four `runLoginCommand` tests in `cli.test.js` open-coded the same `console.log` capture ritual — stash the original, replace with a pushing closure, restore in `finally`, with an `eslint-disable require-atomic-updates` per copy. The four call sites now share one `captureConsoleLogs(fn)` helper, and the suppression lives in one place.

## Test plan
- [x] `node --test test/integration/server/cli.test.js` — 5/5 pass
- [x] `node --test test/integration/server/mcp-server.test.js` — 5/5 pass