### PR TITLE
[abandoned] docs(readme): rewrite Quick Start around mcp auth login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,18 @@
 # GOOGLE_CLOUD_QUOTA_PROJECT=your-project-id
 
 
+# Bring your own OAuth client
+#
+# `mcp auth login` uses a bundled Google-managed OAuth client by default. To use
+# a custom Desktop OAuth client you create in your own Google Cloud project
+# (so authorization grants and the consent screen stay inside a project you
+# own), set both variables below. See docs/auth-bring-your-own-oauth-client.md
+# for the full walkthrough.
+
+# CEP_OAUTH_CLIENT_ID=your-desktop-oauth-client-id
+# CEP_OAUTH_CLIENT_SECRET=your-desktop-oauth-client-secret
+
+
 # Transport
 #
 # The server defaults to stdio transport (for local MCP clients like Claude

--- a/.env.example
+++ b/.env.example
@@ -24,11 +24,16 @@
 
 # Bring your own OAuth client
 #
-# `mcp auth login` uses a bundled Google-managed OAuth client by default. To use
-# a custom Desktop OAuth client you create in your own Google Cloud project
-# (so authorization grants and the consent screen stay inside a project you
-# own), set both variables below. See docs/auth-bring-your-own-oauth-client.md
-# for the full walkthrough.
+# When you run `mcp auth login` without setting these variables, you
+# authenticate through a Google-managed OAuth client that is bundled with the
+# server. To authenticate through a Desktop OAuth client that you have created
+# in a Google Cloud project of your own, set both variables below.
+#
+# With a custom client, the OAuth consent screen and any authorization grants
+# are scoped to your own project rather than to the bundled one.
+#
+# For the full walkthrough, including how to create the Desktop OAuth client
+# in the Cloud console, see docs/auth-bring-your-own-oauth-client.md.
 
 # CEP_OAUTH_CLIENT_ID=your-desktop-oauth-client-id
 # CEP_OAUTH_CLIENT_SECRET=your-desktop-oauth-client-secret

--- a/README.md
+++ b/README.md
@@ -9,23 +9,26 @@ connector policies, browser telemetry, and license management as MCP tools —
 letting any MCP-compatible AI agent inspect and configure a Chrome Enterprise
 environment.
 
-## Important security consideration: Indirect Prompt Injection Risk
-
-When exposing any language model to untrusted data, there's a risk of an
-[indirect prompt injection attack](https://en.wikipedia.org/wiki/Prompt_injection).
-Agentic tools like Gemini CLI, connected to MCP servers, have access to a wide
-array of tools and APIs.
-
-This MCP server grants the agent the ability to read, modify, and delete your
-Google Account data, as well as other data shared with you.
-
-- Never connect this server to untrusted tools.
-- Never feed untrusted content into the model context, including mail,
-  documents, or other resources from unverified sources.
-- Attackers can hide instructions inside untrusted content and use a
-  hijacked CLI session to modify, steal, or destroy your data.
-- Always review the actions Gemini CLI takes on your behalf and confirm
-  they match what you asked for.
+> [!CAUTION]
+> **This server is an administrator-level interface to Chrome Enterprise Premium.**
+> When you connect it to an MCP client, you can use natural-language prompts to:
+>
+> - Create, modify, and delete DLP rules and content detectors.
+> - Change connector policies.
+> - Force-install browser extensions onto every managed Chrome browser.
+> - Enable Google Cloud APIs on your project.
+>
+> An attacker who plants hidden instructions in untrusted inputs—mail,
+> documents, scraped pages, ticket bodies—can hijack the connected MCP
+> client through [indirect prompt injection](https://en.wikipedia.org/wiki/Prompt_injection).
+> The attacker can then run those tools without your consent.
+>
+> To reduce the blast radius:
+>
+> - Connect this server only to MCP clients you trust, on data sources you trust.
+> - Treat every document, message, and webpage you put in front of the agent as untrusted. It might contain hidden instructions.
+> - Pay extra attention to mutating tools (`create_*`, `update_*`, `delete_*`, `enable_*`); they have tenant-wide security impact.
+> - Use a dedicated, least-privilege admin account when experimenting.
 
 ## Quick start
 
@@ -35,10 +38,25 @@ cd chrome-enterprise-premium-mcp
 npm install
 ```
 
-### 1. Authenticate with Google Cloud
+### 1. Sign in
 
-Install the [Google Cloud CLI](https://cloud.google.com/sdk/docs/install) if you
-don't have it, then create
+Run `mcp auth login` and approve consent in the browser. The CLI caches
+the access token at `~/.config/cep-mcp/tokens.json`.
+
+To use a custom OAuth client, provide `CEP_OAUTH_CLIENT_ID` and
+`CEP_OAUTH_CLIENT_SECRET`. With a custom client, you keep authorization
+grants and the consent screen inside a Google Cloud project you own. See
+[Bring your own OAuth client](docs/auth-bring-your-own-oauth-client.md).
+
+For the headless flow, see
+[Sign in from a host without a browser](docs/auth-bring-your-own-oauth-client.md#sign-in-from-a-host-without-a-browser).
+
+#### Application Default Credentials
+
+If you already use `gcloud` and hold Google Cloud admin rights on a
+project, sign in with Application Default Credentials. Install the
+[Google Cloud CLI](https://cloud.google.com/sdk/docs/install) if you don't
+have it, then create
 [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials)
 (ADC) with the scopes needed by each API:
 
@@ -74,31 +92,37 @@ These scopes map to the underlying APIs:
 | `cloud-identity.policies`                                             | [Cloud Identity](https://cloud.google.com/identity/docs)                        | DLP rules and content detectors (CRUD)                             |
 | `service.management`, `service.management.readonly`, `cloud-platform` | [Service Usage](https://cloud.google.com/service-usage/docs)                    | Checking and enabling required APIs                                |
 
-Then set a quota project (identifies which GCP project's API enablement and
-quotas to use):
+Then set a quota project (identifies which Google Cloud project's API
+enablement and quotas to use):
 
 ```bash
 gcloud auth application-default set-quota-project YOUR_PROJECT_ID
 ```
 
-> **Scopes must be provided at login time.** You cannot add scopes to
-> existing ADC credentials. If you get "insufficient scopes" errors,
-> delete `~/.config/gcloud/application_default_credentials.json` and re-run
-> the `gcloud auth application-default login` command from the previous step.
+> [!IMPORTANT]
+> Scopes must be provided at login time. You cannot add scopes to existing
+> ADC credentials. If you get "insufficient scopes" errors, delete
+> `~/.config/gcloud/application_default_credentials.json` and re-run the
+> `gcloud auth application-default login` command.
 >
-> **The quota project is required.** Without it you'll see a "quota project
-> not set" error on the first API call.
->
-> **Restricted Workspace environments:** If your organization restricts third-party
-> app access, an admin must [trust the gcloud OAuth app](docs/troubleshooting.md#configure-oauth-app-for-sensitive-scopes)
+> The quota project is required. Without it the first API call returns a
+> "quota project not set" error.
+
+> [!NOTE]
+> If your organization restricts third-party app access, an administrator
+> must
+> [trust the gcloud OAuth app](docs/troubleshooting.md#configure-oauth-app-for-sensitive-scopes)
 > before you can authenticate with sensitive Workspace scopes.
-> **Alternative to ADC:** run `mcp auth login` for an OAuth-flow setup.
-> Setup walkthrough at [`docs/auth-bring-your-own-oauth-client.md`](docs/auth-bring-your-own-oauth-client.md).
-> Auth-method matrix at [`docs/configuration.md#authenticating-to-google-apis`](docs/configuration.md#authenticating-to-google-apis).
 
-### 2. Enable Required APIs
+#### Hosted deployments
 
-These APIs must be enabled on your GCP project:
+For Cloud Run, Vertex AI Agent Engine, or service-account automation, see
+the
+[authentication setup matrix](docs/configuration.md#authenticate-to-google-apis).
+
+### 2. Enable required APIs
+
+These APIs must be enabled on your Google Cloud project:
 
 ```bash
 gcloud services enable \
@@ -113,12 +137,12 @@ gcloud services enable \
 Or enable them from the
 [API Library](https://console.cloud.google.com/apis/library) in Cloud Console.
 
-> **Propagation delay:** Newly enabled APIs can take 1–5 minutes to become
-> available. The server handles this automatically by retrying
-> `PERMISSION_DENIED` errors with exponential backoff. If you see retry messages
-> on first run, wait; don't restart.
+> [!NOTE]
+> Newly enabled APIs can take 1–5 minutes to become available. The server
+> automatically retries `PERMISSION_DENIED` errors with exponential
+> backoff. If you see retry messages on first run, wait; don't restart.
 
-### 3. Connect Your MCP Client
+### 3. Connect your MCP client
 
 The server uses **stdio** transport; your MCP client launches it as a child
 process. Add the config snippet for your client:
@@ -200,7 +224,11 @@ Add to `~/.gemini/settings.json`:
 
 </details>
 
-> Optional: If you are running from a local checkout instead of npx, replace the command with `node` and args with the absolute path to `mcp-server.js`. Relative paths might not resolve correctly depending on the client.
+> [!TIP]
+> If you are running from a local checkout instead of npx, replace the
+> command with `node` and the args with the absolute path to
+> `mcp-server.js`. Relative paths might not resolve depending on the
+> client.
 
 ### 4. Verify
 
@@ -218,21 +246,22 @@ For environment variables and stdio vs. HTTP transport, see
 
 ## Prerequisites
 
-| Requirement          | Details                                                                                                                                                                                                                               |
-| :------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Node.js**          | >= 18.0.0 (`node --version` to check)                                                                                                                                                                                                 |
-| **Google Cloud CLI** | [`gcloud`](https://cloud.google.com/sdk/docs/install) installed and on your PATH (`gcloud --version` to check)                                                                                                                        |
-| **Google Workspace** | Any edition, plus a [Chrome Enterprise Premium](https://docs.cloud.google.com/chrome-enterprise-premium/docs/overview) license ([60-day free trial available](https://docs.cloud.google.com/chrome-enterprise-premium/docs/overview)) |
-| **Admin role**       | Google Workspace Super Admin, or a delegated admin with Chrome Management and DLP permissions                                                                                                                                         |
-| **GCP project**      | Linked to your Workspace domain, with required APIs enabled                                                                                                                                                                           |
-| **OAuth App Trust**  | The gcloud CLI must be [trusted in the Admin Console](docs/troubleshooting.md#configure-oauth-app-for-sensitive-scopes) for sensitive scopes.                                                                                         |
+| Requirement              | Details                                                                                                                                                                                                                               |
+| :----------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Node.js**              | >= 18.0.0 (`node --version` to check)                                                                                                                                                                                                 |
+| **Google Cloud CLI**     | [`gcloud`](https://cloud.google.com/sdk/docs/install) installed and on your PATH (`gcloud --version` to check)                                                                                                                        |
+| **Google Workspace**     | Any edition, plus a [Chrome Enterprise Premium](https://docs.cloud.google.com/chrome-enterprise-premium/docs/overview) license ([60-day free trial available](https://docs.cloud.google.com/chrome-enterprise-premium/docs/overview)) |
+| **Admin role**           | Google Workspace Super Admin, or a delegated admin with Chrome Management and DLP permissions                                                                                                                                         |
+| **Google Cloud project** | Linked to your Workspace domain, with required APIs enabled                                                                                                                                                                           |
+| **OAuth App Trust**      | The gcloud CLI must be [trusted in the Admin Console](docs/troubleshooting.md#configure-oauth-app-for-sensitive-scopes) for sensitive scopes.                                                                                         |
 
-> **GCP IAM is not enough.** Chrome Management and Admin SDK APIs require a
-> Google Workspace admin role _in addition to_ GCP IAM roles. The user must hold
-> an admin role in the [Admin Console](https://admin.google.com/) (Super Admin
-> or delegated with Chrome Management permissions). Having only GCP IAM
-> permissions produces `403 Permission Denied` with no indication that a
-> Workspace role is missing.
+> [!IMPORTANT]
+> Chrome Management and Admin SDK APIs require a Google Workspace admin
+> role in addition to Google Cloud IAM roles. You must hold an admin role
+> in the [Admin Console](https://admin.google.com/) (Super Admin or
+> delegated with Chrome Management permissions). With only Google Cloud
+> IAM permissions, calls return `403 Permission Denied` with no indication
+> that a Workspace role is missing.
 
 ## Available tools and prompts
 

--- a/docs/auth-bring-your-own-oauth-client.md
+++ b/docs/auth-bring-your-own-oauth-client.md
@@ -16,7 +16,7 @@ limitations under the License.
 
 # Bring your own OAuth client
 
-To run `mcp auth login`, you need a Google OAuth client. Until Google provisions a managed client for this project, you must supply your own. Set `CEP_OAUTH_CLIENT_ID` and `CEP_OAUTH_CLIENT_SECRET` in your environment to point at a Desktop OAuth client that you create in your Google Cloud project.
+To use a custom OAuth client instead of the bundled Google-managed one, set `CEP_OAUTH_CLIENT_ID` and `CEP_OAUTH_CLIENT_SECRET` to point at a Desktop OAuth client you create in a Google Cloud project. With a custom client, you keep authorization grants and the consent screen inside a project you own.
 
 When you log in, the CLI writes an access token to `~/.config/cep-mcp/tokens.json` with file mode `0600`. The cache contains the access token only—no refresh token—and the access token expires after about an hour.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,7 +64,7 @@ PORT=8080 GCP_STDIO=false npx -y @google/chrome-enterprise-premium-mcp@latest
 
 | Setup                      | Transport | Credential source                              | Setup walkthrough                                                                               |
 | :------------------------- | :-------- | :--------------------------------------------- | :---------------------------------------------------------------------------------------------- |
-| `gcloud` ADC (recommended) | stdio     | ADC, full scope set including `cloud-platform` | [Quick Start §1](../README.md#1-authenticate-with-google-cloud)                                 |
+| `gcloud` ADC (recommended) | stdio     | ADC, full scope set including `cloud-platform` | [Application Default Credentials](../README.md#application-default-credentials)                 |
 | OAuth login (workstation)  | stdio     | OAuth token cache, narrow scope set            | [`auth-bring-your-own-oauth-client.md`](auth-bring-your-own-oauth-client.md)                    |
 | Bearer pass-through        | HTTP      | per-request `Authorization: Bearer <token>`    | The caller sets the header; the server forwards it to Google verbatim.                          |
 | Service account + DWD      | stdio     | Service account with domain-wide delegation    | [FAQ entry on service accounts](faq.md#can-i-use-a-service-account-instead-of-user-credentials) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,12 +62,12 @@ PORT=8080 GCP_STDIO=false npx -y @google/chrome-enterprise-premium-mcp@latest
 
 `lib/util/auth.js#getAuthClient` resolves credentials in this priority order: a bearer header on the request, Application Default Credentials, then the OAuth token cache. Pick a setup based on your environment. For situational guidance by deployment shape, see the [Which auth path should I use?](faq.md#which-auth-path-should-i-use) FAQ entry.
 
-| Setup                      | Transport | Credential source                              | Setup walkthrough                                                                               |
-| :------------------------- | :-------- | :--------------------------------------------- | :---------------------------------------------------------------------------------------------- |
-| `gcloud` ADC (recommended) | stdio     | ADC, full scope set including `cloud-platform` | [Application Default Credentials](../README.md#application-default-credentials)                 |
-| OAuth login (workstation)  | stdio     | OAuth token cache, narrow scope set            | [`auth-bring-your-own-oauth-client.md`](auth-bring-your-own-oauth-client.md)                    |
-| Bearer pass-through        | HTTP      | per-request `Authorization: Bearer <token>`    | The caller sets the header; the server forwards it to Google verbatim.                          |
-| Service account + DWD      | stdio     | Service account with domain-wide delegation    | [FAQ entry on service accounts](faq.md#can-i-use-a-service-account-instead-of-user-credentials) |
+| Setup                          | Transport | Credential source                              | Setup walkthrough                                                                               |
+| :----------------------------- | :-------- | :--------------------------------------------- | :---------------------------------------------------------------------------------------------- |
+| `mcp auth login` (recommended) | stdio     | OAuth token cache, narrow scope set            | [`auth-bring-your-own-oauth-client.md`](auth-bring-your-own-oauth-client.md)                    |
+| `gcloud` ADC                   | stdio     | ADC, full scope set including `cloud-platform` | [Application Default Credentials](../README.md#application-default-credentials)                 |
+| Bearer pass-through            | HTTP      | per-request `Authorization: Bearer <token>`    | The caller sets the header; the server forwards it to Google verbatim.                          |
+| Service account + DWD          | stdio     | Service account with domain-wide delegation    | [FAQ entry on service accounts](faq.md#can-i-use-a-service-account-instead-of-user-credentials) |
 
 > [!IMPORTANT]
 > The HTTP-mode default has no network-layer authentication. Bind the listener to a trusted interface only, or set `CEP_BEARER_AUDIENCE` (HTTP mode only) for per-request ID-token verification.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -28,8 +28,8 @@ Chrome Enterprise Premium is a paid add-on available with any Google Workspace e
 
 The right path depends on your environment.
 
-- **Workstation, gcloud installed, you are a Google Cloud admin for the project:** Application Default Credentials. Run `gcloud auth application-default login` per [Application Default Credentials](../README.md#application-default-credentials) in the README.
-- **Workstation, no gcloud or you are not a Google Cloud admin:** OAuth login. Run `mcp auth login`. For the setup walkthrough, see [`auth-bring-your-own-oauth-client.md`](auth-bring-your-own-oauth-client.md).
+- **Workstation (default):** Run `mcp auth login`. For details on bringing your own OAuth client, see [`auth-bring-your-own-oauth-client.md`](auth-bring-your-own-oauth-client.md).
+- **Workstation, already using `gcloud`:** Application Default Credentials is the alternative when you'd rather share a single credential across other Google Cloud tooling. See [Application Default Credentials](../README.md#application-default-credentials) in the README.
 - **Hosted on Cloud Run, Vertex AI Agent Engine, or a similar managed environment:** OAuth bearer per request. The caller sets `Authorization: Bearer <id-token>` and the server verifies the token's `aud` claim against `CEP_BEARER_AUDIENCE`. A service account with domain-wide delegation is the alternative. OAuth is preferred for hosted deployments because a service account with domain-wide delegation grants the server impersonation rights for any user in the domain.
 
 For the per-mechanism technical reference (transport, credential source, setup walkthrough), see the [authentication matrix](configuration.md#authenticate-to-google-apis) in `configuration.md`.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -28,7 +28,7 @@ Chrome Enterprise Premium is a paid add-on available with any Google Workspace e
 
 The right path depends on your environment.
 
-- **Workstation, gcloud installed, you are a Google Cloud admin for the project:** Application Default Credentials. Run `gcloud auth application-default login` per the [Quick Start](../README.md#1-authenticate-with-google-cloud).
+- **Workstation, gcloud installed, you are a Google Cloud admin for the project:** Application Default Credentials. Run `gcloud auth application-default login` per [Application Default Credentials](../README.md#application-default-credentials) in the README.
 - **Workstation, no gcloud or you are not a Google Cloud admin:** OAuth login. Run `mcp auth login`. For the setup walkthrough, see [`auth-bring-your-own-oauth-client.md`](auth-bring-your-own-oauth-client.md).
 - **Hosted on Cloud Run, Vertex AI Agent Engine, or a similar managed environment:** OAuth bearer per request. The caller sets `Authorization: Bearer <id-token>` and the server verifies the token's `aud` claim against `CEP_BEARER_AUDIENCE`. A service account with domain-wide delegation is the alternative. OAuth is preferred for hosted deployments because a service account with domain-wide delegation grants the server impersonation rights for any user in the domain.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 ### "Could not load the default credentials"
 
-Your Application Default Credentials are not configured. Run the login command from the [Quick Start](../README.md#1-authenticate-with-google-cloud), then verify the credentials file exists:
+Your Application Default Credentials are not configured. Run the login command from [Application Default Credentials](../README.md#application-default-credentials), then verify the credentials file exists:
 
 ```bash
 cat ~/.config/gcloud/application_default_credentials.json
@@ -36,7 +36,7 @@ The credentials lack the required scopes. The most common cause is running `gclo
 rm ~/.config/gcloud/application_default_credentials.json
 ```
 
-Then re-run the full login command from the [Quick Start](../README.md#1-authenticate-with-google-cloud).
+Then re-run the full login command from [Application Default Credentials](../README.md#application-default-credentials).
 
 ### "API requires a quota project, which is not set by default"
 


### PR DESCRIPTION
[abandoned]

Originally opened to rewrite the README Quick Start around `mcp auth login`, move the gcloud ADC walkthrough to a sub-section, and convert remaining blockquotes to GitHub callouts.

Abandoned because the change was bundled with #161 and #162 into the consolidated #163, which was itself split into a five-PR chain after review feedback.

Superseded by #173.