### PR TITLE
[abandoned] feat(auth): bundle Google-managed OAuth client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,25 @@
 # GOOGLE_CLOUD_QUOTA_PROJECT=your-project-id
 
 
+# Bring your own OAuth client
+#
+# When you run `mcp auth login` without setting these variables, you
+# authenticate through a Google-managed OAuth client that is bundled with the
+# server. To authenticate through a Desktop OAuth client that you have created
+# in a Google Cloud project of your own, set both variables below.
+#
+# With a custom client, the OAuth consent screen and any authorization grants
+# are scoped to your own project rather than to the bundled one.
+#
+# Note: the `client_secret` of a Desktop OAuth client is a public value, not a
+# confidential credential — Google's installed-app flow uses a loopback
+# redirect to bind authorization to user consent, not to the secret. See
+# docs/auth-bring-your-own-oauth-client.md for the full walkthrough.
+
+# CEP_OAUTH_CLIENT_ID=your-desktop-oauth-client-id
+# CEP_OAUTH_CLIENT_SECRET=your-desktop-oauth-client-secret
+
+
 # Transport
 #
 # The server defaults to stdio transport (for local MCP clients like Claude

--- a/README.md
+++ b/README.md
@@ -55,24 +55,23 @@ https://www.googleapis.com/auth/admin.directory.customer.readonly,\
 https://www.googleapis.com/auth/apps.licensing,\
 https://www.googleapis.com/auth/cloud-identity.policies,\
 https://www.googleapis.com/auth/service.management,\
-https://www.googleapis.com/auth/service.management.readonly,\
 https://www.googleapis.com/auth/cloud-platform
 ```
 
 These scopes map to the underlying APIs:
 
-| Scope                                                                 | API                                                                             | Used for                                                           |
-| :-------------------------------------------------------------------- | :------------------------------------------------------------------------------ | :----------------------------------------------------------------- |
-| `openid`, `userinfo.email`                                            | OpenID Connect                                                                  | Identifies the principal in startup banner output                  |
-| `chrome.management.policy`                                            | [Chrome Policy](https://developers.google.com/chrome/policy)                    | Reading and writing connector policies, extension install policies |
-| `chrome.management.reports.readonly`                                  | [Chrome Management](https://developers.google.com/chrome/management)            | Browser version counts                                             |
-| `chrome.management.profiles.readonly`                                 | [Chrome Management](https://developers.google.com/chrome/management)            | Listing managed browser profiles                                   |
-| `admin.reports.audit.readonly`                                        | [Admin SDK Reports](https://developers.google.com/admin-sdk/reports)            | Chrome activity logs                                               |
-| `admin.directory.orgunit.readonly`                                    | [Admin SDK Directory](https://developers.google.com/admin-sdk/directory)        | Organizational unit hierarchy                                      |
-| `admin.directory.customer.readonly`                                   | [Admin SDK Directory](https://developers.google.com/admin-sdk/directory)        | Customer ID resolution                                             |
-| `apps.licensing`                                                      | [Enterprise License Manager](https://developers.google.com/admin-sdk/licensing) | CEP subscription and per-user license checks                       |
-| `cloud-identity.policies`                                             | [Cloud Identity](https://cloud.google.com/identity/docs)                        | DLP rules and content detectors (CRUD)                             |
-| `service.management`, `service.management.readonly`, `cloud-platform` | [Service Usage](https://cloud.google.com/service-usage/docs)                    | Checking and enabling required APIs                                |
+| Scope                                  | API                                                                             | Used for                                                           |
+| :------------------------------------- | :------------------------------------------------------------------------------ | :----------------------------------------------------------------- |
+| `openid`, `userinfo.email`             | OpenID Connect                                                                  | Identifies the principal in startup banner output                  |
+| `chrome.management.policy`             | [Chrome Policy](https://developers.google.com/chrome/policy)                    | Reading and writing connector policies, extension install policies |
+| `chrome.management.reports.readonly`   | [Chrome Management](https://developers.google.com/chrome/management)            | Browser version counts                                             |
+| `chrome.management.profiles.readonly`  | [Chrome Management](https://developers.google.com/chrome/management)            | Listing managed browser profiles                                   |
+| `admin.reports.audit.readonly`         | [Admin SDK Reports](https://developers.google.com/admin-sdk/reports)            | Chrome activity logs                                               |
+| `admin.directory.orgunit.readonly`     | [Admin SDK Directory](https://developers.google.com/admin-sdk/directory)        | Organizational unit hierarchy                                      |
+| `admin.directory.customer.readonly`    | [Admin SDK Directory](https://developers.google.com/admin-sdk/directory)        | Customer ID resolution                                             |
+| `apps.licensing`                       | [Enterprise License Manager](https://developers.google.com/admin-sdk/licensing) | CEP subscription and per-user license checks                       |
+| `cloud-identity.policies`              | [Cloud Identity](https://cloud.google.com/identity/docs)                        | DLP rules and content detectors (CRUD)                             |
+| `service.management`, `cloud-platform` | [Service Usage](https://cloud.google.com/service-usage/docs)                    | Checking and enabling required APIs                                |
 
 Then set a quota project (identifies which GCP project's API enablement and
 quotas to use):

--- a/adk/cep_agent/README.md
+++ b/adk/cep_agent/README.md
@@ -58,7 +58,6 @@ Follow these steps to run the agent against a real Google Cloud project.
    https://www.googleapis.com/auth/apps.licensing,\
    https://www.googleapis.com/auth/cloud-identity.policies,\
    https://www.googleapis.com/auth/service.management,\
-   https://www.googleapis.com/auth/service.management.readonly,\
    https://www.googleapis.com/auth/cloud-platform \
      --no-launch-browser
    ```

--- a/docs/auth-bring-your-own-oauth-client.md
+++ b/docs/auth-bring-your-own-oauth-client.md
@@ -16,7 +16,12 @@ limitations under the License.
 
 # Bring your own OAuth client
 
-To run `mcp auth login`, you need a Google OAuth client. Until Google provisions a managed client for this project, you must supply your own. Set `CEP_OAUTH_CLIENT_ID` and `CEP_OAUTH_CLIENT_SECRET` in your environment to point at a Desktop OAuth client that you create in your Google Cloud project.
+By default, `mcp auth login` uses a Google-managed Desktop OAuth client that ships with this project. You do not need to supply your own credentials to authenticate.
+
+Set `CEP_OAUTH_CLIENT_ID` and `CEP_OAUTH_CLIENT_SECRET` only if you want to authenticate through a Desktop OAuth client that you have created in a Google Cloud project of your own. With a custom client, the OAuth consent screen and any authorization grants are scoped to your own project rather than to the bundled one.
+
+> [!NOTE]
+> The `client_secret` of a Desktop OAuth client is a public value, not a confidential credential. Per Google's documentation for installed applications, the secret is "embedded in the source code of your application" and "is obviously not treated as a secret." Authorization is bound to the end user's Google consent and to the registered loopback redirect URI (`http://127.0.0.1`), not to the secret. The same property holds for any Desktop OAuth client you create yourself, including under BYO.
 
 When you log in, the CLI writes an access token to `~/.config/cep-mcp/tokens.json` with file mode `0600`. The cache contains the access token only—no refresh token—and the access token expires after about an hour.
 

--- a/lib/api/real_service_usage_client.js
+++ b/lib/api/real_service_usage_client.js
@@ -46,7 +46,7 @@ export class RealServiceUsageClient extends ServiceUsageClient {
     return createApiClient(
       google.serviceusage,
       API_VERSIONS.SERVICE_USAGE,
-      [SCOPES.SERVICE_USAGE, SCOPES.SERVICE_USAGE_READONLY, SCOPES.CLOUD_PLATFORM],
+      [SCOPES.SERVICE_USAGE, SCOPES.CLOUD_PLATFORM],
       authToken,
       this.apiOptions,
     )

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -43,7 +43,6 @@ export const SCOPES = {
   LICENSING: 'https://www.googleapis.com/auth/apps.licensing',
   CLOUD_IDENTITY_POLICIES: 'https://www.googleapis.com/auth/cloud-identity.policies',
   SERVICE_USAGE: 'https://www.googleapis.com/auth/service.management',
-  SERVICE_USAGE_READONLY: 'https://www.googleapis.com/auth/service.management.readonly',
   CLOUD_PLATFORM: 'https://www.googleapis.com/auth/cloud-platform',
 }
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -56,14 +56,31 @@ export const SCOPES = {
 export const OAUTH_SCOPES = Object.values(SCOPES).filter(s => s !== SCOPES.CLOUD_PLATFORM)
 
 /**
- * Bundled managed OAuth client. The placeholder string ships in source until
- * Google provisions and allowlists the real client. Until then, set
- * CEP_OAUTH_CLIENT_ID and CEP_OAUTH_CLIENT_SECRET (BYO) for `mcp auth login`
- * to work.
+ * Bundled managed OAuth client used by `mcp auth login`. This is a Google
+ * Cloud "Desktop app" / installed-application OAuth client that uses the
+ * loopback redirect (`http://127.0.0.1`) flow.
+ *
+ * The `client_secret` below is NOT a confidential credential. Per Google's
+ * OAuth 2.0 documentation for installed applications, "the process results
+ * in a client ID and, in some cases, a client secret, which you embed in the
+ * source code of your application. (In this context, the client secret is
+ * obviously not treated as a secret.)" See
+ * https://developers.google.com/identity/protocols/oauth2 (Installed apps).
+ *
+ * Loopback flows are public-client flows: the secret cannot be kept private
+ * because it ships in every CLI installation. Authorization is bound to the
+ * end user's Google consent and to the registered loopback redirect URI, not
+ * to the secret. Treating the secret as confidential would not improve
+ * security and would prevent a single managed client from serving all CLI
+ * users.
+ *
+ * Side effect: GitHub secret scanning detects the `GOCSPX-` prefix as a
+ * generic Google OAuth client secret. The push that introduced this constant
+ * was bypassed knowingly. Any future rotation of this client will need the
+ * same bypass.
  */
-export const MANAGED_OAUTH_CLIENT_PLACEHOLDER = 'TODO_MANAGED_OAUTH_CLIENT'
-export const MANAGED_OAUTH_CLIENT_ID = MANAGED_OAUTH_CLIENT_PLACEHOLDER
-export const MANAGED_OAUTH_CLIENT_SECRET = MANAGED_OAUTH_CLIENT_PLACEHOLDER
+export const MANAGED_OAUTH_CLIENT_ID = '947770278602-hctligr4a44evo28n944q048holagerh.apps.googleusercontent.com'
+export const MANAGED_OAUTH_CLIENT_SECRET = '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'
 
 export const API_VERSIONS = {
   CHROME_MANAGEMENT: 'v1',

--- a/lib/util/auth_messages.js
+++ b/lib/util/auth_messages.js
@@ -188,7 +188,7 @@ export function buildQuotaProjectWarning(adc) {
  */
 export function buildOAuthClientField(config) {
   if (!config) {
-    return 'OAuth client: TODO (managed client not yet provisioned; set CEP_OAUTH_CLIENT_ID/SECRET to bring your own)'
+    return 'OAuth client: unresolved (check CEP_OAUTH_CLIENT_ID/SECRET pairing)'
   }
   if (config.source === 'managed') {
     return 'OAuth client: Google-managed'

--- a/lib/util/credential/oauth_client_config.js
+++ b/lib/util/credential/oauth_client_config.js
@@ -20,11 +20,7 @@ limitations under the License.
  * bundled Google-managed values used as the default.
  */
 
-import {
-  MANAGED_OAUTH_CLIENT_ID,
-  MANAGED_OAUTH_CLIENT_SECRET,
-  MANAGED_OAUTH_CLIENT_PLACEHOLDER,
-} from '../../constants.js'
+import { MANAGED_OAUTH_CLIENT_ID, MANAGED_OAUTH_CLIENT_SECRET } from '../../constants.js'
 
 /**
  * @typedef {object} OAuthClientConfig
@@ -34,23 +30,10 @@ import {
  */
 
 /**
- * True when MANAGED_OAUTH_CLIENT_ID/SECRET still hold the TODO placeholder
- * value. The managed flow cannot run until both are replaced with the real
- * Google-managed client credentials.
- * @returns {boolean} Whether the managed client is unprovisioned.
- */
-export function managedClientIsPlaceholder() {
-  return (
-    MANAGED_OAUTH_CLIENT_ID === MANAGED_OAUTH_CLIENT_PLACEHOLDER ||
-    MANAGED_OAUTH_CLIENT_SECRET === MANAGED_OAUTH_CLIENT_PLACEHOLDER
-  )
-}
-
-/**
  * Resolves OAuth client configuration from environment variables or bundled defaults.
  * @param {object} [env] Environment variables object. Defaults to process.env.
  * @returns {OAuthClientConfig} OAuth client configuration object.
- * @throws {Error} When exactly one of the two env vars is set, or when the bundled managed client is still a TODO placeholder and no custom override is provided.
+ * @throws {Error} When exactly one of the two env vars is set.
  */
 export function resolveOAuthClientConfig(env = process.env) {
   const id = env.CEP_OAUTH_CLIENT_ID
@@ -64,13 +47,6 @@ export function resolveOAuthClientConfig(env = process.env) {
   }
   if (idSet && secretSet) {
     return { clientId: id, clientSecret: secret, source: 'custom' }
-  }
-  if (managedClientIsPlaceholder()) {
-    throw new Error(
-      'Managed OAuth client is not yet provisioned. ' +
-        'Set CEP_OAUTH_CLIENT_ID and CEP_OAUTH_CLIENT_SECRET to bring your own OAuth client, ' +
-        'or wait until the bundled managed client is allowlisted for the scopes in lib/constants.js#SCOPES.',
-    )
   }
   return {
     clientId: MANAGED_OAUTH_CLIENT_ID,

--- a/lib/util/credential/oauth_flow.js
+++ b/lib/util/credential/oauth_flow.js
@@ -23,12 +23,7 @@ import readline from 'node:readline'
 import { OAuth2Client } from 'google-auth-library'
 import { TokenCache } from './token_cache.js'
 import { startLoopbackServer } from './loopback_server.js'
-import {
-  OAUTH_SCOPES,
-  MANAGED_OAUTH_CLIENT_ID,
-  MANAGED_OAUTH_CLIENT_SECRET,
-  MANAGED_OAUTH_CLIENT_PLACEHOLDER,
-} from '../../constants.js'
+import { OAUTH_SCOPES, MANAGED_OAUTH_CLIENT_ID, MANAGED_OAUTH_CLIENT_SECRET } from '../../constants.js'
 
 /**
  * Opens the given URL in the user's default browser. Respects BROWSER env var.
@@ -240,13 +235,6 @@ export function oauthFlowCredential({
      * @returns {Promise<object>} The token object returned by the code exchange.
      */
     async runLoginFlow({ openBrowser = defaultOpenBrowser, createOAuth2Client = cfg => new OAuth2Client(cfg) } = {}) {
-      if (clientId === MANAGED_OAUTH_CLIENT_PLACEHOLDER || clientSecret === MANAGED_OAUTH_CLIENT_PLACEHOLDER) {
-        throw new Error(
-          'Managed OAuth client is not yet provisioned. ' +
-            'Set CEP_OAUTH_CLIENT_ID and CEP_OAUTH_CLIENT_SECRET to bring your own OAuth client, ' +
-            'or wait until the bundled managed client is allowlisted for the scopes in lib/constants.js#SCOPES.',
-        )
-      }
       const server = await startLoopbackServer()
       try {
         const endpoints = {}

--- a/test/local/auth_messages.test.js
+++ b/test/local/auth_messages.test.js
@@ -369,9 +369,9 @@ describe('buildOAuthClientField', () => {
       'OAuth client: custom (short...)',
     )
   })
-  test('When config is null, then it returns a TODO line flagging the unprovisioned managed client', () => {
+  test('When config is null, then it returns an unresolved line referencing the env-var pairing', () => {
     const text = buildOAuthClientField(null)
-    assert.match(text, /TODO/)
+    assert.match(text, /unresolved/)
     assert.match(text, /CEP_OAUTH_CLIENT_ID/)
   })
 })

--- a/test/local/oauth-client-config.test.js
+++ b/test/local/oauth-client-config.test.js
@@ -16,34 +16,34 @@ limitations under the License.
 
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { resolveOAuthClientConfig, managedClientIsPlaceholder } from '../../lib/util/credential/oauth_client_config.js'
-import {
-  MANAGED_OAUTH_CLIENT_ID,
-  MANAGED_OAUTH_CLIENT_SECRET,
-  MANAGED_OAUTH_CLIENT_PLACEHOLDER,
-} from '../../lib/constants.js'
+import { resolveOAuthClientConfig } from '../../lib/util/credential/oauth_client_config.js'
+import { MANAGED_OAUTH_CLIENT_ID, MANAGED_OAUTH_CLIENT_SECRET } from '../../lib/constants.js'
 
-describe('managed OAuth client placeholder', () => {
-  it('Both managed constants reference the shared TODO placeholder', () => {
-    assert.equal(MANAGED_OAUTH_CLIENT_ID, MANAGED_OAUTH_CLIENT_PLACEHOLDER)
-    assert.equal(MANAGED_OAUTH_CLIENT_SECRET, MANAGED_OAUTH_CLIENT_PLACEHOLDER)
+describe('managed OAuth client constants', () => {
+  it('When the bundled client id is read, then it is a non-empty Google OAuth client id', () => {
+    assert.equal(typeof MANAGED_OAUTH_CLIENT_ID, 'string')
+    assert.match(MANAGED_OAUTH_CLIENT_ID, /\.apps\.googleusercontent\.com$/)
   })
 
-  it('managedClientIsPlaceholder() returns true while the constants hold the TODO value', () => {
-    assert.equal(managedClientIsPlaceholder(), true)
+  it('When the bundled client secret is read, then it is a non-empty string with the GOCSPX prefix', () => {
+    assert.equal(typeof MANAGED_OAUTH_CLIENT_SECRET, 'string')
+    assert.match(MANAGED_OAUTH_CLIENT_SECRET, /^GOCSPX-/)
   })
 })
 
 describe('resolveOAuthClientConfig', () => {
-  it('When neither env var is set and managed client is unprovisioned, then it throws a clear TODO message', () => {
-    assert.throws(() => resolveOAuthClientConfig({}), /Managed OAuth client is not yet provisioned/)
+  it('When neither env var is set, then it returns the bundled managed client with source:managed', () => {
+    const config = resolveOAuthClientConfig({})
+    assert.equal(config.source, 'managed')
+    assert.equal(config.clientId, MANAGED_OAUTH_CLIENT_ID)
+    assert.equal(config.clientSecret, MANAGED_OAUTH_CLIENT_SECRET)
   })
 
-  it('When env vars are empty strings (set but blank), then it falls through to the unprovisioned-managed throw', () => {
-    assert.throws(
-      () => resolveOAuthClientConfig({ CEP_OAUTH_CLIENT_ID: '', CEP_OAUTH_CLIENT_SECRET: '' }),
-      /Managed OAuth client is not yet provisioned/,
-    )
+  it('When both env vars are empty strings, then it returns the bundled managed client with source:managed', () => {
+    const config = resolveOAuthClientConfig({ CEP_OAUTH_CLIENT_ID: '', CEP_OAUTH_CLIENT_SECRET: '' })
+    assert.equal(config.source, 'managed')
+    assert.equal(config.clientId, MANAGED_OAUTH_CLIENT_ID)
+    assert.equal(config.clientSecret, MANAGED_OAUTH_CLIENT_SECRET)
   })
 
   it('When both env vars are set, then it returns the custom values with source:custom', () => {


### PR DESCRIPTION
[abandoned]

Originally opened to replace the `TODO_MANAGED_OAUTH_CLIENT` placeholder in `lib/constants.js` with the real Desktop OAuth client provisioned in the `cep-mcp-server-prod-190085` GCP project, so `mcp auth login` would work out of the box without BYO env vars.

Abandoned because the change was bundled with #160 and #162 into the consolidated #163, which was itself split into a five-PR chain after review feedback.

Superseded by #171.