### PR TITLE
[abandoned] fix(auth): OAuth-mode quota project + auth subcommand

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -16,12 +16,44 @@ limitations under the License.
 */
 
 /**
- * @file CLI entry point. Dispatches argv[2] to a subcommand or to the MCP server.
+ * @file CLI entry point. Dispatches `auth <verb>` subcommands or starts the
+ * MCP server. Recognized verbs: `auth login`, `auth status`. Anything else
+ * (or no argument) starts the server in stdio mode.
  */
 
 /* eslint-disable n/no-process-exit */
 
 import { runServer } from '../mcp-server.js'
+
+const AUTH_HELP = [
+  'Usage: mcp auth <verb>',
+  '',
+  'Verbs:',
+  '  login    Run the OAuth-flow login and cache an access token.',
+  '  status   Show ADC and OAuth-flow credential status.',
+].join('\n')
+
+/**
+ * Dispatches an `auth` subcommand verb to the matching cli_commands handler.
+ * @param {string|undefined} verb - The verb passed after `auth` on the command line.
+ * @returns {Promise<void>} Resolves when the chosen handler finishes.
+ */
+async function runAuth(verb) {
+  if (verb === 'login') {
+    const { runLoginCommand } = await import('../lib/util/credential/cli_commands.js')
+    return runLoginCommand()
+  }
+  if (verb === 'status') {
+    const { runAuthStatusCommand } = await import('../lib/util/credential/cli_commands.js')
+    return runAuthStatusCommand()
+  }
+  if (!verb) {
+    process.stderr.write(`${AUTH_HELP}\n`)
+    return
+  }
+  process.stderr.write(`Unknown auth verb: ${verb}\n\n${AUTH_HELP}\n`)
+  process.exit(2)
+}
 
 /**
  * Dispatches the CLI subcommand.
@@ -29,13 +61,8 @@ import { runServer } from '../mcp-server.js'
  */
 async function main() {
   const sub = process.argv[2]
-  if (sub === 'auth-status') {
-    const { runAuthStatusCommand } = await import('../lib/util/credential/cli_commands.js')
-    return runAuthStatusCommand()
-  }
-  if (sub === 'login') {
-    const { runLoginCommand } = await import('../lib/util/credential/cli_commands.js')
-    return runLoginCommand()
+  if (sub === 'auth') {
+    return runAuth(process.argv[3])
   }
   return runServer()
 }

--- a/lib/util/auth-error.js
+++ b/lib/util/auth-error.js
@@ -18,11 +18,15 @@ limitations under the License.
  * @file Human-readable error messages for Google Cloud auth failures.
  *
  * Detects specific credential issues (insufficient scopes, missing ADC, missing
- * quota project) and returns actionable remediation instructions.
+ * quota project) and returns actionable remediation instructions. Branches on
+ * the active credential source: ADC errors get gcloud-flavored guidance, while
+ * OAuth-flow errors get `mcp auth login` and `GOOGLE_CLOUD_QUOTA_PROJECT`
+ * guidance instead.
  */
 
 import { execFile } from 'node:child_process'
 import { ERROR_MESSAGES, SCOPES } from '../constants.js'
+import { TokenCache } from './credential/token_cache.js'
 
 const GCLOUD_CALL_TIMEOUT_MS = 1000
 const GCLOUD_TOTAL_BUDGET_MS = 5000
@@ -131,43 +135,127 @@ async function suggestQuotaProject(errorMessage) {
 }
 
 /**
+ * Detects whether the active credential is from the OAuth-flow cache rather
+ * than ADC. Returns 'oauth' when valid cached OAuth tokens are present,
+ * 'adc' otherwise. Callers can override by passing `options.authMode`.
+ * @returns {Promise<'oauth'|'adc'>} The detected mode.
+ */
+async function detectAuthMode() {
+  try {
+    const cache = new TokenCache(TokenCache.defaultPath())
+    const tokens = await cache.read()
+    if (tokens && tokens.access_token) {
+      return 'oauth'
+    }
+  } catch {
+    // Cache unreadable — fall through to ADC.
+  }
+  return 'adc'
+}
+
+/**
+ * Builds the ADC-flavored remediation instruction (gcloud commands).
+ * @param {object} ctx - Detection context.
+ * @param {boolean} ctx.isInsufficientScopes - Whether the error indicates missing scopes.
+ * @param {boolean} ctx.isNoCredentials - Whether the error indicates missing credentials.
+ * @param {boolean} ctx.isQuotaProjectNotSet - Whether the error indicates a missing quota project.
+ * @param {boolean} ctx.gcloudInstalled - Whether gcloud is installed locally.
+ * @param {string} ctx.errorMessage - The raw error message.
+ * @returns {Promise<string>} The instruction text, or '' when no specific path matches.
+ */
+async function buildAdcInstruction({
+  isInsufficientScopes,
+  isNoCredentials,
+  isQuotaProjectNotSet,
+  gcloudInstalled,
+  errorMessage,
+}) {
+  if (isInsufficientScopes) {
+    if (gcloudInstalled) {
+      return `Your credentials have insufficient scopes. Please run:\ngcloud auth application-default login --scopes ${Object.values(SCOPES).join(',')}`
+    }
+    return `Your credentials have insufficient scopes and gcloud is not installed. Please install the Google Cloud SDK and then run the login command with required scopes.`
+  }
+  if (isNoCredentials) {
+    if (gcloudInstalled) {
+      return `No credentials found. Please run:\ngcloud auth application-default login`
+    }
+    return `No credentials found and gcloud is not installed. Please install the Google Cloud SDK and then run gcloud auth application-default login.`
+  }
+  if (isQuotaProjectNotSet) {
+    const suggestedProject = await suggestQuotaProject(errorMessage)
+    if (suggestedProject) {
+      return `The API requires a quota project, which is not set by default. We found a potential quota project "${suggestedProject}".\n\nPlease run:\ngcloud auth application-default set-quota-project ${suggestedProject}`
+    }
+    if (gcloudInstalled) {
+      return `The API requires a quota project, which is not set by default. We couldn't automatically determine a suitable project.\n\nPlease find a valid project ID in the Google Cloud Console:\nhttps://console.cloud.google.com/cloud-resource-manager\n\nThen run:\ngcloud auth application-default set-quota-project <YOUR_PROJECT_ID>`
+    }
+    return `The API requires a quota project. Please install the Google Cloud SDK and run: gcloud auth application-default set-quota-project <YOUR_PROJECT_ID>`
+  }
+  return ''
+}
+
+/**
+ * Builds the OAuth-flow remediation instruction. Avoids gcloud and points at
+ * `mcp auth login` plus `GOOGLE_CLOUD_QUOTA_PROJECT` instead.
+ * @param {object} ctx - Detection context.
+ * @param {boolean} ctx.isInsufficientScopes - Whether the error indicates missing scopes.
+ * @param {boolean} ctx.isNoCredentials - Whether the error indicates missing credentials.
+ * @param {boolean} ctx.isQuotaProjectNotSet - Whether the error indicates a missing quota project.
+ * @returns {string} The instruction text, or '' when no specific path matches.
+ */
+function buildOAuthInstruction({ isInsufficientScopes, isNoCredentials, isQuotaProjectNotSet }) {
+  if (isInsufficientScopes) {
+    return `The cached OAuth token is missing one or more required scopes. Re-run \`mcp auth login\` to re-consent with the updated scope set.`
+  }
+  if (isNoCredentials) {
+    return `No OAuth tokens cached. Run \`mcp auth login\` to authenticate, or set up Application Default Credentials with \`gcloud auth application-default login\`.`
+  }
+  if (isQuotaProjectNotSet) {
+    return `The API requires a quota project. Set \`GOOGLE_CLOUD_QUOTA_PROJECT\` in your environment or \`.env\` file to a GCP project ID you have access to. The OAuth-flow path does not use ADC's \`set-quota-project\` mechanism.`
+  }
+  return ''
+}
+
+/**
  * Generates a descriptive error message for authentication failures.
  *
- * Identifies specific error conditions (e.g., insufficient scopes, missing credentials)
- * and provides actionable instructions based on whether `gcloud` is installed.
+ * Identifies specific error conditions (e.g., insufficient scopes, missing
+ * credentials, missing quota project) and provides actionable instructions
+ * tailored to the active credential source — ADC remediations use gcloud,
+ * OAuth-flow remediations use `mcp auth login` and `GOOGLE_CLOUD_QUOTA_PROJECT`.
  * @param {Error} error - The original error object thrown during authentication.
- * @returns {string} A formatted error message with instructions.
+ * @param {object} [options] - Override options.
+ * @param {'oauth'|'adc'} [options.authMode] - Skip detection and force a remediation flavor.
+ * @returns {Promise<string>} A formatted error message with instructions.
  */
-export async function getAuthErrorMessage(error) {
-  const gcloudInstalled = await isGcloudInstalled()
+export async function getAuthErrorMessage(error, options = {}) {
   const errorMessage = error.message || ''
   const isInsufficientScopes = errorMessage.toLowerCase().includes(ERROR_MESSAGES.INSUFFICIENT_SCOPES.toLowerCase())
   const isNoCredentials = errorMessage.toLowerCase().includes(ERROR_MESSAGES.NO_CREDENTIALS.toLowerCase())
   const isQuotaProjectNotSet = errorMessage.includes(ERROR_MESSAGES.QUOTA_PROJECT_NOT_SET)
 
-  let instruction = ''
+  const authMode = options.authMode ?? (await detectAuthMode())
 
-  if (isInsufficientScopes) {
-    if (gcloudInstalled) {
-      instruction = `Your credentials have insufficient scopes. Please run:\ngcloud auth application-default login --scopes ${Object.values(SCOPES).join(',')}`
-    } else {
-      instruction = `Your credentials have insufficient scopes and gcloud is not installed. Please install the Google Cloud SDK and then run the login command with required scopes.`
+  let instruction = ''
+  if (authMode === 'oauth') {
+    instruction = buildOAuthInstruction({ isInsufficientScopes, isNoCredentials, isQuotaProjectNotSet })
+  } else {
+    const gcloudInstalled = await isGcloudInstalled()
+    instruction = await buildAdcInstruction({
+      isInsufficientScopes,
+      isNoCredentials,
+      isQuotaProjectNotSet,
+      gcloudInstalled,
+      errorMessage,
+    })
+  }
+
+  if (authMode === 'oauth') {
+    if (instruction) {
+      return `${instruction}\n\nOriginal error message from Google Auth Library: ${errorMessage}`
     }
-  } else if (isNoCredentials) {
-    if (gcloudInstalled) {
-      instruction = `No credentials found. Please run:\ngcloud auth application-default login`
-    } else {
-      instruction = `No credentials found and gcloud is not installed. Please install the Google Cloud SDK and then run gcloud auth application-default login.`
-    }
-  } else if (isQuotaProjectNotSet) {
-    const suggestedProject = await suggestQuotaProject(errorMessage)
-    if (suggestedProject) {
-      instruction = `The API requires a quota project, which is not set by default. We found a potential quota project "${suggestedProject}".\n\nPlease run:\ngcloud auth application-default set-quota-project ${suggestedProject}`
-    } else if (gcloudInstalled) {
-      instruction = `The API requires a quota project, which is not set by default. We couldn't automatically determine a suitable project.\n\nPlease find a valid project ID in the Google Cloud Console:\nhttps://console.cloud.google.com/cloud-resource-manager\n\nThen run:\ngcloud auth application-default set-quota-project <YOUR_PROJECT_ID>`
-    } else {
-      instruction = `The API requires a quota project. Please install the Google Cloud SDK and run: gcloud auth application-default set-quota-project <YOUR_PROJECT_ID>`
-    }
+    return `ERROR: Authentication failed.\nOriginal error message: ${errorMessage}`
   }
 
   const baseMessage = `ERROR: Google Cloud Application Default Credentials are not set up.\nAn unexpected error occurred during credential verification.\n\nFor more details or alternative setup methods, consider:\n1. If running locally, run: gcloud auth application-default login.\n2. Ensuring the GOOGLE_APPLICATION_CREDENTIALS environment variable points to a valid service account key file.\n3. If on a Google Cloud environment (e.g., GCE, Cloud Run), verify the associated service account has necessary permissions.\n\nOriginal error message from Google Auth Library: ${errorMessage}`

--- a/lib/util/auth.js
+++ b/lib/util/auth.js
@@ -26,11 +26,30 @@ import { getAuthErrorMessage } from './auth-error.js'
 import { TokenCache } from './credential/token_cache.js'
 
 /**
+ * Applies GOOGLE_CLOUD_QUOTA_PROJECT to an auth client. Setting
+ * `quotaProjectId` makes google-auth-library add the `x-goog-user-project`
+ * header to outgoing requests, which Google APIs require for quota and
+ * access-check attribution. ADC clients pick up the project from
+ * `~/.config/gcloud/application_default_credentials.json`; raw OAuth2Client
+ * instances do not, so the env var is the only path for OAuth-flow mode.
+ * @param {import('google-auth-library').AuthClient} client - The client to mutate.
+ * @returns {import('google-auth-library').AuthClient} The same client, returned for chaining.
+ */
+function applyQuotaProject(client) {
+  const fromEnv = process.env.GOOGLE_CLOUD_QUOTA_PROJECT
+  if (fromEnv && !client.quotaProjectId) {
+    client.quotaProjectId = fromEnv
+  }
+  return client
+}
+
+/**
  * Retrieves an authenticated Google Cloud client.
  *
  * Uses Application Default Credentials (ADC) with the supplied scopes. If
  * `authToken` is provided, returns an `OAuth2Client` pre-set with that
- * bearer instead.
+ * bearer instead. Falls back to the cached OAuth-flow tokens when ADC is
+ * unavailable.
  * @param {string[]} scopes - Google API scopes the client needs (used for ADC).
  * @param {string} [authToken] - Optional pre-acquired access token.
  * @returns {Promise<import('google-auth-library').AuthClient>} An authenticated client instance.
@@ -40,12 +59,12 @@ export async function getAuthClient(scopes, authToken) {
   if (authToken) {
     const auth = new OAuth2Client()
     auth.setCredentials({ access_token: authToken })
-    return auth
+    return applyQuotaProject(auth)
   }
 
   const auth = new GoogleAuth({ scopes })
   try {
-    return await auth.getClient()
+    return applyQuotaProject(await auth.getClient())
   } catch (adcError) {
     const cachePath = TokenCache.defaultPath()
     const cache = new TokenCache(cachePath)
@@ -60,7 +79,7 @@ export async function getAuthClient(scopes, authToken) {
       }
       const client = new OAuth2Client()
       client.setCredentials(tokens)
-      return client
+      return applyQuotaProject(client)
     }
     throw new Error(await getAuthErrorMessage(adcError))
   }

--- a/lib/util/google-auth-provider.js
+++ b/lib/util/google-auth-provider.js
@@ -36,15 +36,24 @@ export class GoogleAuthProvider {
    * @throws {Error} If client creation fails or credentials are invalid.
    */
   async getAuthClient(scopes, authToken) {
+    const fromEnv = process.env.GOOGLE_CLOUD_QUOTA_PROJECT
+
     if (authToken) {
       const auth = new OAuth2Client()
       auth.setCredentials({ access_token: authToken })
+      if (fromEnv) {
+        auth.quotaProjectId = fromEnv
+      }
       return auth
     }
 
     const auth = new GoogleAuth({ scopes })
     try {
-      return await auth.getClient()
+      const client = await auth.getClient()
+      if (fromEnv && !client.quotaProjectId) {
+        client.quotaProjectId = fromEnv
+      }
+      return client
     } catch (error) {
       throw new Error(await getAuthErrorMessage(error))
     }

--- a/test/integration/server/cli.test.js
+++ b/test/integration/server/cli.test.js
@@ -28,9 +28,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const CLI = path.resolve(__dirname, '../../../bin/cli.js')
 
 describe('bin/cli.js', () => {
-  describe('auth-status', () => {
-    it('When invoked with auth-status and ADC absent, then it prints the ADC line and an OAuth flow line', () => {
-      const result = spawnSync('node', [CLI, 'auth-status'], {
+  describe('auth status', () => {
+    it('When invoked with `auth status` and ADC absent, then it prints the ADC line and an OAuth flow line', () => {
+      const result = spawnSync('node', [CLI, 'auth', 'status'], {
         encoding: 'utf8',
         env: { ...process.env, GOOGLE_APPLICATION_CREDENTIALS: '/nonexistent' },
       })
@@ -38,6 +38,25 @@ describe('bin/cli.js', () => {
       assert.match(result.stdout, /Auth status:/)
       assert.match(result.stdout, /ADC:/)
       assert.match(result.stdout, /OAuth flow:/)
+    })
+  })
+
+  describe('auth (no verb)', () => {
+    it('When invoked with bare `auth`, then it prints the help text on stderr and exits 0', () => {
+      const result = spawnSync('node', [CLI, 'auth'], { encoding: 'utf8' })
+      assert.equal(result.status, 0)
+      assert.match(result.stderr, /Usage: mcp auth <verb>/)
+      assert.match(result.stderr, /login\s+Run the OAuth-flow login/)
+      assert.match(result.stderr, /status\s+Show ADC and OAuth-flow credential status/)
+    })
+  })
+
+  describe('auth <unknown>', () => {
+    it('When invoked with an unknown auth verb, then it prints help on stderr and exits 2', () => {
+      const result = spawnSync('node', [CLI, 'auth', 'whoami'], { encoding: 'utf8' })
+      assert.equal(result.status, 2)
+      assert.match(result.stderr, /Unknown auth verb: whoami/)
+      assert.match(result.stderr, /Usage: mcp auth <verb>/)
     })
   })
 })

--- a/test/local/auth.test.js
+++ b/test/local/auth.test.js
@@ -149,7 +149,7 @@ describe('Auth', () => {
       })
 
       const error = new Error('The admin.googleapis.com API requires a quota project, which is not set by default.')
-      const message = await getAuthErrorMessage(error)
+      const message = await getAuthErrorMessage(error, { authMode: 'adc' })
 
       assert.match(message, /We found a potential quota project "proj-2"/)
       assert.match(message, /gcloud auth application-default set-quota-project proj-2/)
@@ -181,7 +181,7 @@ describe('Auth', () => {
       })
 
       const error = new Error('The admin.googleapis.com API requires a quota project, which is not set by default.')
-      const message = await getAuthErrorMessage(error)
+      const message = await getAuthErrorMessage(error, { authMode: 'adc' })
 
       assert.match(message, /We found a potential quota project "proj-1"/) // Fallback to first (most recent)
     })
@@ -207,7 +207,7 @@ describe('Auth', () => {
       })
 
       const error = new Error('The admin.googleapis.com API requires a quota project, which is not set by default.')
-      const message = await getAuthErrorMessage(error)
+      const message = await getAuthErrorMessage(error, { authMode: 'adc' })
 
       assert.match(message, /Google Cloud Console/)
       assert.match(message, /console\.cloud\.google\.com\/cloud-resource-manager/)
@@ -235,10 +235,99 @@ describe('Auth', () => {
       })
 
       const error = new Error('The admin.googleapis.com API requires a quota project, which is not set by default.')
-      const message = await getAuthErrorMessage(error)
+      const message = await getAuthErrorMessage(error, { authMode: 'adc' })
 
       assert.match(message, /We found a potential quota project "configured-project"/)
       assert.match(message, /gcloud auth application-default set-quota-project configured-project/)
     })
+
+    describe('OAuth-flow mode', () => {
+      test('When authMode is oauth and the error reports a missing quota project, then the remediation points at GOOGLE_CLOUD_QUOTA_PROJECT and not at a gcloud command', async () => {
+        const { getAuthErrorMessage } = await import('../../lib/util/auth-error.js')
+        const error = new Error('The admin.googleapis.com API requires a quota project, which is not set by default.')
+        const message = await getAuthErrorMessage(error, { authMode: 'oauth' })
+
+        assert.match(message, /GOOGLE_CLOUD_QUOTA_PROJECT/)
+        assert.doesNotMatch(message, /gcloud auth application-default set-quota-project/)
+        assert.doesNotMatch(message, /Please run:\ngcloud/)
+      })
+
+      test('When authMode is oauth and the error reports insufficient scopes, then the remediation points at `mcp auth login`', async () => {
+        const { getAuthErrorMessage } = await import('../../lib/util/auth-error.js')
+        const error = new Error('Request had insufficient authentication scopes.')
+        const message = await getAuthErrorMessage(error, { authMode: 'oauth' })
+
+        assert.match(message, /mcp auth login/)
+        assert.doesNotMatch(message, /gcloud auth application-default login/)
+      })
+
+      test('When authMode is oauth and the error reports missing credentials, then the remediation suggests `mcp auth login`', async () => {
+        const { getAuthErrorMessage } = await import('../../lib/util/auth-error.js')
+        const error = new Error('Could not load the default credentials.')
+        const message = await getAuthErrorMessage(error, { authMode: 'oauth' })
+
+        assert.match(message, /mcp auth login/)
+        assert.doesNotMatch(message, /Application Default Credentials are not set up/)
+      })
+
+      test('When authMode is oauth, then the trailing ADC paragraph is omitted', async () => {
+        const { getAuthErrorMessage } = await import('../../lib/util/auth-error.js')
+        const error = new Error('The admin.googleapis.com API requires a quota project, which is not set by default.')
+        const message = await getAuthErrorMessage(error, { authMode: 'oauth' })
+
+        assert.doesNotMatch(message, /Application Default Credentials are not set up/)
+        assert.doesNotMatch(message, /GOOGLE_APPLICATION_CREDENTIALS environment variable/)
+      })
+    })
+  })
+})
+
+describe('getAuthClient quota project plumbing', () => {
+  test('When GOOGLE_CLOUD_QUOTA_PROJECT is set and an authToken is supplied, then quotaProjectId is applied to the OAuth2Client', async () => {
+    const { getAuthClient } = await esmock('../../lib/util/auth.js', {
+      'google-auth-library': {
+        OAuth2Client: class {
+          setCredentials(credentials) {
+            this.credentials = credentials
+          }
+        },
+      },
+    })
+    const previous = process.env.GOOGLE_CLOUD_QUOTA_PROJECT
+    process.env.GOOGLE_CLOUD_QUOTA_PROJECT = 'my-quota-project'
+    try {
+      const client = await getAuthClient([], 'test-token')
+      assert.equal(client.quotaProjectId, 'my-quota-project')
+    } finally {
+      if (previous === undefined) {
+        delete process.env.GOOGLE_CLOUD_QUOTA_PROJECT
+      } else {
+        // eslint-disable-next-line require-atomic-updates
+        process.env.GOOGLE_CLOUD_QUOTA_PROJECT = previous
+      }
+    }
+  })
+
+  test('When GOOGLE_CLOUD_QUOTA_PROJECT is unset, then quotaProjectId is left undefined on the OAuth2Client', async () => {
+    const { getAuthClient } = await esmock('../../lib/util/auth.js', {
+      'google-auth-library': {
+        OAuth2Client: class {
+          setCredentials(credentials) {
+            this.credentials = credentials
+          }
+        },
+      },
+    })
+    const previous = process.env.GOOGLE_CLOUD_QUOTA_PROJECT
+    delete process.env.GOOGLE_CLOUD_QUOTA_PROJECT
+    try {
+      const client = await getAuthClient([], 'test-token')
+      assert.equal(client.quotaProjectId, undefined)
+    } finally {
+      if (previous !== undefined) {
+        // eslint-disable-next-line require-atomic-updates
+        process.env.GOOGLE_CLOUD_QUOTA_PROJECT = previous
+      }
+    }
   })
 })


### PR DESCRIPTION
[abandoned]

Originally opened to plumb GOOGLE_CLOUD_QUOTA_PROJECT for OAuth-mode requests, branch auth-error remediation by credential source, and restructure the CLI under an `mcp auth login` / `mcp auth status` subcommand parent.

Abandoned because the change was bundled with #160 and #161 into the consolidated #163, which was itself split into a five-PR chain after review feedback.

Superseded by #171.