### PR TITLE
feat(local): put diagnose_environment behind feature flag (default ENABLED)

### DIFF
--- a/lib/util/feature_flags.js
+++ b/lib/util/feature_flags.js
@@ -29,6 +29,16 @@ const PREFIX = 'EXPERIMENT_'
 export const FLAGS = {
   DELETE_TOOL_ENABLED: 'DELETE_TOOL_ENABLED',
   KNOWLEDGE_SEARCH_ENABLED: 'KNOWLEDGE_SEARCH_ENABLED',
+  DIAGNOSE_TOOL_ENABLED: 'DIAGNOSE_TOOL_ENABLED',
+}
+
+/**
+ * Centralized default values for flags if not explicitly set in the environment.
+ */
+const DEFAULT_VALUES = {
+  [FLAGS.DELETE_TOOL_ENABLED]: false,
+  [FLAGS.KNOWLEDGE_SEARCH_ENABLED]: false,
+  [FLAGS.DIAGNOSE_TOOL_ENABLED]: true,
 }
 
 /**
@@ -47,11 +57,11 @@ export class FeatureFlags {
   /**
    * Checks if a feature flag is enabled.
    * @param {string} flag - The name of the flag to check. MUST be a value from FLAGS.
-   * @param {boolean} [defaultValue] - The default value if the flag is not set.
+   * @param {boolean} [defaultValue] - Optional override for the centralized default value.
    * @returns {boolean} True if the flag is enabled, false otherwise.
    * @throws {Error} If the provided flag is not registered in the FLAGS constant.
    */
-  isEnabled(flag, defaultValue = false) {
+  isEnabled(flag, defaultValue) {
     // Strict check to catch typos during development and CI
     if (!Object.values(FLAGS).includes(flag)) {
       throw new Error(`[FeatureFlags] Error: checking unknown flag "${flag}". You must register it in FLAGS first.`)
@@ -59,7 +69,8 @@ export class FeatureFlags {
 
     const value = this.env[`${PREFIX}${flag}`]
     if (value === undefined || value === null) {
-      return defaultValue
+      // Use the provided override, or the centralized default, or fall back to false
+      return defaultValue !== undefined ? defaultValue : (DEFAULT_VALUES[flag] ?? false)
     }
 
     // Defensive check: Ensure value is a string before calling toLowerCase
@@ -68,12 +79,22 @@ export class FeatureFlags {
   }
 
   /**
-   * Logs all currently active (enabled) experiment flags to the console.
-   * Uses a consistent format matching the server startup output.
+   * Checks if a feature flag is currently using its default value from the environment.
+   * @param {string} flag - The name of the flag to check.
+   * @returns {boolean} True if the flag is NOT set in the environment.
+   */
+  isDefault(flag) {
+    return this.env[`${PREFIX}${flag}`] === undefined || this.env[`${PREFIX}${flag}`] === null
+  }
+
+  /**
+   * Logs all currently active environment overrides to the console.
    */
   logActive() {
-    const active = Object.values(FLAGS).filter(f => this.isEnabled(f))
-    console.log(`Active Experiments: ${active.length > 0 ? active.join(', ') : 'None'}`)
+    const overrides = Object.values(FLAGS)
+      .filter(f => !this.isDefault(f))
+      .map(f => `${f}=${this.isEnabled(f)}`)
+    console.log(`Experiment Overrides: ${overrides.length > 0 ? overrides.join(', ') : 'None'}`)
   }
 }
 

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -323,10 +323,11 @@ export async function runServer() {
       makeLoggingCompatibleWithStdio()
     }
 
-    // Log all enabled feature flags
+    // Log feature flag overrides
     Object.values(FLAGS).forEach(flag => {
-      if (featureFlags.isEnabled(flag)) {
-        logger.info(`${TAGS.MCP} EXPERIMENT_${flag} is active.`)
+      if (!featureFlags.isDefault(flag)) {
+        const status = featureFlags.isEnabled(flag) ? 'ENABLED' : 'DISABLED'
+        logger.info(`${TAGS.MCP} EXPERIMENT_${flag} override: ${status}`)
       }
     })
 
@@ -342,9 +343,10 @@ export async function runServer() {
       // Ignore or log
     }
 
-    const activeExps =
+    const flagOverrides =
       Object.values(FLAGS)
-        .filter(flag => featureFlags.isEnabled(flag))
+        .filter(flag => !featureFlags.isDefault(flag))
+        .map(flag => `${flag}=${featureFlags.isEnabled(flag)}`)
         .join(', ') || 'None'
 
     const requiredScopes = Object.values(SCOPES)
@@ -375,7 +377,7 @@ export async function runServer() {
         }
         console.log()
       }
-      console.log(dim(`Active Experiments: ${activeExps}`))
+      console.log(dim(`Experiment Overrides: ${flagOverrides}`))
     }
 
     if (isStdio) {

--- a/test/local/tool-registration.test.js
+++ b/test/local/tool-registration.test.js
@@ -34,7 +34,6 @@ const CORE_TOOLS = [
   'create_regex_detector',
   'create_url_list_detector',
   'create_word_list_detector',
-  'diagnose_environment',
   'enable_chrome_enterprise_connectors',
   'get_chrome_activity_log',
   'get_connector_policy',
@@ -48,9 +47,11 @@ const CORE_TOOLS = [
   'list_org_units',
 ]
 
-const DELETE_EXPERIMENT_TOOLS = ['delete_agent_dlp_rule', 'delete_detector']
-
-const KNOWLEDGE_SEARCH_EXPERIMENT_TOOLS = ['search_content', 'list_documents']
+const EXPERIMENT_MAPPING = {
+  [FLAGS.DELETE_TOOL_ENABLED]: ['delete_agent_dlp_rule', 'delete_detector'],
+  [FLAGS.KNOWLEDGE_SEARCH_ENABLED]: ['search_content', 'list_documents'],
+  [FLAGS.DIAGNOSE_TOOL_ENABLED]: ['diagnose_environment'],
+}
 
 // Tests for SEB tool registration and individual tool handler logic.
 describe('SEB Tool Registration', () => {
@@ -63,36 +64,47 @@ describe('SEB Tool Registration', () => {
   })
 
   // Test if all tools are registered with the server.
-  test('When registerTools is called with no experiments, then it registers only core tools', () => {
+  test('When registerTools is called, then all core tools are always registered', () => {
+    // Disable all experiments to check base core tools
     registerTools(server, { featureFlags: { isEnabled: () => false } })
 
     const registeredToolNames = server.registerTool.mock.calls.map(call => call.arguments[0])
-    assert.deepStrictEqual(registeredToolNames.sort(), [...CORE_TOOLS].sort())
+    for (const tool of CORE_TOOLS) {
+      assert.ok(registeredToolNames.includes(tool), `Core tool "${tool}" should be registered`)
+    }
   })
 
-  test('When registerTools is called with KNOWLEDGE_SEARCH_ENABLED, then it registers core + search tools', () => {
-    registerTools(server, {
-      featureFlags: {
-        isEnabled: flag => flag === FLAGS.KNOWLEDGE_SEARCH_ENABLED,
-      },
+  // Test each experiment registration dynamically
+  for (const [flag, tools] of Object.entries(EXPERIMENT_MAPPING)) {
+    test(`When ${flag} is enabled, then it registers its experimental tools`, () => {
+      registerTools(server, {
+        featureFlags: {
+          isEnabled: f => f === flag,
+        },
+      })
+
+      const registeredToolNames = server.registerTool.mock.calls.map(call => call.arguments[0])
+      for (const tool of tools) {
+        assert.ok(registeredToolNames.includes(tool), `Experimental tool "${tool}" should be registered under ${flag}`)
+      }
     })
 
-    const registeredToolNames = server.registerTool.mock.calls.map(call => call.arguments[0])
-    const expected = [...CORE_TOOLS, ...KNOWLEDGE_SEARCH_EXPERIMENT_TOOLS].sort()
-    assert.deepStrictEqual(registeredToolNames.sort(), expected)
-  })
+    test(`When ${flag} is disabled, then it does NOT register its experimental tools`, () => {
+      registerTools(server, {
+        featureFlags: {
+          isEnabled: f => f !== flag, // Enable others but not this one
+        },
+      })
 
-  test('When registerTools is called with DELETE_TOOL_ENABLED, then it registers core + delete tools', () => {
-    registerTools(server, {
-      featureFlags: {
-        isEnabled: flag => flag === FLAGS.DELETE_TOOL_ENABLED,
-      },
+      const registeredToolNames = server.registerTool.mock.calls.map(call => call.arguments[0])
+      for (const tool of tools) {
+        assert.ok(
+          !registeredToolNames.includes(tool),
+          `Experimental tool "${tool}" should NOT be registered when ${flag} is disabled`,
+        )
+      }
     })
-
-    const registeredToolNames = server.registerTool.mock.calls.map(call => call.arguments[0])
-    const expected = [...CORE_TOOLS, ...DELETE_EXPERIMENT_TOOLS].sort()
-    assert.deepStrictEqual(registeredToolNames.sort(), expected)
-  })
+  }
 
   test('When a shared session state is provided, then it is used across tool registrations', async () => {
     const mockAdminSdkClient = {

--- a/tools/index.js
+++ b/tools/index.js
@@ -99,10 +99,15 @@ export function registerTools(server, options = {}, sessionState) {
   registerInstallSebExtensionTool(server, { ...commonOpts, chromePolicyClient }, state)
   registerCheckAndEnableCepApiTool(server, { ...commonOpts, serviceUsageClient }, state)
   registerEnableChromeEnterpriseConnectorsTool(server, { ...commonOpts, chromePolicyClient }, state)
-  registerDiagnoseEnvironmentTool(
-    server,
-    { ...commonOpts, chromeManagementClient, chromePolicyClient, cloudIdentityClient },
-    state,
-  )
+
+  if (flags.isEnabled(FLAGS.DIAGNOSE_TOOL_ENABLED)) {
+    logger.debug(`${TAGS.MCP} Registering diagnose tool (EXPERIMENT_DIAGNOSE_TOOL_ENABLED is active)`)
+    registerDiagnoseEnvironmentTool(
+      server,
+      { ...commonOpts, chromeManagementClient, chromePolicyClient, cloudIdentityClient },
+      state,
+    )
+  }
+
   registerKnowledgeTools(server, { ...options, featureFlags: flags }, state)
 }


### PR DESCRIPTION
## Summary

- **Feature Flag for Diagnosis:** Adds the `DIAGNOSE_TOOL_ENABLED` feature flag to gate the `diagnose_environment` tool. This tool is **ENABLED by default** to maintain existing functionality while providing an opt-out mechanism.
- **Centralized Defaults:** Refactors `lib/util/feature_flags.js` to support centralized default values. The `DIAGNOSE_TOOL_ENABLED` flag is explicitly set to `true` in code.
- **Smart Logging:**
  - Startup logs now only report **overrides** to the standard configuration. Because the diagnose tool is default ON, it will no longer clutter the logs unless manually disabled.
  - The server banner now displays "Experiment Overrides" instead of all active experiments, highlighting deviations from the baseline.
- **Improved Tool Registration:** Conditionally registers the `diagnose_environment` tool based on the flag state. Added debug logging during registration.
- **Data-Driven Tests:** Refactors `test/local/tool-registration.test.js` into a data-driven structure using `EXPERIMENT_MAPPING`.

## Test plan

- [x] `npm test` passes all tests.
- [x] Verified `DIAGNOSE_TOOL_ENABLED` defaults to `true` in code.
- [x] Verified `EXPERIMENT_DIAGNOSE_TOOL_ENABLED=false` correctly disables the tool and is reported as an override in logs.
- [x] Verified `CEP_LOG_LEVEL=debug` surfaces the registration log when enabled.