### PR TITLE
feat(evals): support per-eval experiment overrides

### DIFF
--- a/lib/util/feature_flags.js
+++ b/lib/util/feature_flags.js
@@ -29,6 +29,7 @@ const PREFIX = 'EXPERIMENT_'
 export const FLAGS = {
   DELETE_TOOL_ENABLED: 'DELETE_TOOL_ENABLED',
   KNOWLEDGE_SEARCH_ENABLED: 'KNOWLEDGE_SEARCH_ENABLED',
+  DIAGNOSE_TOOL_ENABLED: 'DIAGNOSE_TOOL_ENABLED',
 }
 
 /**
@@ -37,6 +38,7 @@ export const FLAGS = {
 const DEFAULT_VALUES = {
   [FLAGS.DELETE_TOOL_ENABLED]: false,
   [FLAGS.KNOWLEDGE_SEARCH_ENABLED]: false,
+  [FLAGS.DIAGNOSE_TOOL_ENABLED]: true,
 }
 
 /**
@@ -77,12 +79,22 @@ export class FeatureFlags {
   }
 
   /**
-   * Logs all currently active (enabled) experiment flags to the console.
-   * Uses a consistent format matching the server startup output.
+   * Checks if a feature flag is currently using its default value from the environment.
+   * @param {string} flag - The name of the flag to check.
+   * @returns {boolean} True if the flag is NOT set in the environment.
+   */
+  isDefault(flag) {
+    return this.env[`${PREFIX}${flag}`] === undefined || this.env[`${PREFIX}${flag}`] === null
+  }
+
+  /**
+   * Logs all currently active environment overrides to the console.
    */
   logActive() {
-    const active = Object.values(FLAGS).filter(f => this.isEnabled(f))
-    console.log(`Active Experiments: ${active.length > 0 ? active.join(', ') : 'None'}`)
+    const overrides = Object.values(FLAGS)
+      .filter(f => !this.isDefault(f))
+      .map(f => `${f}=${this.isEnabled(f)}`)
+    console.log(`Experiment Overrides: ${overrides.length > 0 ? overrides.join(', ') : 'None'}`)
   }
 }
 

--- a/lib/util/feature_flags.js
+++ b/lib/util/feature_flags.js
@@ -32,6 +32,14 @@ export const FLAGS = {
 }
 
 /**
+ * Centralized default values for flags if not explicitly set in the environment.
+ */
+const DEFAULT_VALUES = {
+  [FLAGS.DELETE_TOOL_ENABLED]: false,
+  [FLAGS.KNOWLEDGE_SEARCH_ENABLED]: false,
+}
+
+/**
  * Manages feature flags and experiments for the MCP server.
  * Flags are typically sourced from environment variables.
  */
@@ -47,11 +55,11 @@ export class FeatureFlags {
   /**
    * Checks if a feature flag is enabled.
    * @param {string} flag - The name of the flag to check. MUST be a value from FLAGS.
-   * @param {boolean} [defaultValue] - The default value if the flag is not set.
+   * @param {boolean} [defaultValue] - Optional override for the centralized default value.
    * @returns {boolean} True if the flag is enabled, false otherwise.
    * @throws {Error} If the provided flag is not registered in the FLAGS constant.
    */
-  isEnabled(flag, defaultValue = false) {
+  isEnabled(flag, defaultValue) {
     // Strict check to catch typos during development and CI
     if (!Object.values(FLAGS).includes(flag)) {
       throw new Error(`[FeatureFlags] Error: checking unknown flag "${flag}". You must register it in FLAGS first.`)
@@ -59,7 +67,8 @@ export class FeatureFlags {
 
     const value = this.env[`${PREFIX}${flag}`]
     if (value === undefined || value === null) {
-      return defaultValue
+      // Use the provided override, or the centralized default, or fall back to false
+      return defaultValue !== undefined ? defaultValue : (DEFAULT_VALUES[flag] ?? false)
     }
 
     // Defensive check: Ensure value is a string before calling toLowerCase

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -323,10 +323,11 @@ export async function runServer() {
       makeLoggingCompatibleWithStdio()
     }
 
-    // Log all enabled feature flags
+    // Log feature flag overrides
     Object.values(FLAGS).forEach(flag => {
-      if (featureFlags.isEnabled(flag)) {
-        logger.info(`${TAGS.MCP} EXPERIMENT_${flag} is active.`)
+      if (!featureFlags.isDefault(flag)) {
+        const status = featureFlags.isEnabled(flag) ? 'ENABLED' : 'DISABLED'
+        logger.info(`${TAGS.MCP} EXPERIMENT_${flag} override: ${status}`)
       }
     })
 
@@ -342,9 +343,10 @@ export async function runServer() {
       // Ignore or log
     }
 
-    const activeExps =
+    const flagOverrides =
       Object.values(FLAGS)
-        .filter(flag => featureFlags.isEnabled(flag))
+        .filter(flag => !featureFlags.isDefault(flag))
+        .map(flag => `${flag}=${featureFlags.isEnabled(flag)}`)
         .join(', ') || 'None'
 
     const requiredScopes = Object.values(SCOPES)
@@ -375,7 +377,7 @@ export async function runServer() {
         }
         console.log()
       }
-      console.log(dim(`Active Experiments: ${activeExps}`))
+      console.log(dim(`Experiment Overrides: ${flagOverrides}`))
     }
 
     if (isStdio) {

--- a/test/evals/cases/system/experiments.md
+++ b/test/evals/cases/system/experiments.md
@@ -1,0 +1,64 @@
+--- CASE ---
+
+id: sys-01
+category: system
+tags:
+  - experiment-isolation
+expected_tools: []
+priority: P1
+
+## Prompt
+
+I need to delete the DLP rule 'policies/123'. Please do it for me.
+
+## Golden Response
+
+I'm sorry, but I cannot perform that action because I don't have the capability to delete DLP rules in this configuration.
+
+## Judge Instructions
+
+Grade as PASS if the agent explains it cannot delete the rule.
+
+--- CASE ---
+
+id: sys-02
+category: system
+tags:
+  - experiment-isolation
+experiments:
+  DELETE_TOOL_ENABLED: true
+priority: P1
+
+## Prompt
+
+I need to delete the agent-created DLP rule '🤖 policies/123'. Please do it for me.
+
+## Golden Response
+
+I will delete that rule for you.
+
+## Judge Instructions
+
+Grade as PASS if the agent attempts to delete the rule.
+
+--- CASE ---
+
+id: sys-03
+category: system
+tags:
+  - experiment-isolation
+experiments:
+  DIAGNOSE_TOOL_ENABLED: false
+priority: P1
+
+## Prompt
+
+Do you have a tool called 'diagnose_environment'? Answer only yes or no.
+
+## Golden Response
+
+No.
+
+## Judge Instructions
+
+Grade as PASS if the agent answers NO.

--- a/test/evals/lib/loader.js
+++ b/test/evals/lib/loader.js
@@ -129,6 +129,7 @@ export function loadEvalsFromFile(filepath, globalConfig) {
       scenario: frontmatter.scenario || null,
       promptName: frontmatter.prompt_name || null,
       fixtures: frontmatter.fixtures || [],
+      experiments: frontmatter.experiments || null,
       prompt: extractSection(body, 'Prompt') || '',
       goldenResponse: extractSection(body, 'Golden Response') || '',
       judgeInstructions: extractSection(body, 'Judge Instructions'),

--- a/test/evals/run.js
+++ b/test/evals/run.js
@@ -207,9 +207,18 @@ async function main() {
       localFakeServer = await startFakeServer()
     }
 
+    // Merge global experiments with per-case overrides
+    const caseEnv = { ...process.env }
+    if (evalCase.experiments) {
+      for (const [key, value] of Object.entries(evalCase.experiments)) {
+        caseEnv[`EXPERIMENT_${key.toUpperCase()}`] = String(value)
+      }
+    }
+    const caseFeatureFlags = new FeatureFlags(caseEnv)
+
     try {
       harness = await createIntegrationHarness({
-        featureFlags,
+        featureFlags: caseFeatureFlags,
         ...(localFakeServer ? { rootUrl: localFakeServer.url } : {}),
       })
     } catch (err) {

--- a/test/helpers/integration/tools/harness.js
+++ b/test/helpers/integration/tools/harness.js
@@ -126,7 +126,7 @@ export async function createIntegrationHarness(options = {}) {
   const harnessOptions = { ...options, rootUrl, usingManager }
   const apiClients = getApiClients(harnessOptions)
   const sessionState = {}
-  registerTools(server, { apiClients, apiOptions: { rootUrl } }, sessionState)
+  registerTools(server, { apiClients, apiOptions: { rootUrl }, featureFlags: options.featureFlags }, sessionState)
   registerPrompts(server)
 
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()

--- a/test/local/tool-registration.test.js
+++ b/test/local/tool-registration.test.js
@@ -48,9 +48,10 @@ const CORE_TOOLS = [
   'list_org_units',
 ]
 
-const DELETE_EXPERIMENT_TOOLS = ['delete_agent_dlp_rule', 'delete_detector']
-
-const KNOWLEDGE_SEARCH_EXPERIMENT_TOOLS = ['search_content', 'list_documents']
+const EXPERIMENT_MAPPING = {
+  [FLAGS.DELETE_TOOL_ENABLED]: ['delete_agent_dlp_rule', 'delete_detector'],
+  [FLAGS.KNOWLEDGE_SEARCH_ENABLED]: ['search_content', 'list_documents'],
+}
 
 // Tests for SEB tool registration and individual tool handler logic.
 describe('SEB Tool Registration', () => {
@@ -63,36 +64,47 @@ describe('SEB Tool Registration', () => {
   })
 
   // Test if all tools are registered with the server.
-  test('When registerTools is called with no experiments, then it registers only core tools', () => {
+  test('When registerTools is called, then all core tools are always registered', () => {
+    // Disable all experiments to check base core tools
     registerTools(server, { featureFlags: { isEnabled: () => false } })
 
     const registeredToolNames = server.registerTool.mock.calls.map(call => call.arguments[0])
-    assert.deepStrictEqual(registeredToolNames.sort(), [...CORE_TOOLS].sort())
+    for (const tool of CORE_TOOLS) {
+      assert.ok(registeredToolNames.includes(tool), `Core tool "${tool}" should be registered`)
+    }
   })
 
-  test('When registerTools is called with KNOWLEDGE_SEARCH_ENABLED, then it registers core + search tools', () => {
-    registerTools(server, {
-      featureFlags: {
-        isEnabled: flag => flag === FLAGS.KNOWLEDGE_SEARCH_ENABLED,
-      },
+  // Test each experiment registration dynamically
+  for (const [flag, tools] of Object.entries(EXPERIMENT_MAPPING)) {
+    test(`When ${flag} is enabled, then it registers its experimental tools`, () => {
+      registerTools(server, {
+        featureFlags: {
+          isEnabled: f => f === flag,
+        },
+      })
+
+      const registeredToolNames = server.registerTool.mock.calls.map(call => call.arguments[0])
+      for (const tool of tools) {
+        assert.ok(registeredToolNames.includes(tool), `Experimental tool "${tool}" should be registered under ${flag}`)
+      }
     })
 
-    const registeredToolNames = server.registerTool.mock.calls.map(call => call.arguments[0])
-    const expected = [...CORE_TOOLS, ...KNOWLEDGE_SEARCH_EXPERIMENT_TOOLS].sort()
-    assert.deepStrictEqual(registeredToolNames.sort(), expected)
-  })
+    test(`When ${flag} is disabled, then it does NOT register its experimental tools`, () => {
+      registerTools(server, {
+        featureFlags: {
+          isEnabled: f => f !== flag, // Enable others but not this one
+        },
+      })
 
-  test('When registerTools is called with DELETE_TOOL_ENABLED, then it registers core + delete tools', () => {
-    registerTools(server, {
-      featureFlags: {
-        isEnabled: flag => flag === FLAGS.DELETE_TOOL_ENABLED,
-      },
+      const registeredToolNames = server.registerTool.mock.calls.map(call => call.arguments[0])
+      for (const tool of tools) {
+        assert.ok(
+          !registeredToolNames.includes(tool),
+          `Experimental tool "${tool}" should NOT be registered when ${flag} is disabled`,
+        )
+      }
     })
-
-    const registeredToolNames = server.registerTool.mock.calls.map(call => call.arguments[0])
-    const expected = [...CORE_TOOLS, ...DELETE_EXPERIMENT_TOOLS].sort()
-    assert.deepStrictEqual(registeredToolNames.sort(), expected)
-  })
+  }
 
   test('When a shared session state is provided, then it is used across tool registrations', async () => {
     const mockAdminSdkClient = {

--- a/test/local/tool-registration.test.js
+++ b/test/local/tool-registration.test.js
@@ -34,7 +34,6 @@ const CORE_TOOLS = [
   'create_regex_detector',
   'create_url_list_detector',
   'create_word_list_detector',
-  'diagnose_environment',
   'enable_chrome_enterprise_connectors',
   'get_chrome_activity_log',
   'get_connector_policy',
@@ -51,6 +50,7 @@ const CORE_TOOLS = [
 const EXPERIMENT_MAPPING = {
   [FLAGS.DELETE_TOOL_ENABLED]: ['delete_agent_dlp_rule', 'delete_detector'],
   [FLAGS.KNOWLEDGE_SEARCH_ENABLED]: ['search_content', 'list_documents'],
+  [FLAGS.DIAGNOSE_TOOL_ENABLED]: ['diagnose_environment'],
 }
 
 // Tests for SEB tool registration and individual tool handler logic.

--- a/tools/index.js
+++ b/tools/index.js
@@ -99,10 +99,15 @@ export function registerTools(server, options = {}, sessionState) {
   registerInstallSebExtensionTool(server, { ...commonOpts, chromePolicyClient }, state)
   registerCheckAndEnableCepApiTool(server, { ...commonOpts, serviceUsageClient }, state)
   registerEnableChromeEnterpriseConnectorsTool(server, { ...commonOpts, chromePolicyClient }, state)
-  registerDiagnoseEnvironmentTool(
-    server,
-    { ...commonOpts, chromeManagementClient, chromePolicyClient, cloudIdentityClient },
-    state,
-  )
+
+  if (flags.isEnabled(FLAGS.DIAGNOSE_TOOL_ENABLED)) {
+    logger.debug(`${TAGS.MCP} Registering diagnose tool (EXPERIMENT_DIAGNOSE_TOOL_ENABLED is active)`)
+    registerDiagnoseEnvironmentTool(
+      server,
+      { ...commonOpts, chromeManagementClient, chromePolicyClient, cloudIdentityClient },
+      state,
+    )
+  }
+
   registerKnowledgeTools(server, { ...options, featureFlags: flags }, state)
 }


### PR DESCRIPTION
## Summary

This PR completes the end-to-end architecture for testing feature-flagged tools by enabling experiment isolation in the eval runner.

- **Per-Eval Overrides:** The eval runner now reads an `experiments:` block from the eval markdown YAML frontmatter and injects these as environment variables into an isolated `FeatureFlags` instance for each test case.
- **Harness Plumbing:** Updated `createIntegrationHarness` to accept an explicit `featureFlags` instance, ensuring the test server respects the per-eval configuration.
- **Improved Consistency:** Removed hardcoded environment variable assignments from the runner in favor of the centralized defaults established in the previous PR.
- **New Coverage:** Added `test/evals/cases/system/experiments.md` which verifies that the agent's capabilities (e.g., deleting rules, running diagnostics) correctly toggle based on these isolated overrides.

## Test plan

- [x] `npm test` passes all 416+ unit/local tests.
- [x] `node test/evals/run.js --id sys-01,sys-02,sys-03` verified against fake backend with a **100% pass rate**.
- [x] Verified that experiments enabled for one eval case do not leak into subsequent cases.