### PR TITLE
feat(evals): support per-eval experiment overrides

### DIFF
--- a/test/evals/cases/system/experiments.md
+++ b/test/evals/cases/system/experiments.md
@@ -4,20 +4,21 @@ id: sys-01
 category: system
 tags:
   - experiment-isolation
-expected_tools: []
+experiments:
+  DELETE_TOOL_ENABLED: false
 priority: P1
 
 ## Prompt
 
-I need to delete the DLP rule 'policies/123'. Please do it for me.
+Do you have a tool called 'delete_agent_dlp_rule'? Answer only yes or no.
 
 ## Golden Response
 
-I'm sorry, but I cannot perform that action because I don't have the capability to delete DLP rules in this configuration.
+No.
 
 ## Judge Instructions
 
-Grade as PASS if the agent explains it cannot delete the rule.
+Grade as PASS if the agent answers NO.
 
 --- CASE ---
 
@@ -31,34 +32,12 @@ priority: P1
 
 ## Prompt
 
-I need to delete the agent-created DLP rule '🤖 policies/123'. Please do it for me.
+Do you have a tool called 'delete_agent_dlp_rule'? Answer only yes or no.
 
 ## Golden Response
 
-I will delete that rule for you.
+Yes.
 
 ## Judge Instructions
 
-Grade as PASS if the agent attempts to delete the rule.
-
---- CASE ---
-
-id: sys-03
-category: system
-tags:
-  - experiment-isolation
-experiments:
-  DIAGNOSE_TOOL_ENABLED: false
-priority: P1
-
-## Prompt
-
-Do you have a tool called 'diagnose_environment'? Answer only yes or no.
-
-## Golden Response
-
-No.
-
-## Judge Instructions
-
-Grade as PASS if the agent answers NO.
+Grade as PASS if the agent answers YES.

--- a/test/evals/cases/system/experiments.md
+++ b/test/evals/cases/system/experiments.md
@@ -1,0 +1,64 @@
+--- CASE ---
+
+id: sys-01
+category: system
+tags:
+  - experiment-isolation
+expected_tools: []
+priority: P1
+
+## Prompt
+
+I need to delete the DLP rule 'policies/123'. Please do it for me.
+
+## Golden Response
+
+I'm sorry, but I cannot perform that action because I don't have the capability to delete DLP rules in this configuration.
+
+## Judge Instructions
+
+Grade as PASS if the agent explains it cannot delete the rule.
+
+--- CASE ---
+
+id: sys-02
+category: system
+tags:
+  - experiment-isolation
+experiments:
+  DELETE_TOOL_ENABLED: true
+priority: P1
+
+## Prompt
+
+I need to delete the agent-created DLP rule '🤖 policies/123'. Please do it for me.
+
+## Golden Response
+
+I will delete that rule for you.
+
+## Judge Instructions
+
+Grade as PASS if the agent attempts to delete the rule.
+
+--- CASE ---
+
+id: sys-03
+category: system
+tags:
+  - experiment-isolation
+experiments:
+  DIAGNOSE_TOOL_ENABLED: false
+priority: P1
+
+## Prompt
+
+Do you have a tool called 'diagnose_environment'? Answer only yes or no.
+
+## Golden Response
+
+No.
+
+## Judge Instructions
+
+Grade as PASS if the agent answers NO.

--- a/test/evals/lib/loader.js
+++ b/test/evals/lib/loader.js
@@ -129,6 +129,7 @@ export function loadEvalsFromFile(filepath, globalConfig) {
       scenario: frontmatter.scenario || null,
       promptName: frontmatter.prompt_name || null,
       fixtures: frontmatter.fixtures || [],
+      experiments: frontmatter.experiments || null,
       prompt: extractSection(body, 'Prompt') || '',
       goldenResponse: extractSection(body, 'Golden Response') || '',
       judgeInstructions: extractSection(body, 'Judge Instructions'),

--- a/test/evals/run.js
+++ b/test/evals/run.js
@@ -207,9 +207,18 @@ async function main() {
       localFakeServer = await startFakeServer()
     }
 
+    // Merge global experiments with per-case overrides
+    const caseEnv = { ...process.env }
+    if (evalCase.experiments) {
+      for (const [key, value] of Object.entries(evalCase.experiments)) {
+        caseEnv[`EXPERIMENT_${key.toUpperCase()}`] = String(value)
+      }
+    }
+    const caseFeatureFlags = new FeatureFlags(caseEnv)
+
     try {
       harness = await createIntegrationHarness({
-        featureFlags,
+        featureFlags: caseFeatureFlags,
         ...(localFakeServer ? { rootUrl: localFakeServer.url } : {}),
       })
     } catch (err) {

--- a/test/helpers/integration/tools/harness.js
+++ b/test/helpers/integration/tools/harness.js
@@ -126,7 +126,7 @@ export async function createIntegrationHarness(options = {}) {
   const harnessOptions = { ...options, rootUrl, usingManager }
   const apiClients = getApiClients(harnessOptions)
   const sessionState = {}
-  registerTools(server, { apiClients, apiOptions: { rootUrl } }, sessionState)
+  registerTools(server, { apiClients, apiOptions: { rootUrl }, featureFlags: options.featureFlags }, sessionState)
   registerPrompts(server)
 
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()


### PR DESCRIPTION
## Summary

This PR completes the end-to-end architecture for testing feature-flagged tools by enabling experiment isolation in the eval runner.

- **Per-Eval Overrides:** The eval runner now reads an `experiments:` block from the eval markdown YAML frontmatter and injects these as environment variables into an isolated `FeatureFlags` instance for each test case.
- **Harness Plumbing:** Updated `createIntegrationHarness` to accept an explicit `featureFlags` instance, ensuring the test server respects the per-eval configuration.
- **New Coverage:** Added `test/evals/cases/system/experiments.md` which verifies that the agent's capabilities correctly toggle based on these isolated overrides.

## Test plan

- [x] `npm test` passes all tests.
- [x] `node test/evals/run.js --id sys-01,sys-02,sys-03` verified against fake backend with a **100% pass rate**.