### PR TITLE
feat(http): plumb verified principal through getServer; add CEP_BEARER_PRINCIPAL_SUB lock

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,12 @@
 GCP_STDIO=true
 # PORT=3000
 
+# HTTP-mode: lock the deployment to a single end user.
+# Set this to that user's Google account ID (the `sub` claim from their ID token).
+# When set, the inbound ID token must verify against CEP_BEARER_AUDIENCE AND
+# carry this exact `sub`; otherwise the request is rejected with 403.
+# CEP_BEARER_PRINCIPAL_SUB=1234567890
+
 
 # Evaluations
 #

--- a/.github/expected-tarball.txt
+++ b/.github/expected-tarball.txt
@@ -51,6 +51,7 @@ lib/util/cel_validator.js
 lib/util/chrome_dlp_constants.js
 lib/util/connector_policy_helper.js
 lib/util/credential/adc.js
+lib/util/credential/bearer_verifier.js
 lib/util/credential/cli_commands.js
 lib/util/credential/index.js
 lib/util/credential/jwt_verifier.js

--- a/lib/util/credential/bearer_verifier.js
+++ b/lib/util/credential/bearer_verifier.js
@@ -1,0 +1,50 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file Bearer-token verification used by HTTP-mode middleware.
+ *
+ * The middleware itself lives in mcp-server.js (it owns the Express
+ * res/req plumbing). This module isolates the decision logic so it
+ * can be unit-tested without booting an HTTP server.
+ */
+
+/**
+ * Verify a bearer token against the expected audience and (optionally) a
+ * locked principal sub. Returns a plain object describing the outcome —
+ * `{ok: true, principal}` on accept, `{ok: false, status, message}` on
+ * reject. Callers map the result onto an HTTP response.
+ *
+ * `verify` is injected so callers can stub it in tests.
+ * @param {string} token - The bearer token (without the `Bearer ` prefix).
+ * @param {object} options - Verification options.
+ * @param {string|string[]} options.expectedAudience - Audience(s) accepted.
+ * @param {string} [options.lockedSub] - When non-empty, the principal's `sub` must equal this value, otherwise a 403 result is returned.
+ * @param {(token: string, opts: {expectedAudience: string|string[]}) => Promise<object>} options.verify - The id-token verifier (e.g. `verifyIdToken`).
+ * @returns {Promise<{ok: true, principal: object} | {ok: false, status: number, message: string, error?: Error}>} Verification outcome.
+ */
+export async function verifyBearerToken(token, { expectedAudience, lockedSub, verify }) {
+  let principal
+  try {
+    principal = await verify(token, { expectedAudience })
+  } catch (err) {
+    return { ok: false, status: 401, message: 'Bearer token verification failed', error: err }
+  }
+  if (lockedSub && principal.sub !== lockedSub) {
+    return { ok: false, status: 403, message: 'Principal not authorized for this deployment', principal }
+  }
+  return { ok: true, principal }
+}

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -46,6 +46,7 @@ import { logger } from './lib/util/logger.js'
 import { printBanner, dim } from './lib/util/banner.js'
 import { buildScopesField, buildAuthRemediationLines, buildQuotaProjectWarning } from './lib/util/auth_messages.js'
 import { verifyIdToken, parseExpectedAudience } from './lib/util/credential/jwt_verifier.js'
+import { verifyBearerToken } from './lib/util/credential/bearer_verifier.js'
 import { TAGS, SCOPES } from './lib/constants.js'
 
 // Import Real Clients
@@ -430,22 +431,21 @@ export async function runServer() {
             return
           }
           const token = auth.slice(7).trim()
-          try {
-            const principal = await verifyIdToken(token, { expectedAudience })
-            if (lockedSub && principal.sub !== lockedSub) {
+          const result = await verifyBearerToken(token, { expectedAudience, lockedSub, verify: verifyIdToken })
+          if (!result.ok) {
+            if (result.status === 403) {
               logger.warn(
-                `${TAGS.MCP} Principal sub ${principal.sub} does not match CEP_BEARER_PRINCIPAL_SUB; rejecting`,
+                `${TAGS.MCP} Principal sub ${result.principal.sub} does not match CEP_BEARER_PRINCIPAL_SUB; rejecting`,
               )
-              res.status(403).json({ error: 'Principal not authorized for this deployment' })
-              return
+            } else if (result.error) {
+              logger.warn(`${TAGS.MCP} ID-token verification failed: ${result.error.message}`)
             }
-            // eslint-disable-next-line require-atomic-updates
-            req.verifiedPrincipal = principal
-            next()
-          } catch (err) {
-            logger.warn(`${TAGS.MCP} ID-token verification failed: ${err.message}`)
-            res.status(401).json({ error: 'Bearer token verification failed' })
+            res.status(result.status).json({ error: result.message })
+            return
           }
+          // eslint-disable-next-line require-atomic-updates
+          req.verifiedPrincipal = result.principal
+          next()
         })
       } else {
         logger.warn(

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -404,6 +404,13 @@ export async function runServer() {
       app.use(express.json())
 
       const expectedAudience = parseExpectedAudience(process.env.CEP_BEARER_AUDIENCE)
+      const lockedSub = process.env.CEP_BEARER_PRINCIPAL_SUB || ''
+      if (lockedSub && !expectedAudience) {
+        logger.warn(
+          `${TAGS.MCP} CEP_BEARER_PRINCIPAL_SUB has no effect without CEP_BEARER_AUDIENCE.\n` +
+            `To lock the server to one user, set both: CEP_BEARER_AUDIENCE turns on bearer-token verification, and CEP_BEARER_PRINCIPAL_SUB narrows access to that user.`,
+        )
+      }
       if (expectedAudience) {
         // Trust-boundary middleware: every /mcp, /sse, /messages request must
         // carry a Google-signed ID token whose `aud` matches the expected
@@ -425,7 +432,6 @@ export async function runServer() {
           const token = auth.slice(7).trim()
           try {
             const principal = await verifyIdToken(token, { expectedAudience })
-            const lockedSub = process.env.CEP_BEARER_PRINCIPAL_SUB
             if (lockedSub && principal.sub !== lockedSub) {
               logger.warn(
                 `${TAGS.MCP} Principal sub ${principal.sub} does not match CEP_BEARER_PRINCIPAL_SUB; rejecting`,

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -171,16 +171,17 @@ export function createSessionState() {
 
 /**
  * Builds the Express handler for POST /mcp. Each invocation constructs a fresh
- * per-request sessionState via createSessionState() and passes it to getServer,
- * so concurrent requests cannot share customerId/orgUnit cache.
+ * per-request sessionState via createSessionState() and passes it to getServer
+ * along with the verified principal from req.verifiedPrincipal, so concurrent
+ * requests cannot share customerId/orgUnit cache or principal context.
  * @param {object} gcpInfo - GCP environment metadata.
- * @param {(gcpInfo: object, sessionState: object) => Promise<object>} [getServerImpl] - Override for tests.
+ * @param {(gcpInfo: object, sessionState: object, principal: ?object) => Promise<object>} [getServerImpl] - Override for tests.
  * @returns {(req: import('express').Request, res: import('express').Response) => Promise<void>} The Express request handler.
  */
 export function createMcpPostHandler(gcpInfo, getServerImpl = getServer) {
   return async (req, res) => {
     const sessionState = createSessionState()
-    const server = await getServerImpl(gcpInfo, sessionState)
+    const server = await getServerImpl(gcpInfo, sessionState, req.verifiedPrincipal || null)
     try {
       const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined })
       await server.connect(transport)
@@ -210,18 +211,19 @@ export function createMcpPostHandler(gcpInfo, getServerImpl = getServer) {
 /**
  * Builds the Express handler for GET /sse. Each new SSE connection constructs
  * a fresh per-session sessionState; subsequent /messages POSTs route through
- * the registered transport, which holds a reference to that same server.
+ * the registered transport, which holds a reference to that same server. The
+ * verified principal from req.verifiedPrincipal is plumbed into getServer.
  * @param {object} gcpInfo - GCP environment metadata.
  * @param {Record<string, SSEServerTransport>} sseTransports - Map of sessionId -> transport.
- * @param {(gcpInfo: object, sessionState: object) => Promise<object>} [getServerImpl] - Override for tests.
+ * @param {(gcpInfo: object, sessionState: object, principal: ?object) => Promise<object>} [getServerImpl] - Override for tests.
  * @returns {(req: import('express').Request, res: import('express').Response) => Promise<void>} The Express request handler.
  */
 export function createSseHandler(gcpInfo, sseTransports, getServerImpl = getServer) {
-  return async (_req, res) => {
+  return async (req, res) => {
     logger.info(`${TAGS.MCP} /sse Received request`)
     try {
       const sessionState = createSessionState()
-      const server = await getServerImpl(gcpInfo, sessionState)
+      const server = await getServerImpl(gcpInfo, sessionState, req.verifiedPrincipal || null)
       const transport = new SSEServerTransport('/messages', res)
       sseTransports[transport.sessionId] = transport
       res.on('close', () => {
@@ -249,11 +251,12 @@ export function createSseHandler(gcpInfo, sseTransports, getServerImpl = getServ
 
 /**
  * Initializes and configures the MCP server instance.
- * @param {object} gcpInfo - The detected GCP environment metadata
- * @param {object} sharedSessionState - The shared session state for cross-request persistence
- * @returns {Promise<McpServer>} The configured MCP server instance
+ * @param {object} gcpInfo - The detected GCP environment metadata.
+ * @param {object} sharedSessionState - The shared session state for cross-request persistence.
+ * @param {?import('./lib/util/credential/jwt_verifier.js').VerifiedPrincipal} [principal] - The verified principal for this HTTP request, when present. Null in stdio mode and HTTP mode without CEP_BEARER_AUDIENCE.
+ * @returns {Promise<McpServer>} The configured MCP server instance.
  */
-export async function getServer(gcpInfo, sharedSessionState) {
+export async function getServer(gcpInfo, sharedSessionState, principal = null) {
   const server = new McpServer(
     {
       name: 'chrome-enterprise-premium',
@@ -282,6 +285,10 @@ export async function getServer(gcpInfo, sharedSessionState) {
     logger.info(`${TAGS.MCP} TEST MODE: Real API clients redirected to ${apiOptions.rootUrl}`)
   } else {
     logger.info(`${TAGS.MCP} Using REAL API clients.`)
+  }
+
+  if (principal) {
+    logger.debug(`${TAGS.MCP} Request authenticated as ${principal.email} (sub=${principal.sub})`)
   }
 
   const apiClients = {
@@ -418,6 +425,14 @@ export async function runServer() {
           const token = auth.slice(7).trim()
           try {
             const principal = await verifyIdToken(token, { expectedAudience })
+            const lockedSub = process.env.CEP_BEARER_PRINCIPAL_SUB
+            if (lockedSub && principal.sub !== lockedSub) {
+              logger.warn(
+                `${TAGS.MCP} Principal sub ${principal.sub} does not match CEP_BEARER_PRINCIPAL_SUB; rejecting`,
+              )
+              res.status(403).json({ error: 'Principal not authorized for this deployment' })
+              return
+            }
             // eslint-disable-next-line require-atomic-updates
             req.verifiedPrincipal = principal
             next()

--- a/test/local/bearer_verifier.test.js
+++ b/test/local/bearer_verifier.test.js
@@ -1,0 +1,79 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, test, mock } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { verifyBearerToken } from '../../lib/util/credential/bearer_verifier.js'
+
+const AUDIENCE = '123.apps.googleusercontent.com'
+
+describe('verifyBearerToken', () => {
+  test('When verify resolves and no lockedSub is set, then it returns ok with principal', async () => {
+    const principal = { sub: '111', email: 'alice@example.com' }
+    const verify = mock.fn(async () => principal)
+
+    const result = await verifyBearerToken('token', { expectedAudience: AUDIENCE, lockedSub: '', verify })
+
+    assert.deepStrictEqual(result, { ok: true, principal })
+    assert.strictEqual(verify.mock.callCount(), 1)
+    assert.deepStrictEqual(verify.mock.calls[0].arguments, ['token', { expectedAudience: AUDIENCE }])
+  })
+
+  test('When verify resolves and lockedSub matches principal.sub, then it returns ok', async () => {
+    const principal = { sub: '111', email: 'alice@example.com' }
+    const verify = mock.fn(async () => principal)
+
+    const result = await verifyBearerToken('token', { expectedAudience: AUDIENCE, lockedSub: '111', verify })
+
+    assert.deepStrictEqual(result, { ok: true, principal })
+  })
+
+  test('When verify resolves and lockedSub does not match principal.sub, then it returns a 403 result', async () => {
+    const principal = { sub: '111', email: 'alice@example.com' }
+    const verify = mock.fn(async () => principal)
+
+    const result = await verifyBearerToken('token', { expectedAudience: AUDIENCE, lockedSub: '222', verify })
+
+    assert.strictEqual(result.ok, false)
+    assert.strictEqual(result.status, 403)
+    assert.strictEqual(result.message, 'Principal not authorized for this deployment')
+    assert.deepStrictEqual(result.principal, principal)
+  })
+
+  test('When verify rejects, then it returns a 401 result with the original error', async () => {
+    const error = new Error('audience mismatch')
+    const verify = mock.fn(async () => {
+      throw error
+    })
+
+    const result = await verifyBearerToken('token', { expectedAudience: AUDIENCE, lockedSub: '', verify })
+
+    assert.strictEqual(result.ok, false)
+    assert.strictEqual(result.status, 401)
+    assert.strictEqual(result.message, 'Bearer token verification failed')
+    assert.strictEqual(result.error, error)
+  })
+
+  test('When lockedSub is empty, then sub is not checked', async () => {
+    const principal = { sub: '111' }
+    const verify = mock.fn(async () => principal)
+
+    const result = await verifyBearerToken('token', { expectedAudience: AUDIENCE, lockedSub: '', verify })
+
+    assert.strictEqual(result.ok, true)
+  })
+})

--- a/test/unit/mcp-server-state-isolation.test.js
+++ b/test/unit/mcp-server-state-isolation.test.js
@@ -34,8 +34,8 @@ const fakeMcpServer = {
 
 function makeRecorder() {
   const captured = []
-  const fn = async (_gcpInfo, sessionState) => {
-    captured.push(sessionState)
+  const fn = async (_gcpInfo, sessionState, principal) => {
+    captured.push({ sessionState, principal })
     return fakeMcpServer
   }
   return { fn, captured }
@@ -66,23 +66,64 @@ describe('HTTP per-request session state isolation', () => {
     await handler(fakeReq, fakeRes)
 
     assert.strictEqual(captured.length, 2, 'getServer must be called once per request')
-    assert.notStrictEqual(captured[0], captured[1], 'each request must get a distinct sessionState reference')
-    captured[0].customerId = 'C0TENANT1'
-    assert.strictEqual(captured[1].customerId, null, 'cross-tenant cache must not leak')
+    assert.notStrictEqual(
+      captured[0].sessionState,
+      captured[1].sessionState,
+      'each request must get a distinct sessionState reference',
+    )
+    captured[0].sessionState.customerId = 'C0TENANT1'
+    assert.strictEqual(captured[1].sessionState.customerId, null, 'cross-tenant cache must not leak')
+  })
+
+  test('When createMcpPostHandler receives a request with req.verifiedPrincipal set, then it forwards the principal to getServer', async () => {
+    const { fn: recorder, captured } = makeRecorder()
+    const handler = createMcpPostHandler({}, recorder)
+    const principal = { email: 'admin@example.com', sub: '12345', aud: 'a', iss: 'https://accounts.google.com' }
+    const fakeReq = { body: {}, on: () => {}, verifiedPrincipal: principal }
+    const fakeRes = { on: () => {}, headersSent: false, status: () => fakeRes, json: () => {} }
+
+    await handler(fakeReq, fakeRes)
+
+    assert.strictEqual(captured[0].principal, principal)
+  })
+
+  test('When createMcpPostHandler receives a request with no req.verifiedPrincipal, then it passes null as the principal', async () => {
+    const { fn: recorder, captured } = makeRecorder()
+    const handler = createMcpPostHandler({}, recorder)
+    const fakeReq = { body: {}, on: () => {} }
+    const fakeRes = { on: () => {}, headersSent: false, status: () => fakeRes, json: () => {} }
+
+    await handler(fakeReq, fakeRes)
+
+    assert.strictEqual(captured[0].principal, null)
   })
 
   test('createSseHandler passes a distinct sessionState to getServer per request', async () => {
     const { fn: recorder, captured } = makeRecorder()
     const sseTransports = {}
     const handler = createSseHandler({}, sseTransports, recorder)
+    const fakeReq = { on: () => {} }
     const fakeRes = { on: () => {}, headersSent: false }
 
-    await handler({}, fakeRes)
-    await handler({}, fakeRes)
+    await handler(fakeReq, fakeRes)
+    await handler(fakeReq, fakeRes)
 
     assert.strictEqual(captured.length, 2)
-    assert.notStrictEqual(captured[0], captured[1])
-    captured[0].customerId = 'C0TENANT1'
-    assert.strictEqual(captured[1].customerId, null)
+    assert.notStrictEqual(captured[0].sessionState, captured[1].sessionState)
+    captured[0].sessionState.customerId = 'C0TENANT1'
+    assert.strictEqual(captured[1].sessionState.customerId, null)
+  })
+
+  test('When createSseHandler receives a request with req.verifiedPrincipal set, then it forwards the principal to getServer', async () => {
+    const { fn: recorder, captured } = makeRecorder()
+    const sseTransports = {}
+    const handler = createSseHandler({}, sseTransports, recorder)
+    const principal = { email: 'admin@example.com', sub: '12345', aud: 'a', iss: 'https://accounts.google.com' }
+    const fakeReq = { verifiedPrincipal: principal }
+    const fakeRes = { on: () => {}, headersSent: false }
+
+    await handler(fakeReq, fakeRes)
+
+    assert.strictEqual(captured[0].principal, principal)
   })
 })


### PR DESCRIPTION
## Summary

HTTP-mode hardening. Two related changes:

1. **`req.verifiedPrincipal` is plumbed into `getServer`** as a third argument. `createMcpPostHandler` and `createSseHandler` pass it through. The principal is `null` in stdio mode and in HTTP mode without `CEP_BEARER_AUDIENCE`.

2. **`CEP_BEARER_PRINCIPAL_SUB`** — new optional env var. When set, the bearer-verification middleware additionally requires the verified principal's `sub` to match exactly; mismatches return `403`. Use it to lock an HTTP-mode deployment to a single Google account.

The principal-sub check runs after `verifyIdToken` succeeds, so it is strictly narrower than `CEP_BEARER_AUDIENCE`. With `CEP_BEARER_PRINCIPAL_SUB` set but `CEP_BEARER_AUDIENCE` unset, the server logs a startup warning and the sub check has no effect.

## Changes

- `mcp-server.js`: `getServer(gcpInfo, sharedSessionState, principal = null)` — new third parameter; on non-null, debug-logs `Request authenticated as <email> (sub=<sub>)`. The bearer middleware adds the principal-sub check.
- `.env.example`: documents `CEP_BEARER_PRINCIPAL_SUB`.
- `test/unit/mcp-server-state-isolation.test.js`: new tests assert the principal forwards through both transports.

## Test plan

- [x] `npm run lint`
- [x] `npm test`

## Stack

Fourth of five PRs splitting #163. Independent of the other four (base `main`). Tracked in #167.
