### PR TITLE
feat(server): conditional enable_api tool registration by OAuth client source

### DIFF
--- a/.github/expected-tarball.txt
+++ b/.github/expected-tarball.txt
@@ -45,7 +45,6 @@ lib/util/banner.js
 lib/util/cel_validator.js
 lib/util/chrome_dlp_constants.js
 lib/util/connector_policy_helper.js
-lib/util/credential/adc.js
 lib/util/credential/cli_commands.js
 lib/util/credential/index.js
 lib/util/credential/jwt_verifier.js

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -191,6 +191,22 @@ export function createSseHandler(gcpInfo, sseTransports, getServerImpl = getServ
 }
 
 /**
+ * Returns whether the `enable_api` tool should be registered for this server.
+ * Skipped in Google-managed OAuth mode (the maintainer's project has APIs
+ * pre-enabled, so end users never need to call it). Registered in all other
+ * modes (custom OAuth client, bearer header, service-account key) defensively.
+ * @returns {boolean} True if `enable_api` should be registered.
+ */
+function shouldRegisterEnableApi() {
+  try {
+    const config = resolveOAuthClientConfig()
+    return config.source !== 'managed'
+  } catch {
+    return true
+  }
+}
+
+/**
  * Initializes and configures the MCP server instance.
  * @param {object} gcpInfo - The detected GCP environment metadata
  * @param {object} sharedSessionState - The shared session state for cross-request persistence
@@ -240,6 +256,7 @@ export async function getServer(gcpInfo, sharedSessionState) {
     apiOptions,
     dbPath: process.env.KNOWLEDGE_DB_PATH,
     featureFlags,
+    registerEnableApi: shouldRegisterEnableApi(),
   }
 
   registerTools(server, toolOptions, sharedSessionState)

--- a/test/integration/server/mcp-server.test.js
+++ b/test/integration/server/mcp-server.test.js
@@ -66,7 +66,7 @@ describe('MCP Server in stdio mode', () => {
     }
   })
 
-  test('When listTools is called, then it returns all registered tools', async () => {
+  test('When listTools is called in Google-managed OAuth mode, then check_and_enable_cep_api is absent', async () => {
     const response = await client.listTools()
 
     const tools = response.tools
@@ -75,7 +75,6 @@ describe('MCP Server in stdio mode', () => {
     assert.deepStrictEqual(
       toolNames.sort(),
       [
-        'check_and_enable_cep_api',
         'check_cep_subscription',
         'check_seb_extension_status',
         'check_user_cep_license',
@@ -104,11 +103,9 @@ describe('MCP Server in stdio mode', () => {
   })
 
   describe('MCP Server Startup Logs', () => {
-    // A dummy API root causes probeADC() to short-circuit immediately (it
-    // checks process.env.GOOGLE_API_ROOT_URL and returns early), which
-    // removes the 8-second network-probe window that was racing against the
-    // 12-second spawnSync timeout and causing intermittent failures (#47).
-    const NO_ADC_PROBE = 'http://localhost:1'
+    // A non-routable API root puts the server in fake-API mode so the boot
+    // path never makes a real Google call.
+    const FAKE_API_ROOT = 'http://localhost:1'
 
     test('When server starts with custom PORT, then it logs the correct port', () => {
       const serverPath = path.resolve(__dirname, '../../../mcp-server.js')
@@ -118,7 +115,7 @@ describe('MCP Server in stdio mode', () => {
           PORT: '4000',
           GCP_STDIO: 'false',
           CEP_LOG_LEVEL: 'info',
-          GOOGLE_API_ROOT_URL: NO_ADC_PROBE,
+          GOOGLE_API_ROOT_URL: FAKE_API_ROOT,
         },
         timeout: 12000,
       })
@@ -131,7 +128,7 @@ describe('MCP Server in stdio mode', () => {
     test('When server starts without PORT, then it assigns a random port', () => {
       const serverPath = path.resolve(__dirname, '../../../mcp-server.js')
       const result = spawnSync(process.execPath, [serverPath], {
-        env: { ...process.env, GCP_STDIO: 'false', CEP_LOG_LEVEL: 'info', GOOGLE_API_ROOT_URL: NO_ADC_PROBE },
+        env: { ...process.env, GCP_STDIO: 'false', CEP_LOG_LEVEL: 'info', GOOGLE_API_ROOT_URL: FAKE_API_ROOT },
         timeout: 12000,
       })
 
@@ -157,7 +154,7 @@ describe('MCP Server in stdio mode', () => {
             PORT: port.toString(),
             GCP_STDIO: 'false',
             CEP_LOG_LEVEL: 'info',
-            GOOGLE_API_ROOT_URL: NO_ADC_PROBE,
+            GOOGLE_API_ROOT_URL: FAKE_API_ROOT,
           },
           timeout: 12000,
         })

--- a/test/local/tool-registration.test.js
+++ b/test/local/tool-registration.test.js
@@ -34,6 +34,7 @@ const CORE_TOOLS = [
   'create_regex_detector',
   'create_url_list_detector',
   'create_word_list_detector',
+  'diagnose_environment',
   'enable_chrome_enterprise_connectors',
   'get_chrome_activity_log',
   'get_connector_policy',
@@ -47,11 +48,9 @@ const CORE_TOOLS = [
   'list_org_units',
 ]
 
-const EXPERIMENT_MAPPING = {
-  [FLAGS.DELETE_TOOL_ENABLED]: ['delete_agent_dlp_rule', 'delete_detector'],
-  [FLAGS.KNOWLEDGE_SEARCH_ENABLED]: ['search_content', 'list_documents'],
-  [FLAGS.DIAGNOSE_TOOL_ENABLED]: ['diagnose_environment'],
-}
+const DELETE_EXPERIMENT_TOOLS = ['delete_agent_dlp_rule', 'delete_detector']
+
+const KNOWLEDGE_SEARCH_EXPERIMENT_TOOLS = ['search_content', 'list_documents']
 
 // Tests for SEB tool registration and individual tool handler logic.
 describe('SEB Tool Registration', () => {
@@ -64,47 +63,50 @@ describe('SEB Tool Registration', () => {
   })
 
   // Test if all tools are registered with the server.
-  test('When registerTools is called, then all core tools are always registered', () => {
-    // Disable all experiments to check base core tools
+  test('When registerTools is called with no experiments, then it registers only core tools', () => {
     registerTools(server, { featureFlags: { isEnabled: () => false } })
 
     const registeredToolNames = server.registerTool.mock.calls.map(call => call.arguments[0])
-    for (const tool of CORE_TOOLS) {
-      assert.ok(registeredToolNames.includes(tool), `Core tool "${tool}" should be registered`)
-    }
+    assert.deepStrictEqual(registeredToolNames.sort(), [...CORE_TOOLS].sort())
   })
 
-  // Test each experiment registration dynamically
-  for (const [flag, tools] of Object.entries(EXPERIMENT_MAPPING)) {
-    test(`When ${flag} is enabled, then it registers its experimental tools`, () => {
-      registerTools(server, {
-        featureFlags: {
-          isEnabled: f => f === flag,
-        },
-      })
-
-      const registeredToolNames = server.registerTool.mock.calls.map(call => call.arguments[0])
-      for (const tool of tools) {
-        assert.ok(registeredToolNames.includes(tool), `Experimental tool "${tool}" should be registered under ${flag}`)
-      }
+  test('When registerTools is called with KNOWLEDGE_SEARCH_ENABLED, then it registers core + search tools', () => {
+    registerTools(server, {
+      featureFlags: {
+        isEnabled: flag => flag === FLAGS.KNOWLEDGE_SEARCH_ENABLED,
+      },
     })
 
-    test(`When ${flag} is disabled, then it does NOT register its experimental tools`, () => {
-      registerTools(server, {
-        featureFlags: {
-          isEnabled: f => f !== flag, // Enable others but not this one
-        },
-      })
+    const registeredToolNames = server.registerTool.mock.calls.map(call => call.arguments[0])
+    const expected = [...CORE_TOOLS, ...KNOWLEDGE_SEARCH_EXPERIMENT_TOOLS].sort()
+    assert.deepStrictEqual(registeredToolNames.sort(), expected)
+  })
 
-      const registeredToolNames = server.registerTool.mock.calls.map(call => call.arguments[0])
-      for (const tool of tools) {
-        assert.ok(
-          !registeredToolNames.includes(tool),
-          `Experimental tool "${tool}" should NOT be registered when ${flag} is disabled`,
-        )
-      }
+  test('When registerTools is called with DELETE_TOOL_ENABLED, then it registers core + delete tools', () => {
+    registerTools(server, {
+      featureFlags: {
+        isEnabled: flag => flag === FLAGS.DELETE_TOOL_ENABLED,
+      },
     })
-  }
+
+    const registeredToolNames = server.registerTool.mock.calls.map(call => call.arguments[0])
+    const expected = [...CORE_TOOLS, ...DELETE_EXPERIMENT_TOOLS].sort()
+    assert.deepStrictEqual(registeredToolNames.sort(), expected)
+  })
+
+  test('When registerEnableApi is false, then check_and_enable_cep_api is not registered', () => {
+    registerTools(server, { featureFlags: { isEnabled: () => false }, registerEnableApi: false })
+
+    const registeredToolNames = server.registerTool.mock.calls.map(call => call.arguments[0])
+    assert.ok(!registeredToolNames.includes('check_and_enable_cep_api'))
+  })
+
+  test('When registerEnableApi is omitted, then check_and_enable_cep_api is registered', () => {
+    registerTools(server, { featureFlags: { isEnabled: () => false } })
+
+    const registeredToolNames = server.registerTool.mock.calls.map(call => call.arguments[0])
+    assert.ok(registeredToolNames.includes('check_and_enable_cep_api'))
+  })
 
   test('When a shared session state is provided, then it is used across tool registrations', async () => {
     const mockAdminSdkClient = {

--- a/test/local/tool-registration.test.js
+++ b/test/local/tool-registration.test.js
@@ -34,7 +34,6 @@ const CORE_TOOLS = [
   'create_regex_detector',
   'create_url_list_detector',
   'create_word_list_detector',
-  'diagnose_environment',
   'enable_chrome_enterprise_connectors',
   'get_chrome_activity_log',
   'get_connector_policy',
@@ -49,6 +48,8 @@ const CORE_TOOLS = [
 ]
 
 const DELETE_EXPERIMENT_TOOLS = ['delete_agent_dlp_rule', 'delete_detector']
+
+const DIAGNOSE_EXPERIMENT_TOOLS = ['diagnose_environment']
 
 const KNOWLEDGE_SEARCH_EXPERIMENT_TOOLS = ['search_content', 'list_documents']
 
@@ -91,6 +92,18 @@ describe('SEB Tool Registration', () => {
 
     const registeredToolNames = server.registerTool.mock.calls.map(call => call.arguments[0])
     const expected = [...CORE_TOOLS, ...DELETE_EXPERIMENT_TOOLS].sort()
+    assert.deepStrictEqual(registeredToolNames.sort(), expected)
+  })
+
+  test('When registerTools is called with DIAGNOSE_TOOL_ENABLED, then it registers core + diagnose tools', () => {
+    registerTools(server, {
+      featureFlags: {
+        isEnabled: flag => flag === FLAGS.DIAGNOSE_TOOL_ENABLED,
+      },
+    })
+
+    const registeredToolNames = server.registerTool.mock.calls.map(call => call.arguments[0])
+    const expected = [...CORE_TOOLS, ...DIAGNOSE_EXPERIMENT_TOOLS].sort()
     assert.deepStrictEqual(registeredToolNames.sort(), expected)
   })
 

--- a/tools/index.js
+++ b/tools/index.js
@@ -53,10 +53,11 @@ import { featureFlags, FLAGS } from '../lib/util/feature_flags.js'
  * @param {object} options - Configuration options for the tools.
  * @param {import('../lib/api/api_clients.js').ApiClients} [options.apiClients] - The API clients collection.
  * @param {import('../lib/util/feature_flags.js').FeatureFlags} [options.featureFlags] - The feature flags manager.
+ * @param {boolean} [options.registerEnableApi] - Whether to register `check_and_enable_cep_api`. Defaults to `true`. Skipped in Google-managed OAuth mode where APIs are pre-enabled in the maintainer's project.
  * @param {object} [sessionState] - The session state object for caching.
  */
 export function registerTools(server, options = {}, sessionState) {
-  const { apiClients = {}, featureFlags: flags = featureFlags } = options
+  const { apiClients = {}, featureFlags: flags = featureFlags, registerEnableApi = true } = options
   const {
     adminSdk,
     chromeManagement: chromeManagementClient,
@@ -97,17 +98,14 @@ export function registerTools(server, options = {}, sessionState) {
   registerCreateDefaultDlpRulesTool(server, { ...commonOpts, cloudIdentityClient }, state)
   registerCheckSebExtensionStatusTool(server, { ...commonOpts, chromePolicyClient }, state)
   registerInstallSebExtensionTool(server, { ...commonOpts, chromePolicyClient }, state)
-  registerCheckAndEnableCepApiTool(server, { ...commonOpts, serviceUsageClient }, state)
-  registerEnableChromeEnterpriseConnectorsTool(server, { ...commonOpts, chromePolicyClient }, state)
-
-  if (flags.isEnabled(FLAGS.DIAGNOSE_TOOL_ENABLED)) {
-    logger.debug(`${TAGS.MCP} Registering diagnose tool (EXPERIMENT_DIAGNOSE_TOOL_ENABLED is active)`)
-    registerDiagnoseEnvironmentTool(
-      server,
-      { ...commonOpts, chromeManagementClient, chromePolicyClient, cloudIdentityClient },
-      state,
-    )
+  if (registerEnableApi) {
+    registerCheckAndEnableCepApiTool(server, { ...commonOpts, serviceUsageClient }, state)
   }
-
+  registerEnableChromeEnterpriseConnectorsTool(server, { ...commonOpts, chromePolicyClient }, state)
+  registerDiagnoseEnvironmentTool(
+    server,
+    { ...commonOpts, chromeManagementClient, chromePolicyClient, cloudIdentityClient },
+    state,
+  )
   registerKnowledgeTools(server, { ...options, featureFlags: flags }, state)
 }

--- a/tools/index.js
+++ b/tools/index.js
@@ -102,10 +102,15 @@ export function registerTools(server, options = {}, sessionState) {
     registerCheckAndEnableCepApiTool(server, { ...commonOpts, serviceUsageClient }, state)
   }
   registerEnableChromeEnterpriseConnectorsTool(server, { ...commonOpts, chromePolicyClient }, state)
-  registerDiagnoseEnvironmentTool(
-    server,
-    { ...commonOpts, chromeManagementClient, chromePolicyClient, cloudIdentityClient },
-    state,
-  )
+
+  if (flags.isEnabled(FLAGS.DIAGNOSE_TOOL_ENABLED)) {
+    logger.debug(`${TAGS.MCP} Registering diagnose tool (EXPERIMENT_DIAGNOSE_TOOL_ENABLED is active)`)
+    registerDiagnoseEnvironmentTool(
+      server,
+      { ...commonOpts, chromeManagementClient, chromePolicyClient, cloudIdentityClient },
+      state,
+    )
+  }
+
   registerKnowledgeTools(server, { ...options, featureFlags: flags }, state)
 }


### PR DESCRIPTION
## Summary

`check_and_enable_cep_api` registration is now gated on the resolved OAuth client source.

- **Bundled Google-managed client** (`source: 'managed'`): tool is not registered. The maintainer's project has the required APIs pre-enabled, so end users on the bundled client never need to call this tool.
- **Custom OAuth client**, **bearer header** (HTTP transport), **service-account key**, or **failure resolving config**: tool is registered.

The tool requires `service.management` and is state-changing (it can enable APIs in the caller's Google Cloud project). Removing the registration in managed-client mode aligns the exposed surface with what the bundled client can actually act on.

## Changes

- `tools/index.js`: `registerTools` accepts `registerEnableApi` (default `true`); registration is conditional on it.
- `mcp-server.js`: `shouldRegisterEnableApi()` returns `false` only when `source === 'managed'`. Errors resolving the OAuth client config fall through to `true`.
- `test/integration/server/mcp-server.test.js`: updated assertion checks absence of the tool in managed mode.
- `test/local/tool-registration.test.js`: two new tests cover `registerEnableApi: false` and the default-true path.

## Test plan

- [x] `npm run lint`
- [x] `npm test`

## Stack

Third of five PRs splitting #163. Stacks on #171. Tracked in #167.
