### PR TITLE
docs: rewrite for OAuth-only auth and the deployment-status warning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@
 #
 # Google attributes API quota and access checks to the project that owns
 # the OAuth client used to mint the access token (the bundled Google-managed
-# client, or a BYO custom client's project). No env var is needed to
+# client, or your own custom client's project). No env var is needed to
 # select the quota project.
 #
 # See README.md for the full scopes list.
@@ -51,11 +51,35 @@
 #
 # The server defaults to stdio transport (for local MCP clients such as
 # the Gemini CLI or any other agent/LLM that speaks MCP over stdio). Set
-# GCP_STDIO=false to start an HTTP server instead. HTTP mode is
-# unauthenticated; bind to a trusted interface only.
+# GCP_STDIO=false to start an HTTP server instead. HTTP mode has no
+# inbound authentication by default; bind to a trusted interface only,
+# or set CEP_BEARER_AUDIENCE below to require ID-token verification.
 
 GCP_STDIO=true
 # PORT=3000
+
+
+# Inbound bearer ID-token verification (HTTP mode only)
+#
+# CEP_BEARER_AUDIENCE turns verification on. Set it to the OAuth client
+# ID(s) (comma-separated for multiple) whose ID tokens this server should
+# accept. Every inbound request must then carry
+# `Authorization: Bearer <id-token>`, and the server checks the token's
+# `aud` claim before forwarding to Google. Failures return 401. With the
+# variable unset, verification is off and the server warns at startup.
+#
+# CEP_BEARER_PRINCIPAL_SUB further locks the server to one Google account.
+# Set it to the `sub` claim from the desired user's ID token (a stable
+# per-account identifier). Mismatches return 403. With it unset, any token
+# whose `aud` is accepted may call the server. Has no effect unless
+# CEP_BEARER_AUDIENCE is also set.
+#
+# To find the right `sub`, start the server with CEP_BEARER_AUDIENCE set
+# and LOG_LEVEL=debug, then have the principal send one request; the
+# server logs `Request authenticated as <email> (sub=<sub>)`.
+
+# CEP_BEARER_AUDIENCE=your-oauth-client-id.apps.googleusercontent.com
+# CEP_BEARER_PRINCIPAL_SUB=123456789012345678901
 
 
 # Evaluations

--- a/.github/expected-tarball.txt
+++ b/.github/expected-tarball.txt
@@ -45,7 +45,6 @@ lib/util/banner.js
 lib/util/cel_validator.js
 lib/util/chrome_dlp_constants.js
 lib/util/connector_policy_helper.js
-lib/util/credential/adc.js
 lib/util/credential/cli_commands.js
 lib/util/credential/index.js
 lib/util/credential/jwt_verifier.js

--- a/README.md
+++ b/README.md
@@ -9,26 +9,7 @@ connector policies, browser telemetry, and license management as MCP tools,
 so any MCP-compatible AI agent can inspect and configure a Chrome Enterprise
 environment.
 
-> [!CAUTION]
-> **This server is an administrator-level interface to Chrome Enterprise Premium.**
-> When you connect it to an MCP client, you can use natural-language prompts to:
->
-> - Create, modify, and delete DLP rules and content detectors.
-> - Change connector policies.
-> - Force-install browser extensions onto every managed Chrome browser.
-> - Enable Google Cloud APIs on your project.
->
-> An attacker who plants hidden instructions in untrusted inputs—mail,
-> documents, scraped pages, ticket bodies—can hijack the connected MCP
-> client through [indirect prompt injection](https://en.wikipedia.org/wiki/Prompt_injection).
-> The attacker can then run those tools without your consent.
->
-> To reduce the blast radius:
->
-> - Connect this server only to MCP clients you trust, on data sources you trust.
-> - Treat every document, message, and webpage you put in front of the agent as untrusted. It might contain hidden instructions.
-> - Pay extra attention to mutating tools (`create_*`, `update_*`, `delete_*`, `enable_*`); they have tenant-wide security impact.
-> - Use a dedicated, least-privilege admin account when experimenting.
+<img width="1280" height="640" alt="c7b0d696-8488-48f9-8a11-bf8bbc72ee7e" src="https://github.com/user-attachments/assets/2665d05d-3f02-4577-8183-2972e74b02e6" />
 
 ## Quick start
 
@@ -107,29 +88,7 @@ Or enable them from the
 The server uses **stdio** transport; your MCP client launches it as a child
 process. Add the config snippet for your client:
 
-<details>
-<summary><strong>VS Code</strong></summary>
-
-Add to `.vscode/mcp.json`:
-
-```json
-{
-  "servers": {
-    "cep": {
-      "command": "npx",
-      "args": ["-y", "@google/chrome-enterprise-premium-mcp@latest"],
-      "env": { "GCP_STDIO": "true" }
-    }
-  }
-}
-```
-
-</details>
-
-<details>
-<summary><strong>Gemini CLI</strong></summary>
-
-Add to `~/.gemini/settings.json`:
+For example, add to `~/.gemini/settings.json`:
 
 ```json
 {
@@ -159,6 +118,27 @@ Restart your MCP client, then ask:
 
 You should see the available tools listed in the response. If they don't
 appear, see [Troubleshooting](#troubleshooting) for the usual causes.
+
+> [!CAUTION]
+> **This server is an administrator-level interface to Chrome Enterprise Premium.**
+> When you connect it to an MCP client, you can use natural-language prompts to:
+>
+> - Create, modify, and delete DLP rules and content detectors.
+> - Change connector policies.
+> - Force-install browser extensions onto every managed Chrome browser.
+> - Enable Google Cloud APIs on your project.
+>
+> An attacker who plants hidden instructions in untrusted inputs—mail,
+> documents, scraped pages, ticket bodies—can hijack the connected MCP
+> client through [indirect prompt injection](https://en.wikipedia.org/wiki/Prompt_injection).
+> The attacker can then run those tools without your consent.
+>
+> To reduce the blast radius:
+>
+> - Connect this server only to MCP clients you trust, on data sources you trust.
+> - Treat every document, message, and webpage you put in front of the agent as untrusted. It might contain hidden instructions.
+> - Pay extra attention to mutating tools (`create_*`, `update_*`, `delete_*`, `enable_*`); they have tenant-wide security impact.
+> - Use a dedicated, least-privilege admin account when experimenting.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -43,15 +43,15 @@ npm install
 Run `mcp auth login` and approve consent in the browser. The CLI caches
 the access token at `~/.config/cep-mcp/tokens.json`.
 
-If you'd rather keep authorization grants and the consent screen inside a
-Google Cloud project you own, provide `CEP_OAUTH_CLIENT_ID` and
-`CEP_OAUTH_CLIENT_SECRET` instead. The
-[Bring your own OAuth client](docs/auth-bring-your-own-oauth-client.md)
-guide walks through creating the OAuth client and registering its redirect URIs.
+To keep authorization grants and the consent screen inside a Google Cloud
+project you own, provide `CEP_OAUTH_CLIENT_ID` and `CEP_OAUTH_CLIENT_SECRET`
+instead. For the steps to create the OAuth client and register its redirect
+URIs, see
+[Bring your own OAuth client](docs/auth-bring-your-own-oauth-client.md).
 
-If you're signing in from a CI runner or an SSH session without a browser,
-[Sign in from a host without a browser](docs/auth-bring-your-own-oauth-client.md#sign-in-from-a-host-without-a-browser)
-covers the paste-the-redirect flow.
+For the paste-the-redirect flow used on CI runners and SSH sessions without
+a browser, see
+[Sign in from a host without a browser](docs/auth-bring-your-own-oauth-client.md#sign-in-from-a-host-without-a-browser).
 
 The scope set requested at consent maps to the underlying APIs:
 
@@ -158,7 +158,7 @@ Restart your MCP client, then ask:
 > "What Chrome Enterprise Premium tools do you have access to?"
 
 You should see the available tools listed in the response. If they don't
-appear, the [Troubleshooting](#troubleshooting) section covers the usual causes.
+appear, see [Troubleshooting](#troubleshooting) for the usual causes.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ gcloud services enable \
   chromepolicy.googleapis.com \
   cloudidentity.googleapis.com \
   licensing.googleapis.com \
-  serviceusage.googleapis.com
+  serviceusage.googleapis.com \
+  servicemanagement.googleapis.com
 ```
 
 Or enable them from the

--- a/README.md
+++ b/README.md
@@ -24,13 +24,12 @@ npm install
 Run `mcp auth login` and approve consent in the browser. The CLI caches
 the access token at `~/.config/cep-mcp/tokens.json`.
 
-To keep authorization grants and the consent screen inside a Google Cloud
-project you own, provide `CEP_OAUTH_CLIENT_ID` and `CEP_OAUTH_CLIENT_SECRET`
-instead. For the steps to create the OAuth client and register its redirect
-URIs, see
-[Bring your own OAuth client](docs/auth-bring-your-own-oauth-client.md).
+To use a custom OAuth client in a Cloud project of your own, set
+`CEP_OAUTH_CLIENT_ID` and `CEP_OAUTH_CLIENT_SECRET` and re-run
+`mcp auth login`. See
+[Use a custom OAuth client](docs/auth-bring-your-own-oauth-client.md).
 
-For the paste-the-redirect flow used on CI runners and SSH sessions without
+For the paste-the-redirect flow on CI runners and SSH sessions without
 a browser, see
 [Sign in from a host without a browser](docs/auth-bring-your-own-oauth-client.md#sign-in-from-a-host-without-a-browser).
 
@@ -61,9 +60,13 @@ For Cloud Run, Vertex AI Agent Engine, or service-account automation, see
 the
 [authentication setup matrix](docs/configuration.md#authenticate-to-google-apis).
 
-### 2. Enable required APIs
+### 2. Enable required APIs (custom OAuth client or service account only)
 
-These APIs must be enabled on your Google Cloud project:
+Skip this step if you used the default Google-managed OAuth client.
+
+For a custom OAuth client (`CEP_OAUTH_CLIENT_ID` /
+`CEP_OAUTH_CLIENT_SECRET`) or a service-account key, enable these
+APIs in the Cloud project that owns those credentials:
 
 ```bash
 gcloud services enable \
@@ -79,9 +82,10 @@ Or enable them from the
 [API Library](https://console.cloud.google.com/apis/library) in Cloud Console.
 
 > [!NOTE]
-> Newly enabled APIs can take 1–5 minutes to become available. The server
-> automatically retries `PERMISSION_DENIED` errors with exponential
-> backoff. If you see retry messages on first run, wait; don't restart.
+> Newly enabled APIs can take 1–5 minutes to become available.
+> `PERMISSION_DENIED` responses are retried automatically with
+> exponential backoff, so wait through any retry messages on first run
+> instead of restarting.
 
 ### 3. Connect your MCP client
 

--- a/README.md
+++ b/README.md
@@ -5,27 +5,30 @@ A [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server for
 (CEP). CEP extends Chrome's built-in security with Data Loss Prevention (DLP),
 real-time threat protection (phishing and malware scanning), and Context-Aware
 Access controls. This server exposes CEP's DLP rules, content detectors,
-connector policies, browser telemetry, and license management as MCP tools —
-letting any MCP-compatible AI agent inspect and configure a Chrome Enterprise
+connector policies, browser telemetry, and license management as MCP tools,
+so any MCP-compatible AI agent can inspect and configure a Chrome Enterprise
 environment.
 
-## Important security consideration: Indirect Prompt Injection Risk
-
-When exposing any language model to untrusted data, there's a risk of an
-[indirect prompt injection attack](https://en.wikipedia.org/wiki/Prompt_injection).
-Agentic tools like Gemini CLI, connected to MCP servers, have access to a wide
-array of tools and APIs.
-
-This MCP server grants the agent the ability to read, modify, and delete your
-Google Account data, as well as other data shared with you.
-
-- Never connect this server to untrusted tools.
-- Never feed untrusted content into the model context, including mail,
-  documents, or other resources from unverified sources.
-- Attackers can hide instructions inside untrusted content and use a
-  hijacked CLI session to modify, steal, or destroy your data.
-- Always review the actions Gemini CLI takes on your behalf and confirm
-  they match what you asked for.
+> [!CAUTION]
+> **This server is an administrator-level interface to Chrome Enterprise Premium.**
+> When you connect it to an MCP client, you can use natural-language prompts to:
+>
+> - Create, modify, and delete DLP rules and content detectors.
+> - Change connector policies.
+> - Force-install browser extensions onto every managed Chrome browser.
+> - Enable Google Cloud APIs on your project.
+>
+> An attacker who plants hidden instructions in untrusted inputs—mail,
+> documents, scraped pages, ticket bodies—can hijack the connected MCP
+> client through [indirect prompt injection](https://en.wikipedia.org/wiki/Prompt_injection).
+> The attacker can then run those tools without your consent.
+>
+> To reduce the blast radius:
+>
+> - Connect this server only to MCP clients you trust, on data sources you trust.
+> - Treat every document, message, and webpage you put in front of the agent as untrusted. It might contain hidden instructions.
+> - Pay extra attention to mutating tools (`create_*`, `update_*`, `delete_*`, `enable_*`); they have tenant-wide security impact.
+> - Use a dedicated, least-privilege admin account when experimenting.
 
 ## Quick start
 
@@ -35,70 +38,51 @@ cd chrome-enterprise-premium-mcp
 npm install
 ```
 
-### 1. Authenticate with Google Cloud
+### 1. Sign in
 
-Install the [Google Cloud CLI](https://cloud.google.com/sdk/docs/install) if you
-don't have it, then create
-[Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials)
-(ADC) with the scopes needed by each API:
+Run `mcp auth login` and approve consent in the browser. The CLI caches
+the access token at `~/.config/cep-mcp/tokens.json`.
 
-```bash
-gcloud auth application-default login \
---scopes=openid,\
-https://www.googleapis.com/auth/userinfo.email,\
-https://www.googleapis.com/auth/chrome.management.policy,\
-https://www.googleapis.com/auth/chrome.management.reports.readonly,\
-https://www.googleapis.com/auth/chrome.management.profiles.readonly,\
-https://www.googleapis.com/auth/admin.reports.audit.readonly,\
-https://www.googleapis.com/auth/admin.directory.orgunit.readonly,\
-https://www.googleapis.com/auth/admin.directory.customer.readonly,\
-https://www.googleapis.com/auth/apps.licensing,\
-https://www.googleapis.com/auth/cloud-identity.policies,\
-https://www.googleapis.com/auth/service.management,\
-https://www.googleapis.com/auth/service.management.readonly,\
-https://www.googleapis.com/auth/cloud-platform
-```
+If you'd rather keep authorization grants and the consent screen inside a
+Google Cloud project you own, provide `CEP_OAUTH_CLIENT_ID` and
+`CEP_OAUTH_CLIENT_SECRET` instead. The
+[Bring your own OAuth client](docs/auth-bring-your-own-oauth-client.md)
+guide walks through creating the OAuth client and registering its redirect URIs.
 
-These scopes map to the underlying APIs:
+If you're signing in from a CI runner or an SSH session without a browser,
+[Sign in from a host without a browser](docs/auth-bring-your-own-oauth-client.md#sign-in-from-a-host-without-a-browser)
+covers the paste-the-redirect flow.
 
-| Scope                                                                 | API                                                                             | Used for                                                           |
-| :-------------------------------------------------------------------- | :------------------------------------------------------------------------------ | :----------------------------------------------------------------- |
-| `openid`, `userinfo.email`                                            | OpenID Connect                                                                  | Identifies the principal in startup banner output                  |
-| `chrome.management.policy`                                            | [Chrome Policy](https://developers.google.com/chrome/policy)                    | Reading and writing connector policies, extension install policies |
-| `chrome.management.reports.readonly`                                  | [Chrome Management](https://developers.google.com/chrome/management)            | Browser version counts                                             |
-| `chrome.management.profiles.readonly`                                 | [Chrome Management](https://developers.google.com/chrome/management)            | Listing managed browser profiles                                   |
-| `admin.reports.audit.readonly`                                        | [Admin SDK Reports](https://developers.google.com/admin-sdk/reports)            | Chrome activity logs                                               |
-| `admin.directory.orgunit.readonly`                                    | [Admin SDK Directory](https://developers.google.com/admin-sdk/directory)        | Organizational unit hierarchy                                      |
-| `admin.directory.customer.readonly`                                   | [Admin SDK Directory](https://developers.google.com/admin-sdk/directory)        | Customer ID resolution                                             |
-| `apps.licensing`                                                      | [Enterprise License Manager](https://developers.google.com/admin-sdk/licensing) | CEP subscription and per-user license checks                       |
-| `cloud-identity.policies`                                             | [Cloud Identity](https://cloud.google.com/identity/docs)                        | DLP rules and content detectors (CRUD)                             |
-| `service.management`, `service.management.readonly`, `cloud-platform` | [Service Usage](https://cloud.google.com/service-usage/docs)                    | Checking and enabling required APIs                                |
+The scope set requested at consent maps to the underlying APIs:
 
-Then set a quota project (identifies which GCP project's API enablement and
-quotas to use):
+| Scope                                 | API                                                                             | Used for                                                           |
+| :------------------------------------ | :------------------------------------------------------------------------------ | :----------------------------------------------------------------- |
+| `openid`, `userinfo.email`            | OpenID Connect                                                                  | Identifies the principal in startup banner output                  |
+| `chrome.management.policy`            | [Chrome Policy](https://developers.google.com/chrome/policy)                    | Reading and writing connector policies, extension install policies |
+| `chrome.management.reports.readonly`  | [Chrome Management](https://developers.google.com/chrome/management)            | Browser version counts                                             |
+| `chrome.management.profiles.readonly` | [Chrome Management](https://developers.google.com/chrome/management)            | Listing managed browser profiles                                   |
+| `admin.reports.audit.readonly`        | [Admin SDK Reports](https://developers.google.com/admin-sdk/reports)            | Chrome activity logs                                               |
+| `admin.directory.orgunit.readonly`    | [Admin SDK Directory](https://developers.google.com/admin-sdk/directory)        | Organizational unit hierarchy                                      |
+| `admin.directory.customer.readonly`   | [Admin SDK Directory](https://developers.google.com/admin-sdk/directory)        | Customer ID resolution                                             |
+| `apps.licensing`                      | [Enterprise License Manager](https://developers.google.com/admin-sdk/licensing) | CEP subscription and per-user license checks                       |
+| `cloud-identity.policies`             | [Cloud Identity](https://cloud.google.com/identity/docs)                        | DLP rules and content detectors (CRUD)                             |
+| `service.management`                  | [Service Usage](https://cloud.google.com/service-usage/docs)                    | Checking and enabling required APIs                                |
 
-```bash
-gcloud auth application-default set-quota-project YOUR_PROJECT_ID
-```
-
-> **Scopes must be provided at login time.** You cannot add scopes to
-> existing ADC credentials. If you get "insufficient scopes" errors,
-> delete `~/.config/gcloud/application_default_credentials.json` and re-run
-> the `gcloud auth application-default login` command from the previous step.
->
-> **The quota project is required.** Without it you'll see a "quota project
-> not set" error on the first API call.
->
-> **Restricted Workspace environments:** If your organization restricts third-party
-> app access, an admin must [trust the gcloud OAuth app](docs/troubleshooting.md#configure-oauth-app-for-sensitive-scopes)
+> [!NOTE]
+> If your organization restricts third-party app access, an administrator
+> must
+> [trust the OAuth client](docs/troubleshooting.md#configure-oauth-app-for-sensitive-scopes)
 > before you can authenticate with sensitive Workspace scopes.
-> **Alternative to ADC:** run `mcp auth login` for an OAuth-flow setup.
-> Setup walkthrough at [`docs/auth-bring-your-own-oauth-client.md`](docs/auth-bring-your-own-oauth-client.md).
-> Auth-method matrix at [`docs/configuration.md#authenticating-to-google-apis`](docs/configuration.md#authenticating-to-google-apis).
 
-### 2. Enable Required APIs
+#### Hosted deployments
 
-These APIs must be enabled on your GCP project:
+For Cloud Run, Vertex AI Agent Engine, or service-account automation, see
+the
+[authentication setup matrix](docs/configuration.md#authenticate-to-google-apis).
+
+### 2. Enable required APIs
+
+These APIs must be enabled on your Google Cloud project:
 
 ```bash
 gcloud services enable \
@@ -113,54 +97,15 @@ gcloud services enable \
 Or enable them from the
 [API Library](https://console.cloud.google.com/apis/library) in Cloud Console.
 
-> **Propagation delay:** Newly enabled APIs can take 1–5 minutes to become
-> available. The server handles this automatically by retrying
-> `PERMISSION_DENIED` errors with exponential backoff. If you see retry messages
-> on first run, wait; don't restart.
+> [!NOTE]
+> Newly enabled APIs can take 1–5 minutes to become available. The server
+> automatically retries `PERMISSION_DENIED` errors with exponential
+> backoff. If you see retry messages on first run, wait; don't restart.
 
-### 3. Connect Your MCP Client
+### 3. Connect your MCP client
 
 The server uses **stdio** transport; your MCP client launches it as a child
 process. Add the config snippet for your client:
-
-<details>
-<summary><strong>Claude Desktop</strong></summary>
-
-Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
-or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
-
-```json
-{
-  "mcpServers": {
-    "cep": {
-      "command": "npx",
-      "args": ["-y", "@google/chrome-enterprise-premium-mcp@latest"],
-      "env": { "GCP_STDIO": "true" }
-    }
-  }
-}
-```
-
-</details>
-
-<details>
-<summary><strong>Claude Code</strong></summary>
-
-Add to `.mcp.json` in your project root:
-
-```json
-{
-  "mcpServers": {
-    "cep": {
-      "command": "npx",
-      "args": ["-y", "@google/chrome-enterprise-premium-mcp@latest"],
-      "env": { "GCP_STDIO": "true" }
-    }
-  }
-}
-```
-
-</details>
 
 <details>
 <summary><strong>VS Code</strong></summary>
@@ -200,7 +145,11 @@ Add to `~/.gemini/settings.json`:
 
 </details>
 
-> Optional: If you are running from a local checkout instead of npx, replace the command with `node` and args with the absolute path to `mcp-server.js`. Relative paths might not resolve correctly depending on the client.
+> [!TIP]
+> If you are running from a local checkout instead of npx, replace the
+> command with `node` and the args with the absolute path to
+> `mcp-server.js`. Relative paths might not resolve depending on the
+> client.
 
 ### 4. Verify
 
@@ -208,8 +157,8 @@ Restart your MCP client, then ask:
 
 > "What Chrome Enterprise Premium tools do you have access to?"
 
-The agent discovers and lists the available tools. If tools don't
-appear, see [Troubleshooting](#troubleshooting).
+You should see the available tools listed in the response. If they don't
+appear, the [Troubleshooting](#troubleshooting) section covers the usual causes.
 
 ## Configuration
 
@@ -218,21 +167,21 @@ For environment variables and stdio vs. HTTP transport, see
 
 ## Prerequisites
 
-| Requirement          | Details                                                                                                                                                                                                                               |
-| :------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Node.js**          | >= 18.0.0 (`node --version` to check)                                                                                                                                                                                                 |
-| **Google Cloud CLI** | [`gcloud`](https://cloud.google.com/sdk/docs/install) installed and on your PATH (`gcloud --version` to check)                                                                                                                        |
-| **Google Workspace** | Any edition, plus a [Chrome Enterprise Premium](https://docs.cloud.google.com/chrome-enterprise-premium/docs/overview) license ([60-day free trial available](https://docs.cloud.google.com/chrome-enterprise-premium/docs/overview)) |
-| **Admin role**       | Google Workspace Super Admin, or a delegated admin with Chrome Management and DLP permissions                                                                                                                                         |
-| **GCP project**      | Linked to your Workspace domain, with required APIs enabled                                                                                                                                                                           |
-| **OAuth App Trust**  | The gcloud CLI must be [trusted in the Admin Console](docs/troubleshooting.md#configure-oauth-app-for-sensitive-scopes) for sensitive scopes.                                                                                         |
+| Requirement              | Details                                                                                                                                                                                                                               |
+| :----------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Node.js**              | >= 18.0.0 (`node --version` to check)                                                                                                                                                                                                 |
+| **Google Workspace**     | Any edition, plus a [Chrome Enterprise Premium](https://docs.cloud.google.com/chrome-enterprise-premium/docs/overview) license ([60-day free trial available](https://docs.cloud.google.com/chrome-enterprise-premium/docs/overview)) |
+| **Admin role**           | Google Workspace Super Admin, or a delegated admin with Chrome Management and DLP permissions                                                                                                                                         |
+| **Google Cloud project** | Linked to your Workspace domain, with required APIs enabled                                                                                                                                                                           |
+| **OAuth App Trust**      | The OAuth client must be [trusted in the Admin Console](docs/troubleshooting.md#configure-oauth-app-for-sensitive-scopes) for sensitive scopes.                                                                                       |
 
-> **GCP IAM is not enough.** Chrome Management and Admin SDK APIs require a
-> Google Workspace admin role _in addition to_ GCP IAM roles. The user must hold
-> an admin role in the [Admin Console](https://admin.google.com/) (Super Admin
-> or delegated with Chrome Management permissions). Having only GCP IAM
-> permissions produces `403 Permission Denied` with no indication that a
-> Workspace role is missing.
+> [!IMPORTANT]
+> Chrome Management and Admin SDK APIs require a Google Workspace admin
+> role in addition to Google Cloud IAM roles. You must hold an admin role
+> in the [Admin Console](https://admin.google.com/) (Super Admin or
+> delegated with Chrome Management permissions). With only Google Cloud
+> IAM permissions, calls return `403 Permission Denied` with no indication
+> that a Workspace role is missing.
 
 ## Available tools and prompts
 

--- a/adk/cep_agent/README.md
+++ b/adk/cep_agent/README.md
@@ -57,13 +57,11 @@ Follow these steps to run the agent against a real Google Cloud project.
    https://www.googleapis.com/auth/admin.directory.customer.readonly,\
    https://www.googleapis.com/auth/apps.licensing,\
    https://www.googleapis.com/auth/cloud-identity.policies,\
-   https://www.googleapis.com/auth/service.management,\
-   https://www.googleapis.com/auth/service.management.readonly,\
-   https://www.googleapis.com/auth/cloud-platform \
+   https://www.googleapis.com/auth/service.management \
      --no-launch-browser
    ```
 
-   For an OAuth-flow alternative that does not require `gcloud` (and uses the OAuth-narrow scope set without `cloud-platform`), run `mcp auth login` from the repo root. For the setup walkthrough, see [`docs/auth-bring-your-own-oauth-client.md`](../../docs/auth-bring-your-own-oauth-client.md).
+   For an OAuth-flow alternative that does not require `gcloud`, run `mcp auth login` from the repo root. For the setup walkthrough, see [`docs/auth-bring-your-own-oauth-client.md`](../../docs/auth-bring-your-own-oauth-client.md).
 
 2. Start the ADK server:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,7 +37,7 @@ limitations under the License.
 
 - **Client abstraction.** Each Google API has a client wrapper in `lib/api/*_client.js`. Tool code calls these clients. For tests, the client instance receives a `rootUrl` override and a stub auth client to redirect calls at the in-process fake server. For the full pattern, see [`lib/api/README.md`](../lib/api/README.md).
 - **Structured tool output.** Tools return structured JSON with both machine-readable data and a human-readable summary.
-- **Retry with backoff.** API calls retry on `PERMISSION_DENIED` (gRPC code 7) up to seven times to handle eventual consistency after enabling APIs. The first retry waits 15 seconds; subsequent retries use exponential backoff.
+- **Retry with backoff.** The server retries `PERMISSION_DENIED` (gRPC code 7) up to seven times to handle eventual consistency after enabling APIs, with a 15-second initial delay; subsequent retries use exponential backoff.
 - **CEL validation.** DLP rule conditions are validated offline against the Chrome CEL grammar before submission to Google.
 
 ## Test backends
@@ -45,4 +45,4 @@ limitations under the License.
 Tests and evals run against two backends, controlled by the `CEP_BACKEND` environment variable.
 
 - **Fake** (default for presubmit). An in-process Express server at `test/helpers/fake-api-server.js` mimics the five Google APIs the server uses. The client classes target it through a `rootUrl` override and a stub auth client. The fake backend makes no network calls and needs no credentials.
-- **Real** (postsubmit). The client classes call the live Google APIs using your Application Default Credentials. The real backend requires authentication and the relevant APIs to be enabled.
+- **Real** (postsubmit). The client classes call the live Google APIs using your cached OAuth tokens (run `mcp auth login` first) or a service-account key from `GOOGLE_APPLICATION_CREDENTIALS`. The real backend requires authentication and the relevant APIs to be enabled.

--- a/docs/auth-bring-your-own-oauth-client.md
+++ b/docs/auth-bring-your-own-oauth-client.md
@@ -16,7 +16,12 @@ limitations under the License.
 
 # Bring your own OAuth client
 
-To run `mcp auth login`, you need a Google OAuth client. Until Google provisions a managed client for this project, you must supply your own. Set `CEP_OAUTH_CLIENT_ID` and `CEP_OAUTH_CLIENT_SECRET` in your environment to point at a Desktop OAuth client that you create in your Google Cloud project.
+By default, `mcp auth login` uses a Google-managed Desktop OAuth client that ships with this project. You do not need to supply your own credentials to authenticate.
+
+Set `CEP_OAUTH_CLIENT_ID` and `CEP_OAUTH_CLIENT_SECRET` only if you want to authenticate through a Desktop OAuth client that you have created in a Google Cloud project of your own. With a custom client, the OAuth consent screen and any authorization grants are scoped to your own project rather than to the bundled one.
+
+> [!NOTE]
+> The `client_secret` of a Desktop OAuth client is a public value, not a confidential credential. Per Google's documentation for installed applications, the secret is "embedded in the source code of your application" and "is obviously not treated as a secret." Authorization is bound to the end user's Google consent and to the registered loopback redirect URI (`http://127.0.0.1`), not to the secret. The same property holds for any Desktop OAuth client you create yourself, including under BYO.
 
 When you log in, the CLI writes an access token to `~/.config/cep-mcp/tokens.json` with file mode `0600`. The cache contains the access token only—no refresh token—and the access token expires after about an hour.
 
@@ -44,7 +49,7 @@ Follow these steps to authenticate the CLI with the OAuth client you created:
 
 2. Run `mcp auth login`.
 3. Approve consent in the browser that the CLI opens.
-4. Verify the cache by running `mcp auth-status`.
+4. Verify the cache by running `mcp auth status`.
 
 ## Sign in from a host without a browser
 
@@ -63,7 +68,7 @@ Follow these steps to sign in by pasting the redirect URL from a different machi
 
 ## Scopes
 
-When you log in, the CLI requests every scope listed in `lib/constants.js#OAUTH_SCOPES`. That set is `SCOPES` minus `cloud-platform`, so the consent screen shows the narrower per-API scopes the server actually uses. To see which scopes the cached token actually granted, run `mcp auth-status`.
+When you log in, you'll see a consent screen requesting the full scope set the server needs (defined in `lib/constants.js`). To see which scopes the cached token actually granted, run `mcp auth status`.
 
 ## Refresh expired tokens
 

--- a/docs/auth-bring-your-own-oauth-client.md
+++ b/docs/auth-bring-your-own-oauth-client.md
@@ -21,7 +21,7 @@ By default, `mcp auth login` uses a Google-managed Desktop OAuth client that shi
 Set `CEP_OAUTH_CLIENT_ID` and `CEP_OAUTH_CLIENT_SECRET` only if you want to authenticate through a Desktop OAuth client that you have created in a Google Cloud project of your own. With a custom client, the OAuth consent screen and any authorization grants are scoped to your own project rather than to the bundled one.
 
 > [!NOTE]
-> The `client_secret` of a Desktop OAuth client is a public value, not a confidential credential. Per Google's documentation for installed applications, the secret is "embedded in the source code of your application" and "is obviously not treated as a secret." Authorization is bound to the end user's Google consent and to the registered loopback redirect URI (`http://127.0.0.1`), not to the secret. The same property holds for any Desktop OAuth client you create yourself, including under BYO.
+> The `client_secret` of a Desktop OAuth client is a public value, not a confidential credential. Per Google's documentation for installed applications, the secret is "embedded in the source code of your application" and "is obviously not treated as a secret." Authorization is bound to the end user's Google consent and to the registered loopback redirect URI (`http://127.0.0.1`), not to the secret. The same property holds for any Desktop OAuth client you create yourself.
 
 When you log in, the CLI writes an access token to `~/.config/cep-mcp/tokens.json` with file mode `0600`. The cache contains the access token only—no refresh token—and the access token expires after about an hour.
 

--- a/docs/auth-bring-your-own-oauth-client.md
+++ b/docs/auth-bring-your-own-oauth-client.md
@@ -36,6 +36,37 @@ Follow these steps to create a Desktop OAuth client and copy its credentials:
 5. Click **Create**.
 6. From the **OAuth client created** dialog, copy the client ID and the client secret.
 
+## Enable required APIs
+
+The project that owns your OAuth client must have every Google API the server calls enabled. If an API is disabled, the first tool call against it returns `SERVICE_DISABLED`. Enable them up front so you don't hit that mid-session.
+
+With gcloud:
+
+```bash
+gcloud services enable \
+  admin.googleapis.com \
+  chromemanagement.googleapis.com \
+  chromepolicy.googleapis.com \
+  cloudidentity.googleapis.com \
+  licensing.googleapis.com \
+  serviceusage.googleapis.com \
+  servicemanagement.googleapis.com \
+  --project=YOUR_PROJECT_ID
+```
+
+Or, from the [API Library](https://console.cloud.google.com/apis/library) in the Cloud Console, enable each of:
+
+- Admin SDK API
+- Chrome Management API
+- Chrome Policy API
+- Cloud Identity API
+- Enterprise License Manager API
+- Service Usage API
+- Service Management API
+
+> [!NOTE]
+> Newly enabled APIs can take 1–5 minutes to propagate. The server retries `PERMISSION_DENIED` automatically with exponential backoff, so wait through any retry messages on first run instead of restarting.
+
 ## Sign in for the first time
 
 Follow these steps to authenticate the CLI with the OAuth client you created:

--- a/docs/auth-cloud-run-and-gemini-enterprise.md
+++ b/docs/auth-cloud-run-and-gemini-enterprise.md
@@ -22,9 +22,11 @@ For hosted deployments, OAuth is the recommended authentication path. A service 
 
 OAuth bearer per request has two parts.
 
-The first part is the OAuth-handling layer. Vertex AI Agent Engine handles OAuth consent for you. You register your OAuth client with Agent Engine; the registered redirect URI is `https://vertexaisearch.cloud.google.com/oauth-redirect`. Agent Engine receives the authorization code, exchanges it for tokens, and forwards the user's access token (or ID token) on every tool-call request to your MCP server.
+The first part is the OAuth-handling layer. With Vertex AI Agent Engine, OAuth consent is managed for you: you register your OAuth client with Agent Engine using the redirect URI `https://vertexaisearch.cloud.google.com/oauth-redirect`. From then on, the user's access token (or ID token) is forwarded on every tool-call request to your MCP server.
 
-The second part is inbound verification. In HTTP mode, set `CEP_BEARER_AUDIENCE` to the OAuth client ID you registered. The server then checks every inbound request's `Authorization: Bearer <id-token>` against that audience before forwarding to Google. Failures return `401 Unauthorized`. For configuration detail, see [`configuration.md`](configuration.md#authenticate-to-google-apis).
+The second part is inbound verification. In HTTP mode, set `CEP_BEARER_AUDIENCE` to the OAuth client ID you registered. With it set, every inbound request's `Authorization: Bearer <id-token>` is checked against that audience before any forward to Google, and failures return `401 Unauthorized`.
+
+If you want the full set of HTTP-mode variables, [`configuration.md`](configuration.md#authenticate-to-google-apis) lists them.
 
 ### Cloud Run setup sketch
 
@@ -38,7 +40,9 @@ gcloud run deploy cep-mcp \
 
 Replace `YOUR_OAUTH_CLIENT_ID` with the client ID of the OAuth client you registered with Agent Engine.
 
-Register the OAuth client with Vertex AI Agent Engine through the Agent Engine console or its CLI. The exact `create-auth` invocation lives in the Agent Engine documentation. For this MCP server, the registration needs the OAuth client ID, the OAuth client secret, Google's standard authorization and token URIs, and a scope list. The scope list is `OAUTH_SCOPES` from `lib/constants.js`, which is the full `SCOPES` set minus `cloud-platform`.
+Register the OAuth client with Vertex AI Agent Engine through the Agent Engine console or its CLI. The exact `create-auth` invocation lives in the Agent Engine documentation. For this MCP server, the registration needs the OAuth client ID, the OAuth client secret, Google's standard authorization and token URIs, and a scope list.
+
+For the scope list, use the full scope set the server requests (defined in `lib/constants.js`).
 
 A reference walkthrough of an end-to-end ADK agent on Vertex AI Agent Engine with OAuth is the third-party blog post [Powering up your agent in production with ADK, OAuth, and Gemini Enterprise](https://fmind.medium.com/powering-up-your-agent-in-production-with-adk-oauth-and-gemini-enterprise-a52b0716fcba).
 

--- a/docs/auth-cloud-run-and-gemini-enterprise.md
+++ b/docs/auth-cloud-run-and-gemini-enterprise.md
@@ -26,7 +26,7 @@ The first part is the OAuth-handling layer. With Vertex AI Agent Engine, OAuth c
 
 The second part is inbound verification. In HTTP mode, set `CEP_BEARER_AUDIENCE` to the OAuth client ID you registered. With it set, every inbound request's `Authorization: Bearer <id-token>` is checked against that audience before any forward to Google, and failures return `401 Unauthorized`.
 
-If you want the full set of HTTP-mode variables, [`configuration.md`](configuration.md#authenticate-to-google-apis) lists them.
+For the full set of HTTP-mode variables, see [`configuration.md`](configuration.md#authenticate-to-google-apis).
 
 ### Cloud Run setup sketch
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,12 +46,13 @@ PORT=8080 GCP_STDIO=false npx -y @google/chrome-enterprise-premium-mcp@latest
 
 ## Key variables
 
-| Variable              | Description                                                                                                                                                                                                                                        | Default |
-| :-------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------ |
-| `GCP_STDIO`           | `true` for stdio (local), `false` for HTTP (remote).                                                                                                                                                                                               | `true`  |
-| `PORT`                | Network port when `GCP_STDIO=false`.                                                                                                                                                                                                               | `0`     |
-| `LOG_LEVEL`           | Verbosity. One of `error`, `warn`, `info`, `debug`.                                                                                                                                                                                                | `info`  |
-| `CEP_BEARER_AUDIENCE` | When set in HTTP mode, every inbound request must carry an `Authorization: Bearer <id-token>` whose `aud` claim is in this value (comma-separated for multiple). When unset, ID-token verification is off and the server prints a startup warning. | -       |
+| Variable                   | Description                                                                                                                                                                                                                                        | Default |
+| :------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------ |
+| `GCP_STDIO`                | `true` for stdio (local), `false` for HTTP (remote).                                                                                                                                                                                               | `true`  |
+| `PORT`                     | Network port when `GCP_STDIO=false`.                                                                                                                                                                                                               | `0`     |
+| `LOG_LEVEL`                | Verbosity. One of `error`, `warn`, `info`, `debug`.                                                                                                                                                                                                | `info`  |
+| `CEP_BEARER_AUDIENCE`      | When set in HTTP mode, every inbound request must carry an `Authorization: Bearer <id-token>` whose `aud` claim is in this value (comma-separated for multiple). When unset, ID-token verification is off and the server prints a startup warning. | -       |
+| `CEP_BEARER_PRINCIPAL_SUB` | When set, narrows access to a single Google account: requests whose token `sub` does not match return `403 Forbidden`. Has no effect unless `CEP_BEARER_AUDIENCE` is also set.                                                                     | -       |
 
 > [!NOTE]
 > When `GCP_STDIO=false` and `PORT` is unset or `0`, the server binds to a random available port. The actual port is logged at startup, for example: `Chrome Enterprise Premium MCP server listening on port X`.
@@ -81,4 +82,22 @@ If you're not sure which path applies to you, see the [Which auth path should I 
 
 ### Inbound bearer ID-token verification (HTTP mode)
 
-For HTTP-mode deployments behind an OAuth-bearing caller, such as Vertex AI Agent Engine, set `CEP_BEARER_AUDIENCE` to the OAuth client ID whose ID-token issuance is allowed for this server. With it set, every inbound request must carry `Authorization: Bearer <id-token>`, and the server checks the token's `aud` claim against `CEP_BEARER_AUDIENCE`. Failures return `401 Unauthorized` ahead of any forward to Google. When `CEP_BEARER_AUDIENCE` is unset, the check is off and the server prints a startup warning.
+For HTTP-mode deployments behind an OAuth-bearing caller (such as Vertex AI Agent Engine), turn on per-request ID-token verification with two environment variables. They serve different purposes and you usually set both.
+
+**`CEP_BEARER_AUDIENCE` — turns verification on.**
+
+- Set it to the OAuth client ID(s) whose ID tokens this server accepts. Comma-separated for multiple.
+- With it set, every inbound request must carry `Authorization: Bearer <id-token>`, and the server checks the token's `aud` claim against this list before forwarding anything to Google.
+- A failure returns `401 Unauthorized`.
+- When `CEP_BEARER_AUDIENCE` is unset, verification is off and the server prints a startup warning.
+
+**`CEP_BEARER_PRINCIPAL_SUB` — locks the server to one Google account.**
+
+- Set it to the `sub` claim from the desired user's ID token. The `sub` is a stable, per-Google-account identifier that does not change when the user's email changes.
+- With it set, the server accepts only tokens whose `sub` matches; mismatches return `403 Forbidden`. With it unset, any token whose `aud` is allowed by `CEP_BEARER_AUDIENCE` may call the server.
+- Why set it: in a single-tenant deployment (one specific human, one specific service account), restrict access to that one principal instead of any caller who can mint a token from an allowed OAuth client.
+- Prerequisite: `CEP_BEARER_AUDIENCE` must also be set. On its own, `CEP_BEARER_PRINCIPAL_SUB` has no effect; the server logs a startup warning explaining what is missing.
+
+**Finding the right `sub` value.**
+
+Start the server with `CEP_BEARER_AUDIENCE` set and `LOG_LEVEL=debug`, then have the desired principal send one request. The server logs `Request authenticated as <email> (sub=<sub>)`. Copy the `sub` value into `CEP_BEARER_PRINCIPAL_SUB` and restart.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,7 +68,7 @@ The server resolves credentials in `lib/util/auth.js#getAuthClient` and tries ea
 
 Most workstation users want the OAuth flow. Most hosted deployments (Cloud Run, Vertex AI Agent Engine) want bearer pass-through. Service accounts cover the cases where neither fits.
 
-If you're not sure which path applies to you, the [Which auth path should I use?](faq.md#which-auth-path-should-i-use) FAQ entry walks through the common deployment shapes.
+If you're not sure which path applies to you, see the [Which auth path should I use?](faq.md#which-auth-path-should-i-use) FAQ entry for the common deployment shapes.
 
 | Setup                          | Transport | Credential source                           | Setup walkthrough                                                                               |
 | :----------------------------- | :-------- | :------------------------------------------ | :---------------------------------------------------------------------------------------------- |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,8 +29,7 @@ Add the variables to the `env` block of your MCP client's settings file. The cli
       "command": "npx",
       "args": ["-y", "@google/chrome-enterprise-premium-mcp@latest"],
       "env": {
-        "GCP_STDIO": "true",
-        "GOOGLE_CLOUD_QUOTA_PROJECT": "your-project-id"
+        "GCP_STDIO": "true"
       }
     }
   }
@@ -47,27 +46,35 @@ PORT=8080 GCP_STDIO=false npx -y @google/chrome-enterprise-premium-mcp@latest
 
 ## Key variables
 
-| Variable                     | Description                                                                                                                                                                                                                                        | Default |
-| :--------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------ |
-| `GCP_STDIO`                  | `true` for stdio (local), `false` for HTTP (remote).                                                                                                                                                                                               | `true`  |
-| `PORT`                       | Network port when `GCP_STDIO=false`.                                                                                                                                                                                                               | `0`     |
-| `GOOGLE_CLOUD_QUOTA_PROJECT` | Google Cloud project ID for API quotas.                                                                                                                                                                                                            | -       |
-| `LOG_LEVEL`                  | Verbosity. One of `error`, `warn`, `info`, `debug`.                                                                                                                                                                                                | `info`  |
-| `CEP_BEARER_AUDIENCE`        | When set in HTTP mode, every inbound request must carry an `Authorization: Bearer <id-token>` whose `aud` claim is in this value (comma-separated for multiple). When unset, ID-token verification is off and the server prints a startup warning. | -       |
+| Variable              | Description                                                                                                                                                                                                                                        | Default |
+| :-------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------ |
+| `GCP_STDIO`           | `true` for stdio (local), `false` for HTTP (remote).                                                                                                                                                                                               | `true`  |
+| `PORT`                | Network port when `GCP_STDIO=false`.                                                                                                                                                                                                               | `0`     |
+| `LOG_LEVEL`           | Verbosity. One of `error`, `warn`, `info`, `debug`.                                                                                                                                                                                                | `info`  |
+| `CEP_BEARER_AUDIENCE` | When set in HTTP mode, every inbound request must carry an `Authorization: Bearer <id-token>` whose `aud` claim is in this value (comma-separated for multiple). When unset, ID-token verification is off and the server prints a startup warning. | -       |
 
 > [!NOTE]
 > When `GCP_STDIO=false` and `PORT` is unset or `0`, the server binds to a random available port. The actual port is logged at startup, for example: `Chrome Enterprise Premium MCP server listening on port X`.
 
 ## Authenticate to Google APIs
 
-`lib/util/auth.js#getAuthClient` resolves credentials in this priority order: a bearer header on the request, Application Default Credentials, then the OAuth token cache. Pick a setup based on your environment. For situational guidance by deployment shape, see the [Which auth path should I use?](faq.md#which-auth-path-should-i-use) FAQ entry.
+The server resolves credentials in `lib/util/auth.js#getAuthClient` and tries each source in turn:
 
-| Setup                      | Transport | Credential source                              | Setup walkthrough                                                                               |
-| :------------------------- | :-------- | :--------------------------------------------- | :---------------------------------------------------------------------------------------------- |
-| `gcloud` ADC (recommended) | stdio     | ADC, full scope set including `cloud-platform` | [Quick Start §1](../README.md#1-authenticate-with-google-cloud)                                 |
-| OAuth login (workstation)  | stdio     | OAuth token cache, narrow scope set            | [`auth-bring-your-own-oauth-client.md`](auth-bring-your-own-oauth-client.md)                    |
-| Bearer pass-through        | HTTP      | per-request `Authorization: Bearer <token>`    | The caller sets the header; the server forwards it to Google verbatim.                          |
-| Service account + DWD      | stdio     | Service account with domain-wide delegation    | [FAQ entry on service accounts](faq.md#can-i-use-a-service-account-instead-of-user-credentials) |
+1. **Inbound bearer token.** If the HTTP request carries an `Authorization: Bearer <token>` header, the server forwards that token to Google verbatim.
+
+2. **Service-account key.** Otherwise, if `GOOGLE_APPLICATION_CREDENTIALS` is set, the server reads the service-account JSON key file and signs requests with a JWT. Set `CEP_IMPERSONATE_SUBJECT` to a user email to enable domain-wide delegation.
+
+3. **Cached OAuth token.** Otherwise, the server reads the access token that `mcp auth login` cached at `~/.config/cep-mcp/tokens.json`.
+
+Most workstation users want the OAuth flow. Most hosted deployments (Cloud Run, Vertex AI Agent Engine) want bearer pass-through. Service accounts cover the cases where neither fits.
+
+If you're not sure which path applies to you, the [Which auth path should I use?](faq.md#which-auth-path-should-i-use) FAQ entry walks through the common deployment shapes.
+
+| Setup                          | Transport | Credential source                           | Setup walkthrough                                                                               |
+| :----------------------------- | :-------- | :------------------------------------------ | :---------------------------------------------------------------------------------------------- |
+| `mcp auth login` (recommended) | stdio     | OAuth token cache                           | [`auth-bring-your-own-oauth-client.md`](auth-bring-your-own-oauth-client.md)                    |
+| Bearer pass-through            | HTTP      | per-request `Authorization: Bearer <token>` | The caller sets the header; the server forwards it to Google verbatim.                          |
+| Service account + DWD          | stdio     | Service account with domain-wide delegation | [FAQ entry on service accounts](faq.md#can-i-use-a-service-account-instead-of-user-credentials) |
 
 > [!IMPORTANT]
 > The HTTP-mode default has no network-layer authentication. Bind the listener to a trusted interface only, or set `CEP_BEARER_AUDIENCE` (HTTP mode only) for per-request ID-token verification.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -28,19 +28,22 @@ Chrome Enterprise Premium is a paid add-on available with any Google Workspace e
 
 The right path depends on your environment.
 
-- **Workstation, gcloud installed, you are a Google Cloud admin for the project:** Application Default Credentials. Run `gcloud auth application-default login` per the [Quick Start](../README.md#1-authenticate-with-google-cloud).
-- **Workstation, no gcloud or you are not a Google Cloud admin:** OAuth login. Run `mcp auth login`. For the setup walkthrough, see [`auth-bring-your-own-oauth-client.md`](auth-bring-your-own-oauth-client.md).
-- **Hosted on Cloud Run, Vertex AI Agent Engine, or a similar managed environment:** OAuth bearer per request. The caller sets `Authorization: Bearer <id-token>` and the server verifies the token's `aud` claim against `CEP_BEARER_AUDIENCE`. A service account with domain-wide delegation is the alternative. OAuth is preferred for hosted deployments because a service account with domain-wide delegation grants the server impersonation rights for any user in the domain.
+- **Workstation (default):** Run `mcp auth login`. To use your own OAuth client instead of the bundled Google-managed one, see [`auth-bring-your-own-oauth-client.md`](auth-bring-your-own-oauth-client.md).
+- **Hosted on Cloud Run, Vertex AI Agent Engine, or a similar managed environment:** OAuth bearer per request. The caller sets `Authorization: Bearer <id-token>`, and the server verifies the token's `aud` claim against `CEP_BEARER_AUDIENCE`.
+
+  A service account with domain-wide delegation is the alternative: set `GOOGLE_APPLICATION_CREDENTIALS` to the key file path, and set `CEP_IMPERSONATE_SUBJECT` to the user the SA should act as.
+
+  OAuth is preferred for hosted deployments because domain-wide delegation grants the server impersonation rights for every user in the domain, which is a much wider trust grant than per-user OAuth.
 
 For the per-mechanism technical reference (transport, credential source, setup walkthrough), see the [authentication matrix](configuration.md#authenticate-to-google-apis) in `configuration.md`.
 
 ## Can I use a service account instead of user credentials?
 
-Yes. The service account must have [domain-wide delegation](https://developers.google.com/identity/protocols/oauth2/service-account#delegatingauthority) configured in the Admin Console with the required scopes. Set `GOOGLE_APPLICATION_CREDENTIALS` to the path of the service account key file.
+Yes. The service account must have [domain-wide delegation](https://developers.google.com/identity/protocols/oauth2/service-account#delegatingauthority) configured in the Admin Console with the required scopes. Set `GOOGLE_APPLICATION_CREDENTIALS` to the path of the service account key file, and set `CEP_IMPERSONATE_SUBJECT` to the email of the user the service account should act as.
 
 ## Why do I see "Retrying in 15s..." on the first call?
 
-Newly enabled APIs take a few minutes to propagate. The server retries `PERMISSION_DENIED` (gRPC code 7) up to seven times automatically; the first retry waits 15 seconds. The behavior is normal on first run and resolves within a minute or two.
+Newly enabled APIs take a few minutes to propagate. The server retries `PERMISSION_DENIED` (gRPC code 7) up to seven times automatically, with a 15-second initial delay. The behavior is normal on first run and resolves within a minute or two.
 
 ## How do I enable experimental features?
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -18,56 +18,46 @@ limitations under the License.
 
 ## Authentication
 
-### "Could not load the default credentials"
+### "No cached OAuth credentials" or "No Google credentials configured"
 
-Your Application Default Credentials are not configured. Run the login command from the [Quick Start](../README.md#1-authenticate-with-google-cloud), then verify the credentials file exists:
+You haven't authorized the server yet. Run `mcp auth login`; a consent page opens in your browser, and on approval the access token is written to `~/.config/cep-mcp/tokens.json`.
 
-```bash
-cat ~/.config/gcloud/application_default_credentials.json
-```
-
-If the file does not exist, the login did not complete; check whether your browser opened a consent tab that you missed.
+If the file does not exist after the login flow, the consent didn't complete; check whether your browser opened a consent tab you missed.
 
 ### "Request had insufficient authentication scopes"
 
-The credentials lack the required scopes. The most common cause is running `gcloud auth application-default login` without the `--scopes` flag; the default scope (`cloud-platform`) does not cover Workspace APIs such as the Admin SDK or Chrome Management. You cannot add scopes to existing ADC credentials, so delete and re-create them:
+The cached OAuth token does not cover one or more required scopes. Re-run `mcp auth login` to re-consent with the full scope set.
+
+Scopes can't be added to an existing token; the cache is replaced on every login.
+
+### "API has not been used in project … before or it is disabled"
+
+A required API is not enabled in the Google Cloud project that owns your OAuth client.
+
+If you're using the bundled Google-managed OAuth client, you should never see this error.
+
+If you're using a [BYO OAuth client](auth-bring-your-own-oauth-client.md), the project where you created the client must enable the same APIs the server uses. The fastest path is to call the `check_and_enable_cep_api` tool against your project, or run:
 
 ```bash
-rm ~/.config/gcloud/application_default_credentials.json
+gcloud services enable admin.googleapis.com chromemanagement.googleapis.com chromepolicy.googleapis.com cloudidentity.googleapis.com licensing.googleapis.com serviceusage.googleapis.com --project=YOUR_PROJECT_ID
 ```
-
-Then re-run the full login command from the [Quick Start](../README.md#1-authenticate-with-google-cloud).
-
-### "API requires a quota project, which is not set by default"
-
-Google needs to know which project's API quotas and enablement to use. The error appears on the first API call, not at login:
-
-```bash
-gcloud auth application-default set-quota-project YOUR_PROJECT_ID
-```
-
-Replace `YOUR_PROJECT_ID` with your Google Cloud project ID. If you do not know which project to use, run `gcloud projects list` and pick the one linked to your Workspace domain.
 
 ### "invalid_grant" or "Token has been revoked"
 
-Cached credentials are stale. Common causes are a password change, an admin revoking access, MFA re-enrollment, or the token expiring after seven days of inactivity. Delete `~/.config/gcloud/application_default_credentials.json` and re-authenticate.
+Cached credentials are stale. Common causes are a password change, an admin revoking access, MFA re-enrollment, or the access token expiring. Delete `~/.config/cep-mcp/tokens.json` and re-run `mcp auth login`.
 
 ### Configure OAuth app for sensitive scopes
 
 This step is required because Chrome Enterprise Premium requests access to
-sensitive scopes, so the gcloud OAuth app needs to be explicitly
+sensitive scopes, so the OAuth app the server uses must be explicitly
 allow-listed.
 
-1.  Go to [App Access Control](https://admin.google.com/ac/owl/list?tab=configuredApps) in the Admin Console. Check that you are logged in with the right account via upper-right account icon.
+1.  Go to [App Access Control](https://admin.google.com/ac/owl/list?tab=configuredApps) in the Admin Console. Check that you are logged in with the right account via the upper-right account icon.
 2.  Click **Configure new app** and select **OAuth App Name Or Client ID**.
-3.  Search for the OAuth app ID: `764086051850-6qr4p6gpi6hn506pt8ejuq83di341hur.apps.googleusercontent.com`.
-4.  Select the **Google Cloud SDK** app from the results.
+3.  Search for the OAuth client ID. For the Google-managed bundled client, look up the value the CLI prints in its banner under "API credentials"; for [BYO clients](auth-bring-your-own-oauth-client.md) use your own client ID.
+4.  Select the matching app from the results.
 5.  Check the box for the **OAuth Client ID** and click **Select**.
 6.  Select **Trusted: Can access all Google services** for Access to Google Data and click **Configure**.
-
-### `gcloud` is installed but `gcloud auth` fails with "command not found"
-
-Your shell can find a `gcloud` binary but the auth subcommand does not run as expected. Check that `which gcloud` points at the binary you intend, and confirm with `gcloud version` that the install is recent. If the install looks broken, reinstall the Cloud SDK from the [official installer](https://docs.cloud.google.com/sdk/docs/install).
 
 ## Permissions
 
@@ -95,7 +85,9 @@ These warnings are harmless. Some Node.js features used by dependencies emit war
 
 ### Wrong Node version
 
-The server requires Node 18 or later. Check with `node --version`. If you use [nvm](https://github.com/nvm-sh/nvm), run `nvm use 18` (or later) in the project directory. MCP clients launch `node` as a subprocess and use whatever `node` is on the system PATH, which can differ from the version your shell's `nvm` selects.
+The server requires Node 18 or later. Check with `node --version`. If you use [nvm](https://github.com/nvm-sh/nvm), run `nvm use 18` (or later) in the project directory.
+
+When an MCP client spawns `node`, it picks up whatever is on the system PATH, which can differ from the version your shell's `nvm` selects.
 
 ## MCP client integration
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -36,7 +36,7 @@ A required API is not enabled in the Google Cloud project that owns your OAuth c
 
 If you're using the bundled Google-managed OAuth client, you should never see this error.
 
-If you're using a [BYO OAuth client](auth-bring-your-own-oauth-client.md), the project where you created the client must enable the same APIs the server uses. The fastest path is to call the `check_and_enable_cep_api` tool against your project, or run:
+If you're using [your own OAuth client](auth-bring-your-own-oauth-client.md), the project where you created the client must enable the same APIs the server uses. The fastest path is to call the `check_and_enable_cep_api` tool against your project, or run:
 
 ```bash
 gcloud services enable admin.googleapis.com chromemanagement.googleapis.com chromepolicy.googleapis.com cloudidentity.googleapis.com licensing.googleapis.com serviceusage.googleapis.com --project=YOUR_PROJECT_ID
@@ -54,7 +54,7 @@ allow-listed.
 
 1.  Go to [App Access Control](https://admin.google.com/ac/owl/list?tab=configuredApps) in the Admin Console. Check that you are logged in with the right account via the upper-right account icon.
 2.  Click **Configure new app** and select **OAuth App Name Or Client ID**.
-3.  Search for the OAuth client ID. For the Google-managed bundled client, look up the value the CLI prints in its banner under "API credentials"; for [BYO clients](auth-bring-your-own-oauth-client.md) use your own client ID.
+3.  Search for the OAuth client ID. For the Google-managed bundled client, look up the value the CLI prints in its banner under "API credentials"; for a [custom OAuth client](auth-bring-your-own-oauth-client.md), use your own client ID.
 4.  Select the matching app from the results.
 5.  Check the box for the **OAuth Client ID** and click **Select**.
 6.  Select **Trusted: Can access all Google services** for Access to Google Data and click **Configure**.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -36,10 +36,10 @@ A required API is not enabled in the Google Cloud project that owns your OAuth c
 
 If you're using the bundled Google-managed OAuth client, you should never see this error.
 
-If you're using [your own OAuth client](auth-bring-your-own-oauth-client.md), the project where you created the client must enable the same APIs the server uses. The fastest path is to call the `check_and_enable_cep_api` tool against your project, or run:
+If you're using [your own OAuth client](auth-bring-your-own-oauth-client.md), the project where you created the client must enable the same APIs the server uses — see [Enable required APIs](auth-bring-your-own-oauth-client.md#enable-required-apis) for the full list and the gcloud command. The fastest in-session fix is to call the `check_and_enable_cep_api` tool against your project, or run:
 
 ```bash
-gcloud services enable admin.googleapis.com chromemanagement.googleapis.com chromepolicy.googleapis.com cloudidentity.googleapis.com licensing.googleapis.com serviceusage.googleapis.com --project=YOUR_PROJECT_ID
+gcloud services enable admin.googleapis.com chromemanagement.googleapis.com chromepolicy.googleapis.com cloudidentity.googleapis.com licensing.googleapis.com serviceusage.googleapis.com servicemanagement.googleapis.com --project=YOUR_PROJECT_ID
 ```
 
 ### "invalid_grant" or "Token has been revoked"

--- a/gemini-extension/README.md
+++ b/gemini-extension/README.md
@@ -32,9 +32,8 @@ The extension manifest at the repo root
 ([`gemini-extension.json`](../gemini-extension.json)) points at it and
 tells Gemini CLI to launch `mcp-server.js` as the MCP backend.
 
-`lib/constants.js` defines two OAuth scope sets:
-
-- **`SCOPES`:** every scope the server uses via ADC, including
-  `cloud-platform`.
-- **`OAUTH_SCOPES`:** `SCOPES` minus `cloud-platform`. The OAuth-flow
-  login uses this on the consent screen.
+> **`oauth_scopes` is install-time only.** The list lives in the
+> manifest so the Gemini CLI extension installer has the right consent
+> screen during `gemini extension install`. The server's runtime scope
+> set lives separately in `lib/constants.js#SCOPES`. Keep the two lists
+> in sync — they must enumerate the same scopes for the same APIs.

--- a/gemini-extension/README.md
+++ b/gemini-extension/README.md
@@ -32,8 +32,8 @@ The extension manifest at the repo root
 ([`gemini-extension.json`](../gemini-extension.json)) points at it and
 tells Gemini CLI to launch `mcp-server.js` as the MCP backend.
 
-> **`oauth_scopes` is install-time only.** The list lives in the
-> manifest so the Gemini CLI extension installer has the right consent
-> screen during `gemini extension install`. The server's runtime scope
-> set lives separately in `lib/constants.js#SCOPES`. Keep the two lists
-> in sync — they must enumerate the same scopes for the same APIs.
+> **`oauth_scopes` is install-time only:**
+>
+> - The list in this manifest drives the consent screen the Gemini CLI extension installer shows during `gemini extension install`.
+> - The server's runtime scope set lives separately in `lib/constants.js#SCOPES`.
+> - Keep the two lists in sync. They must enumerate the same scopes for the same APIs; updating one without the other is a foot-gun.

--- a/gemini-extension/README.md
+++ b/gemini-extension/README.md
@@ -36,4 +36,4 @@ tells Gemini CLI to launch `mcp-server.js` as the MCP backend.
 >
 > - The list in this manifest drives the consent screen the Gemini CLI extension installer shows during `gemini extension install`.
 > - The server's runtime scope set lives separately in `lib/constants.js#SCOPES`.
-> - Keep the two lists in sync. They must enumerate the same scopes for the same APIs; updating one without the other is a foot-gun.
+> - Keep the two lists in sync. If they diverge, the install-time consent screen asks for different scopes than the runtime token request, and sign-in fails.

--- a/lib/util/README.md
+++ b/lib/util/README.md
@@ -46,8 +46,7 @@ logging, retry, GCP detection, CEL validation, and feature flags.
 
 - `oauth_flow.js`: `oauthFlowCredential()`. Managed-OAuth login flow
   through `runLoginFlow()` (loopback callback or headless paste-back) and
-  a probe over the cached token. Default scopes: `OAUTH_SCOPES` (no
-  `cloud-platform`).
+  a probe over the cached token. Default scopes: `Object.values(SCOPES)`.
 
 - `token_cache.js`: `TokenCache`. Read-write access on a path-injected
   file with mode 0600. Refresh tokens are stripped.
@@ -59,7 +58,7 @@ logging, retry, GCP detection, CEL validation, and feature flags.
   bundled placeholder, BYO env vars, or future custom modes).
 
 - `cli_commands.js`: `runAuthStatusCommand` and `runLoginCommand` for
-  the `mcp auth-status` and `mcp auth login` CLI subcommands.
+  the `mcp auth status` and `mcp auth login` CLI subcommands.
 
 - `jwt_verifier.js`: `verifyIdToken` plus `parseExpectedAudience`. Used
   by `mcp-server.js` middleware in HTTP mode when `CEP_BEARER_AUDIENCE`


### PR DESCRIPTION
## Summary

User-facing docs sweep for OAuth-only auth. Touches README, troubleshooting, FAQ, configuration, the custom-OAuth-client guide, the Cloud Run / Gemini Enterprise guide, and architecture.md.

## Changes

- **README** — sign-in section leads with the bundled-managed default. Step 2 ("Enable required APIs") is conditional on having a custom OAuth client or a service account. Scope table no longer lists `cloud-platform`. Prerequisites table no longer lists `gcloud`.
- **Troubleshooting** — ADC entries removed (`Could not load default credentials`, gcloud insufficient scopes, gcloud quota project, gcloud not found). New `SERVICE_DISABLED` entry covers the 403 a custom-OAuth-client user hits when their Cloud project hasn't enabled the required APIs.
- **FAQ** — gcloud / ADC row removed from the auth-path matrix. SA-DWD entry now mentions `CEP_IMPERSONATE_SUBJECT`.
- **Configuration** — credential resolution rendered as a numbered three-step list (bearer → SA-JWT → cached OAuth). New plain-English subsections for `CEP_BEARER_AUDIENCE` and `CEP_BEARER_PRINCIPAL_SUB`, including how to find the right `sub` value from a debug-log line.
- **Custom OAuth client guide** — terminology updated to "your own OAuth client" / "custom OAuth client" throughout. New note explains the Desktop OAuth client `client_secret` is a public value per Google's installed-app spec.
- **Cloud Run / Gemini Enterprise guide** — inbound bearer-verification description rewritten. Scope-list reference points at `lib/constants.js#SCOPES` (no longer at the deleted `OAUTH_SCOPES`).
- **architecture.md** — test-backend description updated for OAuth-only.

`GOOGLE_CLOUD_QUOTA_PROJECT` and the ADC env vars are removed from docs.

## Test plan

- [x] `npm run lint`
- [x] `npm test`
- [x] Manual review of rendered Markdown.

## Stack

Last of five PRs splitting #163. Stacks on #171. Tracked in #167.
