### PR TITLE
feat(local): always register diagnose_environment

### DIFF
--- a/test/local/tool-registration.test.js
+++ b/test/local/tool-registration.test.js
@@ -34,6 +34,7 @@ const CORE_TOOLS = [
   'create_regex_detector',
   'create_url_list_detector',
   'create_word_list_detector',
+  'diagnose_environment',
   'enable_chrome_enterprise_connectors',
   'get_chrome_activity_log',
   'get_connector_policy',
@@ -48,8 +49,6 @@ const CORE_TOOLS = [
 ]
 
 const DELETE_EXPERIMENT_TOOLS = ['delete_agent_dlp_rule', 'delete_detector']
-
-const DIAGNOSE_EXPERIMENT_TOOLS = ['diagnose_environment']
 
 const KNOWLEDGE_SEARCH_EXPERIMENT_TOOLS = ['search_content', 'list_documents']
 
@@ -92,18 +91,6 @@ describe('SEB Tool Registration', () => {
 
     const registeredToolNames = server.registerTool.mock.calls.map(call => call.arguments[0])
     const expected = [...CORE_TOOLS, ...DELETE_EXPERIMENT_TOOLS].sort()
-    assert.deepStrictEqual(registeredToolNames.sort(), expected)
-  })
-
-  test('When registerTools is called with DIAGNOSE_TOOL_ENABLED, then it registers core + diagnose tools', () => {
-    registerTools(server, {
-      featureFlags: {
-        isEnabled: flag => flag === FLAGS.DIAGNOSE_TOOL_ENABLED,
-      },
-    })
-
-    const registeredToolNames = server.registerTool.mock.calls.map(call => call.arguments[0])
-    const expected = [...CORE_TOOLS, ...DIAGNOSE_EXPERIMENT_TOOLS].sort()
     assert.deepStrictEqual(registeredToolNames.sort(), expected)
   })
 

--- a/tools/index.js
+++ b/tools/index.js
@@ -102,15 +102,10 @@ export function registerTools(server, options = {}, sessionState) {
     registerCheckAndEnableCepApiTool(server, { ...commonOpts, serviceUsageClient }, state)
   }
   registerEnableChromeEnterpriseConnectorsTool(server, { ...commonOpts, chromePolicyClient }, state)
-
-  if (flags.isEnabled(FLAGS.DIAGNOSE_TOOL_ENABLED)) {
-    logger.debug(`${TAGS.MCP} Registering diagnose tool (EXPERIMENT_DIAGNOSE_TOOL_ENABLED is active)`)
-    registerDiagnoseEnvironmentTool(
-      server,
-      { ...commonOpts, chromeManagementClient, chromePolicyClient, cloudIdentityClient },
-      state,
-    )
-  }
-
+  registerDiagnoseEnvironmentTool(
+    server,
+    { ...commonOpts, chromeManagementClient, chromePolicyClient, cloudIdentityClient },
+    state,
+  )
   registerKnowledgeTools(server, { ...options, featureFlags: flags }, state)
 }


### PR DESCRIPTION
## Summary

Promote `diagnose_environment` from `FLAGS.DIAGNOSE_TOOL_ENABLED`-gated to always-on.

The tool is read-only and inexpensive to register; gating it behind an experiment forced agents to fail before they could diagnose the failure. Always-on registration removes that catch-22.

The `FLAGS.DIAGNOSE_TOOL_ENABLED` enum entry stays defined so deployments that already set `EXPERIMENT_DIAGNOSE_TOOL_ENABLED` in env do not break.

## Changes

- `tools/index.js`: removes the `if (flags.isEnabled(FLAGS.DIAGNOSE_TOOL_ENABLED))` gate around `registerDiagnoseEnvironmentTool`.
- `test/local/tool-registration.test.js`: moves `diagnose_environment` from the `DIAGNOSE_EXPERIMENT_TOOLS` list into `CORE_TOOLS`; drops the now-redundant `DIAGNOSE_TOOL_ENABLED` registration test.

## Test plan

- [x] `npm run lint`
- [x] `npm test`

## Stack

Split out of #172 (PR-C of the #163 series). Stacks on #172. Tracked in #167.
