### PR TITLE
feat(scripts): add npm run auth:login and auth:status

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,8 @@ npm install
 
 ```bash
 npm start             # Stdio mode (default)
+npm run auth:login    # Run the OAuth flow against the bundled or custom client
+npm run auth:status   # Show OAuth credential status
 npm run mcp-inspector # MCP Inspector (browser-based debugging UI)
 ```
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "prompts/"
   ],
   "scripts": {
+    "auth:login": "node bin/cli.js auth login",
+    "auth:status": "node bin/cli.js auth status",
     "eval": "CEP_BACKEND=fake node test/evals/run.js",
     "eval:agentic": "CEP_BACKEND=fake node test/evals/run.js --category inspection,troubleshooting,mutation,discovery,connectors",
     "eval:boundary": "CEP_BACKEND=fake node test/evals/run.js --category boundary",


### PR DESCRIPTION
## Summary

Adds `npm run auth:login` and `npm run auth:status` so contributors working from a local checkout can drive the OAuth CLI without typing `node bin/cli.js auth ...`.

## Changes

- `package.json`: two new scripts.
- `CONTRIBUTING.md`: lists them in the "Running locally" block.

## Test plan

- [x] `npm run auth:status` prints the credential probe output.
- [x] `npm run lint`
- [x] `npm test`

## Stack

Stacks on #173 (last in the #163 split). Tracked in #167.
