### PR TITLE
test(evals): add scenarios and system evals for API remediation

### DIFF
--- a/test/evals/cases/system/api-remediation-core.md
+++ b/test/evals/cases/system/api-remediation-core.md
@@ -17,7 +17,7 @@ Check the Google Cloud APIs for my project my-test-project.
 
 ## Golden Response
 
-Agent should run `check_and_enable_cep_api` (without `enable: true` since the user hasn't authorized it yet). It should identify that `chromemanagement.googleapis.com` and `chromepolicy.googleapis.com` are disabled (while others like `admin.googleapis.com` and `serviceusage.googleapis.com` are enabled).
+Agent should run `check_and_enable_cep_api` (without `enable: true` since the user hasn't authorized it yet). It should identify that `chromemanagement.googleapis.com` and `chromepolicy.googleapis.com` are disabled (while others like `admin.googleapis.com` and `serviceusage.googleapis.com` are enabled) for project `my-test-project`.
 It must ask the user if they would like the agent to automatically enable these two missing APIs for them.
 
 ## Judge Instructions

--- a/test/evals/cases/system/api-remediation-core.md
+++ b/test/evals/cases/system/api-remediation-core.md
@@ -1,0 +1,27 @@
+---
+id: s04
+category: system
+tags: [api, remediation, core]
+priority: P1
+expected_tools: [check_and_enable_cep_api]
+scenario: some-cep-apis-disabled
+required_patterns:
+  - "chromemanagement.googleapis.com"
+  - "chromepolicy.googleapis.com"
+  - "my-test-project"
+---
+
+## Prompt
+
+Check the Google Cloud APIs for my project my-test-project.
+
+## Golden Response
+
+Agent should run `check_and_enable_cep_api` (without `enable: true` since the user hasn't authorized it yet). It should identify that `chromemanagement.googleapis.com` and `chromepolicy.googleapis.com` are disabled (while others like `admin.googleapis.com` and `serviceusage.googleapis.com` are enabled).
+It must ask the user if they would like the agent to automatically enable these two missing APIs for them.
+
+## Judge Instructions
+
+Verify that the agent:
+- Identifies that `chromemanagement.googleapis.com` and `chromepolicy.googleapis.com` are disabled.
+- Explicitly asks the user if they would like the agent to automatically enable these APIs.

--- a/test/evals/cases/system/api-remediation-prereq.md
+++ b/test/evals/cases/system/api-remediation-prereq.md
@@ -1,0 +1,26 @@
+---
+id: s05
+category: system
+tags: [api, remediation, prereq]
+priority: P1
+expected_tools: [check_and_enable_cep_api]
+scenario: service-usage-disabled
+required_patterns:
+  - "Service Usage API"
+  - "https://console.cloud.google.com/apis/library/serviceusage.googleapis.com"
+  - "project=my-test-project"
+---
+
+## Prompt
+
+Check my Google Cloud APIs for project my-test-project.
+
+## Golden Response
+
+Agent should attempt to call `check_and_enable_cep_api`. It should detect a Service Usage API failure and recognize that `serviceusage.googleapis.com` itself is disabled on the project. Since this prerequisite API cannot be automatically enabled, it must provide the exact Cloud Console link:
+`https://console.cloud.google.com/apis/library/serviceusage.googleapis.com?project=my-test-project`
+and clearly instruct the user to manually enable it in the browser.
+
+## Judge Instructions
+
+Verify that the agent identifies that the prerequisite Service Usage API is disabled. The agent must guide the user to enable it manually and provide the console link including the correct project ID `my-test-project`.

--- a/test/evals/run.js
+++ b/test/evals/run.js
@@ -218,6 +218,7 @@ async function main() {
 
     try {
       harness = await createIntegrationHarness({
+        backend,
         featureFlags: caseFeatureFlags,
         ...(localFakeServer ? { rootUrl: localFakeServer.url } : {}),
       })

--- a/test/evals/scenarios/service-usage-disabled.js
+++ b/test/evals/scenarios/service-usage-disabled.js
@@ -1,0 +1,25 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @fileoverview Scenario: Service Usage API itself is disabled.
+ */
+
+/** @param {object} state - Cloned base state. */
+export function mutate(state) {
+  state.serviceUsage['serviceusage.googleapis.com'] = 'DISABLED'
+  return state
+}

--- a/test/evals/scenarios/some-cep-apis-disabled.js
+++ b/test/evals/scenarios/some-cep-apis-disabled.js
@@ -1,0 +1,34 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @fileoverview Scenario: Some core CEP APIs are disabled (while others are enabled).
+ */
+
+/** @param {object} state - Cloned base state. */
+export function mutate(state) {
+  // Disabled APIs
+  state.serviceUsage['chromemanagement.googleapis.com'] = 'DISABLED'
+  state.serviceUsage['chromepolicy.googleapis.com'] = 'DISABLED'
+
+  // Explicitly Enabled APIs
+  state.serviceUsage['admin.googleapis.com'] = 'ENABLED'
+  state.serviceUsage['cloudidentity.googleapis.com'] = 'ENABLED'
+  state.serviceUsage['licensing.googleapis.com'] = 'ENABLED'
+  state.serviceUsage['serviceusage.googleapis.com'] = 'ENABLED'
+
+  return state
+}

--- a/test/helpers/fake-api-server.js
+++ b/test/helpers/fake-api-server.js
@@ -618,6 +618,15 @@ export function createFakeApp() {
 
   // Service Usage: Get Service
   app.get('/v1/projects/:projectId/services/:serviceName', (req, res) => {
+    if (state.serviceUsage['serviceusage.googleapis.com'] === 'DISABLED') {
+      return res.status(403).json({
+        error: {
+          code: 403,
+          message: `Service Usage API has not been used in project [${req.params.projectId}] before or it is disabled. Enable it by visiting https://console.cloud.google.com/apis/library/serviceusage.googleapis.com?project=${req.params.projectId} then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.`,
+          status: 'PERMISSION_DENIED',
+        },
+      })
+    }
     const stateVal = state.serviceUsage[req.params.serviceName] || 'DISABLED'
     res.json({
       name: `projects/${req.params.projectId}/services/${req.params.serviceName}`,
@@ -627,6 +636,15 @@ export function createFakeApp() {
 
   // Service Usage: Enable Service
   app.post('/v1/projects/:projectId/services/:serviceName\\:enable', (req, res) => {
+    if (state.serviceUsage['serviceusage.googleapis.com'] === 'DISABLED') {
+      return res.status(403).json({
+        error: {
+          code: 403,
+          message: `Service Usage API has not been used in project [${req.params.projectId}] before or it is disabled. Enable it by visiting https://console.cloud.google.com/apis/library/serviceusage.googleapis.com?project=${req.params.projectId} then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.`,
+          status: 'PERMISSION_DENIED',
+        },
+      })
+    }
     state.serviceUsage[req.params.serviceName] = 'ENABLED'
     res.json({
       done: true,


### PR DESCRIPTION
## Description
This PR adds comprehensive evaluation cases and scenarios to verify the agent's behavior when required Google Cloud APIs are disabled, alongside a critical fix for the integration harness.

## Proposed Changes
- **Integration Harness Fix**: Modified `test/evals/run.js` to pass `backend: 'fake'` explicitly to `createIntegrationHarness()`, preventing tests from falling back to real GCP APIs.
- **Service Usage Disabled Error**: Updated `/v1/projects/:projectId/services/:serviceName` endpoints in `test/helpers/fake-api-server.js` to realistically throw a 403 error when `serviceusage.googleapis.com` is disabled.
- **Eval Scenarios & Cases**:
  - Added `service-usage-disabled` scenario and case `s05` to test manual console link and remediation when prerequisite API is disabled.
  - Added `some-cep-apis-disabled` scenario and case `s04` to test automated enablement when core APIs are disabled.

