### PR TITLE
feat: support retrieving all chrome connector policies in one call

### DIFF
--- a/test/evals/cases/connectors/c13-all_connectors_summary.eval.js
+++ b/test/evals/cases/connectors/c13-all_connectors_summary.eval.js
@@ -1,0 +1,28 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export default {
+  id: 'c13',
+  priority: 'P1',
+  tags: ['connectors'],
+  scenario: 'healthy',
+  expectedTools: ['get_connector_policy'],
+  prompt: 'Show me a summary of all Chrome Enterprise connector policies at once for the Root OU.',
+  goldenResponse:
+    'A structured summary of all Chrome Enterprise connector policies for the Root OU containing File Upload, File Download, Bulk Text Entry, Print Analysis, Real-time URL Check, and Event Reporting connectors, indicating they are all Configured.',
+  judgeInstructions:
+    'Pass if the agent retrieves all 6 connector policies using get_connector_policy with policy "ALL" (or by default) and lists or summarizes their status correctly.',
+}

--- a/test/evals/cases/connectors/c14-all_connectors_default.eval.js
+++ b/test/evals/cases/connectors/c14-all_connectors_default.eval.js
@@ -1,0 +1,39 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/ /*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+/usr/local/google/home/tushardey/chrome-enterprise-premium-mcp/test/evals/cases/connectors/c14-all_connectors_default.eval.js
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export default {
+  id: 'c14',
+  priority: 'P1',
+  tags: ['connectors'],
+  scenario: 'healthy',
+  expectedTools: ['get_connector_policy'],
+  prompt: 'Get the connector policies for the Root OU without specifying a particular connector type.',
+  goldenResponse:
+    'Since no specific connector type was requested, all Chrome Enterprise connector policies (File Upload, File Download, Bulk Text Entry, Print Analysis, Real-time URL Check, and Event Reporting) are retrieved and summarized as Configured.',
+  judgeInstructions:
+    'Pass if the agent retrieves all connector policies when no specific policy/connector type is requested by defaulting to ALL.',
+}

--- a/test/evals/cases/connectors/c14-all_connectors_default.eval.js
+++ b/test/evals/cases/connectors/c14-all_connectors_default.eval.js
@@ -12,17 +12,6 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-*/ /*
-Copyright 2026 Google LLC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-/usr/local/google/home/tushardey/chrome-enterprise-premium-mcp/test/evals/cases/connectors/c14-all_connectors_default.eval.js
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
 */
 
 export default {

--- a/test/local/get_connector_policy.test.js
+++ b/test/local/get_connector_policy.test.js
@@ -499,5 +499,221 @@ describe('get_connector_policy Tool', () => {
       assert.strictEqual(policies[0]["serviceProvider (describe to user as 'Provider')"], 'Chrome Enterprise Premium')
       assert.strictEqual(policies[0]["delayDeliveryUntilVerdict (describe to user as 'Delay Enforcement')"], 'Yes')
     })
+
+    test('When policy is ALL, then it fetches all connector policies in parallel and returns aggregated results', async () => {
+      // Return mock data for each of the 6 connector types
+      const mockGetConnectorPolicy = mock.fn(async (customerId, orgUnitId, policySchemaFilter) => {
+        if (policySchemaFilter === 'chrome.users.OnFileAttachedConnectorPolicy') {
+          return [
+            {
+              value: {
+                value: {
+                  serviceProvider: 'SERVICE_PROVIDER_CHROME_ENTERPRISE_PREMIUM',
+                  delayDeliveryUntilVerdict: true,
+                },
+              },
+            },
+          ]
+        }
+        if (policySchemaFilter === 'chrome.users.OnFileDownloadedConnectorPolicy') {
+          return [
+            {
+              value: {
+                value: {
+                  serviceProvider: 'SERVICE_PROVIDER_CHROME_ENTERPRISE_PREMIUM',
+                  delayDeliveryUntilVerdict: true,
+                },
+              },
+            },
+          ]
+        }
+        if (policySchemaFilter === 'chrome.users.OnBulkTextEntryConnectorPolicy') {
+          return [
+            {
+              value: {
+                value: {
+                  serviceProvider: 'SERVICE_PROVIDER_CHROME_ENTERPRISE_PREMIUM',
+                  minimumDataLength: 100,
+                },
+              },
+            },
+          ]
+        }
+        if (policySchemaFilter === 'chrome.users.OnPrintAnalysisConnectorPolicy') {
+          return [
+            {
+              value: {
+                value: {
+                  onPrintAnalysisConnectorConfiguration: {
+                    printConfigurations: [
+                      {
+                        serviceProvider: 'SERVICE_PROVIDER_CHROME_ENTERPRISE_PREMIUM',
+                        delayDeliveryUntilVerdict: true,
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          ]
+        }
+        if (policySchemaFilter === 'chrome.users.RealtimeUrlCheck') {
+          return [
+            {
+              value: {
+                value: {
+                  realtimeUrlCheckEnabled: 'ENTERPRISE_REAL_TIME_URL_CHECK_MODE_ENUM_ENABLED',
+                },
+              },
+            },
+          ]
+        }
+        if (policySchemaFilter === 'chrome.users.OnSecurityEvent') {
+          return [
+            {
+              value: {
+                value: {
+                  reportingConnector: {
+                    serviceProvider: 'SERVICE_PROVIDER_CHROME_ENTERPRISE_PREMIUM',
+                    eventConfiguration: {
+                      enabledEventNames: [
+                        'contentTransferEvent',
+                        'unscannedFileEvent',
+                        'dangerousDownloadEvent',
+                        'sensitiveDataEvent',
+                        'interstitialEvent',
+                        'urlFilteringInterstitialEvent',
+                        'suspiciousUrlEvent',
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          ]
+        }
+        return []
+      })
+
+      const chromePolicyClient = { getConnectorPolicy: mockGetConnectorPolicy }
+      registerGetConnectorPolicyTool(server, { chromePolicyClient }, {})
+      const handler = server.registerTool.mock.calls.find(call => call.arguments[0] === 'get_connector_policy')
+        .arguments[2]
+
+      const result = await handler({ customerId: 'C0123', orgUnitId: 'ou123', policy: 'ALL' }, { requestInfo: {} })
+
+      // Verify call counts (6 calls, one for each policy schema)
+      assert.strictEqual(mockGetConnectorPolicy.mock.callCount(), 6)
+
+      // Verify summary contains entries for all connectors and warnings
+      const text = result.content[0].text
+      assert.ok(text.includes('Chrome Enterprise Connector Policies (OU: `ou123`)'))
+      assert.ok(text.includes('Upload Content Analysis (ON_FILE_ATTACHED):** 🟢 Configured'))
+      assert.ok(text.includes('File Download Analysis (ON_FILE_DOWNLOAD):** 🟢 Configured'))
+      assert.ok(text.includes('Bulk Text Entry Analysis (paste) (ON_BULK_TEXT_ENTRY):** 🟢 Configured'))
+      assert.ok(text.includes('Print Analysis (ON_PRINT):** 🟢 Configured'))
+      assert.ok(text.includes('Real-Time URL Check (ON_REALTIME_URL_NAVIGATION):** 🟢 Configured'))
+      assert.ok(text.includes('Event Reporting (ON_SECURITY_EVENT):** 🟢 Configured'))
+
+      // Verify structured output format
+      assert.strictEqual(result.structuredContent.configured, true)
+      assert.strictEqual(result.structuredContent.connectorType, 'ALL')
+      assert.ok(Array.isArray(result.structuredContent.connectorPolicies))
+
+      // Ensure ON_FILE_ATTACHED items are annotated with connectorType
+      const fileAttachedPolicy = result.structuredContent.connectorPolicies.find(
+        p => p.connectorType === 'ON_FILE_ATTACHED',
+      )
+      assert.ok(fileAttachedPolicy)
+      assert.strictEqual(
+        fileAttachedPolicy["serviceProvider (describe to user as 'Provider')"],
+        'Chrome Enterprise Premium',
+      )
+
+      // Ensure structured mapping connectors is returned correctly
+      assert.ok(result.structuredContent.connectors)
+      assert.strictEqual(result.structuredContent.connectors.ON_FILE_ATTACHED.configured, true)
+      assert.strictEqual(result.structuredContent.connectors.ON_FILE_DOWNLOAD.configured, true)
+      assert.strictEqual(result.structuredContent.connectors.ON_BULK_TEXT_ENTRY.configured, true)
+      assert.strictEqual(result.structuredContent.connectors.ON_PRINT.configured, true)
+      assert.strictEqual(result.structuredContent.connectors.ON_REALTIME_URL_NAVIGATION.configured, true)
+      assert.strictEqual(result.structuredContent.connectors.ON_SECURITY_EVENT.configured, true)
+    })
+
+    test('When policy is ALL, then it fetches all connector policies in parallel and correctly handles 3P, CEP, warning and unconfigured states', async () => {
+      const mockGetConnectorPolicy = mock.fn(async (customerId, orgUnitId, policySchemaFilter) => {
+        // ON_FILE_ATTACHED: CEP but has a warning (delay delivery disabled)
+        if (policySchemaFilter === 'chrome.users.OnFileAttachedConnectorPolicy') {
+          return [
+            {
+              value: {
+                value: {
+                  serviceProvider: 'SERVICE_PROVIDER_CHROME_ENTERPRISE_PREMIUM',
+                  delayDeliveryUntilVerdict: false,
+                },
+              },
+            },
+          ]
+        }
+        // ON_PRINT: 3P provider (Symantec Endpoint DLP)
+        if (policySchemaFilter === 'chrome.users.OnPrintAnalysisConnectorPolicy') {
+          return [
+            {
+              value: {
+                value: {
+                  onPrintAnalysisConnectorConfiguration: {
+                    printConfigurations: [
+                      {
+                        serviceProvider: 'SERVICE_PROVIDER_SYMANTEC_ENDPOINT_DLP',
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          ]
+        }
+        return [] // others unconfigured
+      })
+
+      const chromePolicyClient = { getConnectorPolicy: mockGetConnectorPolicy }
+      registerGetConnectorPolicyTool(server, { chromePolicyClient }, {})
+      const handler = server.registerTool.mock.calls.find(call => call.arguments[0] === 'get_connector_policy')
+        .arguments[2]
+
+      const result = await handler({ customerId: 'C0123', orgUnitId: 'ou123', policy: 'ALL' }, { requestInfo: {} })
+
+      const text = result.content[0].text
+      assert.ok(text.includes('Chrome Enterprise Connector Policies (OU: `ou123`)'))
+      assert.ok(text.includes('Upload Content Analysis (ON_FILE_ATTACHED):** 🟢 Configured'))
+      assert.ok(text.includes('Print Analysis (ON_PRINT):** 🟢 Configured'))
+      assert.ok(text.includes('File Download Analysis (ON_FILE_DOWNLOAD):** ⚪ Not configured'))
+
+      // Verify warning contents
+      assert.ok(text.includes('[Upload Content Analysis] Delay enforcement is disabled'))
+      assert.ok(text.includes('[Print Analysis] 3rd party provider detected'))
+
+      // Verify structured connectors mapping
+      assert.ok(result.structuredContent.connectors)
+      assert.strictEqual(result.structuredContent.connectors.ON_FILE_ATTACHED.configured, true)
+      assert.strictEqual(result.structuredContent.connectors.ON_PRINT.configured, true)
+      assert.strictEqual(result.structuredContent.connectors.ON_FILE_DOWNLOAD.configured, false)
+    })
+
+    test('When policy is omitted, then it defaults to ALL and retrieves all connector policies', async () => {
+      const mockGetConnectorPolicy = mock.fn(async (_customerId, _orgUnitId, _policySchemaFilter) => {
+        return []
+      })
+
+      const chromePolicyClient = { getConnectorPolicy: mockGetConnectorPolicy }
+      registerGetConnectorPolicyTool(server, { chromePolicyClient }, {})
+      const handler = server.registerTool.mock.calls.find(call => call.arguments[0] === 'get_connector_policy')
+        .arguments[2]
+
+      const result = await handler({ customerId: 'C0123', orgUnitId: 'ou123' }, { requestInfo: {} })
+
+      assert.strictEqual(mockGetConnectorPolicy.mock.callCount(), 6)
+      assert.strictEqual(result.structuredContent.connectorType, 'ALL')
+    })
   })
 })

--- a/test/unit/tools/get_connector_policy.test.js
+++ b/test/unit/tools/get_connector_policy.test.js
@@ -1153,4 +1153,275 @@ describe('get_connector_policy tool handler', () => {
     assert.match(summary, /⚠️ Malware Analysis is restricted. Scanning is DISABLED for specific URL patterns/)
     assert.match(summary, /⚠️ Sensitive Analysis is restricted. Scanning is NOT enabled for all files/)
   })
+
+  test('When policy is ALL, then it retrieves all connectors and handles errors gracefully if a connector fetch fails', async () => {
+    const mockChromePolicyClient = {
+      getConnectorPolicy: async (customerId, orgUnitId, policy) => {
+        if (policy === 'chrome.users.OnFileAttachedConnectorPolicy') {
+          return [
+            {
+              value: {
+                value: {
+                  serviceProvider: 'SERVICE_PROVIDER_CHROME_ENTERPRISE_PREMIUM',
+                  delayDeliveryUntilVerdict: true,
+                },
+              },
+            },
+          ]
+        }
+        if (policy === 'chrome.users.OnSecurityEvent') {
+          throw new Error('Database network failure')
+        }
+        return []
+      },
+    }
+
+    const handler = getHandler(mockChromePolicyClient)
+
+    const result = await handler({ customerId: 'C123', orgUnitId: 'OU123', policy: 'ALL' }, { requestInfo: {} })
+
+    assert.strictEqual(result.isError, true)
+    assert.match(result.content[0].text, /Database network failure/)
+  })
+
+  test('When policy is ALL, then it retrieves all connectors and returns the unified and structured data', async () => {
+    const mockChromePolicyClient = {
+      getConnectorPolicy: async (customerId, orgUnitId, policy) => {
+        if (policy === 'chrome.users.OnFileAttachedConnectorPolicy') {
+          return [
+            {
+              value: {
+                value: {
+                  serviceProvider: 'SERVICE_PROVIDER_CHROME_ENTERPRISE_PREMIUM',
+                  delayDeliveryUntilVerdict: true,
+                },
+              },
+            },
+          ]
+        }
+        if (policy === 'chrome.users.OnFileDownloadedConnectorPolicy') {
+          return [
+            {
+              value: {
+                value: {
+                  serviceProvider: 'SERVICE_PROVIDER_CHROME_ENTERPRISE_PREMIUM',
+                  delayDeliveryUntilVerdict: true,
+                },
+              },
+            },
+          ]
+        }
+        if (policy === 'chrome.users.OnBulkTextEntryConnectorPolicy') {
+          return [
+            {
+              value: {
+                value: {
+                  serviceProvider: 'SERVICE_PROVIDER_CHROME_ENTERPRISE_PREMIUM',
+                  minimumDataLength: 100,
+                },
+              },
+            },
+          ]
+        }
+        if (policy === 'chrome.users.OnPrintAnalysisConnectorPolicy') {
+          return [
+            {
+              value: {
+                value: {
+                  onPrintAnalysisConnectorConfiguration: {
+                    printConfigurations: [
+                      {
+                        serviceProvider: 'SERVICE_PROVIDER_CHROME_ENTERPRISE_PREMIUM',
+                        delayDeliveryUntilVerdict: true,
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          ]
+        }
+        if (policy === 'chrome.users.RealtimeUrlCheck') {
+          return [
+            {
+              value: {
+                value: {
+                  realtimeUrlCheckEnabled: 'ENTERPRISE_REAL_TIME_URL_CHECK_MODE_ENUM_ENABLED',
+                },
+              },
+            },
+          ]
+        }
+        if (policy === 'chrome.users.OnSecurityEvent') {
+          return [
+            {
+              value: {
+                value: {
+                  reportingConnector: {
+                    serviceProvider: 'SERVICE_PROVIDER_CHROME_ENTERPRISE_PREMIUM',
+                    eventConfiguration: {
+                      enabledEventNames: [
+                        'contentTransferEvent',
+                        'unscannedFileEvent',
+                        'dangerousDownloadEvent',
+                        'sensitiveDataEvent',
+                        'interstitialEvent',
+                        'urlFilteringInterstitialEvent',
+                        'suspiciousUrlEvent',
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          ]
+        }
+        return []
+      },
+    }
+
+    const handler = getHandler(mockChromePolicyClient)
+
+    const result = await handler({ customerId: 'C123', orgUnitId: 'OU123', policy: 'ALL' }, { requestInfo: {} })
+
+    const summary = result.content[0].text
+
+    // Verify summary displays all connectors correctly
+    assert.match(summary, /Upload Content Analysis \(ON_FILE_ATTACHED\):\*\* 🟢 Configured/)
+    assert.match(summary, /File Download Analysis \(ON_FILE_DOWNLOAD\):\*\* 🟢 Configured/)
+    assert.match(summary, /Bulk Text Entry Analysis \(paste\) \(ON_BULK_TEXT_ENTRY\):\*\* 🟢 Configured/)
+    assert.match(summary, /Print Analysis \(ON_PRINT\):\*\* 🟢 Configured/)
+    assert.match(summary, /Real-Time URL Check \(ON_REALTIME_URL_NAVIGATION\):\*\* 🟢 Configured/)
+    assert.match(summary, /Event Reporting \(ON_SECURITY_EVENT\):\*\* 🟢 Configured/)
+
+    // Verify structured output elements
+    assert.strictEqual(result.structuredContent.configured, true)
+    assert.strictEqual(result.structuredContent.connectorType, 'ALL')
+
+    // Verify connectors object
+    assert.ok(result.structuredContent.connectors)
+    const attachment = result.structuredContent.connectors.ON_FILE_ATTACHED
+    assert.strictEqual(attachment.configured, true)
+    assert.strictEqual(
+      attachment.connectorPolicies[0]["serviceProvider (describe to user as 'Provider')"],
+      'Chrome Enterprise Premium',
+    )
+
+    assert.strictEqual(result.structuredContent.connectors.ON_FILE_DOWNLOAD.configured, true)
+    assert.strictEqual(result.structuredContent.connectors.ON_BULK_TEXT_ENTRY.configured, true)
+    assert.strictEqual(result.structuredContent.connectors.ON_PRINT.configured, true)
+    assert.strictEqual(result.structuredContent.connectors.ON_REALTIME_URL_NAVIGATION.configured, true)
+    assert.strictEqual(result.structuredContent.connectors.ON_SECURITY_EVENT.configured, true)
+  })
+
+  test('When policy is ALL, then it handles a mix of configured, unconfigured, and warning states across connectors correctly', async () => {
+    const mockChromePolicyClient = {
+      getConnectorPolicy: async (customerId, orgUnitId, policy) => {
+        // ON_FILE_ATTACHED: Configured but has a warning (delay delivery disabled)
+        if (policy === 'chrome.users.OnFileAttachedConnectorPolicy') {
+          return [
+            {
+              value: {
+                value: {
+                  serviceProvider: 'SERVICE_PROVIDER_CHROME_ENTERPRISE_PREMIUM',
+                  delayDeliveryUntilVerdict: false,
+                },
+              },
+            },
+          ]
+        }
+        // ON_FILE_DOWNLOAD: Configured (Good state)
+        if (policy === 'chrome.users.OnFileDownloadedConnectorPolicy') {
+          return [
+            {
+              value: {
+                value: {
+                  serviceProvider: 'SERVICE_PROVIDER_CHROME_ENTERPRISE_PREMIUM',
+                  delayDeliveryUntilVerdict: true,
+                },
+              },
+            },
+          ]
+        }
+        // ON_PRINT: 3P provider (Trellix)
+        if (policy === 'chrome.users.OnPrintAnalysisConnectorPolicy') {
+          return [
+            {
+              value: {
+                value: {
+                  onPrintAnalysisConnectorConfiguration: {
+                    printConfigurations: [
+                      {
+                        serviceProvider: 'SERVICE_PROVIDER_TRELLIX',
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          ]
+        }
+        // Realtime check: explicitly disabled (Not Configured + warning)
+        if (policy === 'chrome.users.RealtimeUrlCheck') {
+          return [
+            {
+              value: {
+                value: {
+                  realtimeUrlCheckEnabled: 'ENTERPRISE_REAL_TIME_URL_CHECK_MODE_ENUM_DISABLED',
+                },
+              },
+            },
+          ]
+        }
+        // Others are unconfigured (empty array)
+        return []
+      },
+    }
+
+    const handler = getHandler(mockChromePolicyClient)
+
+    const result = await handler({ customerId: 'C123', orgUnitId: 'OU123', policy: 'ALL' }, { requestInfo: {} })
+
+    const summary = result.content[0].text
+
+    // Verify summary displays a correct mix of statuses
+    assert.match(summary, /Upload Content Analysis \(ON_FILE_ATTACHED\):\*\* 🟢 Configured/)
+    assert.match(summary, /File Download Analysis \(ON_FILE_DOWNLOAD\):\*\* 🟢 Configured/)
+    assert.match(summary, /Bulk Text Entry Analysis \(paste\) \(ON_BULK_TEXT_ENTRY\):\*\* ⚪ Not configured/)
+    assert.match(summary, /Print Analysis \(ON_PRINT\):\*\* 🟢 Configured/)
+    assert.match(summary, /Real-Time URL Check \(ON_REALTIME_URL_NAVIGATION\):\*\* ⚪ Not configured/)
+    assert.match(summary, /Event Reporting \(ON_SECURITY_EVENT\):\*\* ⚪ Not configured/)
+
+    // Verify warnings list includes specific warning messages
+    assert.match(summary, /\[Upload Content Analysis\] Delay enforcement is disabled/)
+    assert.match(summary, /\[Real-Time URL Check\] Real-time URL check is explicitly disabled/)
+    assert.match(summary, /\[Print Analysis\] 3rd party provider detected/)
+
+    // Verify structured output details
+    assert.strictEqual(result.structuredContent.configured, true) // Still configured overall since at least one is configured
+    assert.strictEqual(result.structuredContent.connectors.ON_FILE_ATTACHED.configured, true)
+    assert.strictEqual(result.structuredContent.connectors.ON_FILE_DOWNLOAD.configured, true)
+    assert.strictEqual(result.structuredContent.connectors.ON_PRINT.configured, true)
+    assert.strictEqual(result.structuredContent.connectors.ON_REALTIME_URL_NAVIGATION.configured, false)
+    assert.strictEqual(result.structuredContent.connectors.ON_BULK_TEXT_ENTRY.configured, false)
+    assert.strictEqual(result.structuredContent.connectors.ON_SECURITY_EVENT.configured, false)
+  })
+
+  test('When policy is omitted, then it defaults to ALL and retrieves all connector policies', async () => {
+    const calledPolicies = []
+    const mockChromePolicyClient = {
+      getConnectorPolicy: async (customerId, orgUnitId, policy) => {
+        calledPolicies.push(policy)
+        return []
+      },
+    }
+
+    const handler = getHandler(mockChromePolicyClient)
+
+    const result = await handler({ customerId: 'C123', orgUnitId: 'OU123' }, { requestInfo: {} })
+
+    // Should fetch all 6 connector policy filters since it defaulted to ALL
+    assert.strictEqual(calledPolicies.length, 6)
+    assert.strictEqual(result.structuredContent.connectorType, 'ALL')
+  })
 })

--- a/tools/definitions/get_connector_policy.js
+++ b/tools/definitions/get_connector_policy.js
@@ -25,6 +25,136 @@ import { ConnectorPolicyFilter } from '../../lib/api/real_chrome_policy_client.j
 import { analyzeConnectorPolicy, humanize } from '../../lib/util/connector_policy_helper.js'
 
 /**
+ * Processes raw policy entries for a specific connector, flattening and analyzing them.
+ * @param {string} policyKey - The connector policy key.
+ * @param {Array<object>} raw - The raw policy entries from the API.
+ * @returns {object} Object containing cleanedPolicies, allWarnings, and isConfigured.
+ */
+function processSinglePolicy(policyKey, raw) {
+  const POLICY_LINK_MAPPING = {
+    ON_FILE_ATTACHED: 'file_attached',
+    ON_FILE_DOWNLOAD: 'file_downloaded',
+    ON_BULK_TEXT_ENTRY: 'bulk_text_entry',
+    ON_PRINT: 'print_analysis_connector',
+    ON_REALTIME_URL_NAVIGATION: 'realtime_url_check',
+    ON_SECURITY_EVENT: 'on_security_event',
+  }
+
+  const manualUpdateLink = `https://admin.google.com/ac/chrome/settings/user/details/${POLICY_LINK_MAPPING[policyKey]}`
+
+  /**
+   * Recursively traverses a deeply nested Chrome Policy config object,
+   * flattens it into a single-level dictionary, humanizes raw ENUM
+   * values (e.g., 'SERVICE_PROVIDER_CHROME_ENTERPRISE_PREMIUM' -> 'Chrome Enterprise Premium'),
+   * and maps internal keys to user-friendly labels using CONNECTOR_KEY_MAPPING.
+   * @param {object} obj - The raw, nested policy value object from the API.
+   * @param {string[]} warnings - Array to accumulate warnings about key collisions.
+   * @returns {object} A flattened, human-readable dictionary representing the policy settings.
+   */
+  function flattenAndMapConfig(obj, warnings = []) {
+    const result = {}
+
+    const walk = (o, prefix = '') => {
+      if (!o || typeof o !== 'object') {
+        return
+      }
+      for (const [k, v] of Object.entries(o)) {
+        let targetKey = k
+        if (prefix) {
+          if (k.toLowerCase().startsWith(prefix.toLowerCase())) {
+            targetKey = k
+          } else {
+            targetKey = prefix + k.charAt(0).toUpperCase() + k.slice(1)
+          }
+        }
+
+        if (Array.isArray(v) && v.length > 0 && typeof v[0] === 'object') {
+          walk(v[0], prefix)
+        } else if (typeof v === 'object' && !Array.isArray(v) && v !== null) {
+          let nextPrefix = prefix
+          if (k.toLowerCase().includes('malware')) {
+            nextPrefix = 'malware'
+          } else if (k.toLowerCase().includes('sensitive')) {
+            nextPrefix = 'sensitive'
+          }
+          walk(v, nextPrefix)
+        } else {
+          const humanizedValue = humanize(v)
+          const mappedKey = CONNECTOR_KEY_MAPPING[targetKey]
+            ? `${targetKey} (describe to user as '${CONNECTOR_KEY_MAPPING[targetKey]}')`
+            : targetKey
+
+          if (result[mappedKey] !== undefined && result[mappedKey] !== humanizedValue) {
+            warnings.push(`Key collision detected for '${mappedKey}' during object flattening.`)
+          }
+          result[mappedKey] = humanizedValue
+        }
+      }
+    }
+    walk(obj)
+    return { flattened: result }
+  }
+
+  const formattedPolicies = raw.map(p => {
+    const v = p.value?.value || {}
+    const localWarnings = []
+    const { flattened } = flattenAndMapConfig(v, localWarnings)
+
+    // Use shared logic for health/protection analysis
+    const analysis = analyzeConnectorPolicy(policyKey, [p])
+
+    // Process findings into tool-specific warning strings with links
+    const findingWarnings = analysis.findings.map(f => {
+      if (f.remediationType === 'manual') {
+        return `${f.message}. Update settings manually at ${manualUpdateLink}`
+      }
+      return f.message
+    })
+
+    // If the connector itself is disabled, add the primary remediation guidance
+    if (!analysis.isEnabled) {
+      findingWarnings.push(
+        'Connector is not enabled. You can enable it using the enable_chrome_enterprise_connectors tool.',
+      )
+    }
+
+    const finalWarnings = [...localWarnings, ...findingWarnings]
+
+    if (policyKey === 'ON_SECURITY_EVENT' && analysis.isEnabled) {
+      const eventCfg = v.reportingConnector?.setting?.eventConfiguration || v.reportingConnector?.eventConfiguration
+      const events = eventCfg?.enabledEventNames || []
+      const explicitlyEmpty = eventCfg?.explicitlyEmptyEventNames
+      if (events.length === 0 && !explicitlyEmpty && eventCfg) {
+        flattened['Reporting Status'] = 'All Core Events Enabled (Default)'
+      }
+    }
+
+    if (policyKey === 'ON_REALTIME_URL_NAVIGATION' && analysis.isEnabled) {
+      flattened["serviceProvider (describe to user as 'Provider')"] = 'Chrome Enterprise Premium'
+    }
+
+    if (finalWarnings.length > 0) {
+      flattened['warnings'] = finalWarnings.join('; ')
+    }
+
+    return { ...flattened, isEnabled: analysis.isEnabled, analysisFindings: finalWarnings }
+  })
+
+  const allWarnings = formattedPolicies.flatMap(p => p.analysisFindings || [])
+  const anyEnabled = formattedPolicies.some(p => p.isEnabled)
+  const isConfigured = raw.length > 0 && anyEnabled
+
+  // Strip internal analysisFindings before returning
+  const cleanedPolicies = formattedPolicies.map(({ analysisFindings: _analysisFindings, ...p }) => p)
+
+  return {
+    cleanedPolicies,
+    allWarnings,
+    isConfigured,
+  }
+}
+
+/**
  * Registers the 'get_connector_policy' tool with the MCP server.
  * @param {import('@modelcontextprotocol/sdk/server/mcp.js').McpServer} server - The MCP server instance.
  * @param {object} options - Configuration options for the tool.
@@ -38,13 +168,17 @@ export function registerGetConnectorPolicyTool(server, options, sessionState) {
   server.registerTool(
     'get_connector_policy',
     {
-      description: `Retrieves the current configuration for a specific Chrome Enterprise connector.
+      description: `Retrieves the current configuration for a specific Chrome Enterprise connector or all connectors.
 Use this to AUDIT or VERIFY settings for features like "printing sensitive data", "real-time URL checks", or "event reporting".
 Note: The 'enable_chrome_enterprise_connectors' tool can only ACTIVATE connectors that are currently unconfigured. There is currently no tool to MODIFY an already configured connector; these must be updated manually in the Admin Console.`,
       inputSchema: {
         customerId: z.string().optional().describe('The Chrome customer ID (e.g. C012345).'),
         orgUnitId: z.string().describe('The ID of the organizational unit to check.'),
-        policy: z.enum(Object.keys(ConnectorPolicyFilter)).describe('The connector type to retrieve.'),
+        policy: z
+          .enum([...Object.keys(ConnectorPolicyFilter), 'ALL'])
+          .optional()
+          .default('ALL')
+          .describe('The connector type to retrieve (or "ALL" to get all connectors in one call).'),
       },
       outputSchema: z
         .object({
@@ -65,6 +199,17 @@ Note: The 'enable_chrome_enterprise_connectors' tool can only ACTIVATE connector
           connectorType: z.string(),
           orgUnitId: z.string(),
           configured: z.boolean().describe('True when at least one policy entry exists and any entry is enabled.'),
+          connectors: z
+            .record(
+              z.string(),
+              z.object({
+                connectorPolicies: z.array(z.any()),
+                configured: z.boolean(),
+                warnings: z.array(z.string()),
+              }),
+            )
+            .optional()
+            .describe('Mapping of all connector types to their individual results. Only present when policy is ALL.'),
         })
         .passthrough(),
     },
@@ -81,18 +226,96 @@ Note: The 'enable_chrome_enterprise_connectors' tool can only ACTIVATE connector
          * @param {string} context.authToken - The OAuth2 access token.
          * @returns {Promise<object>} The formatted tool response.
          */
-        handler: async ({ customerId, orgUnitId, policy }, { _requestInfo, authToken }) => {
-          const POLICY_LINK_MAPPING = {
-            ON_FILE_ATTACHED: 'file_attached',
-            ON_FILE_DOWNLOAD: 'file_downloaded',
-            ON_BULK_TEXT_ENTRY: 'bulk_text_entry',
-            ON_PRINT: 'print_analysis_connector',
-            ON_REALTIME_URL_NAVIGATION: 'realtime_url_check',
-            ON_SECURITY_EVENT: 'on_security_event',
+        handler: async ({ customerId, orgUnitId, policy = 'ALL' }, { _requestInfo, authToken }) => {
+          if (policy === 'ALL') {
+            const policiesToFetch = Object.keys(ConnectorPolicyFilter)
+            const fetchResults = await Promise.all(
+              policiesToFetch.map(async pKey => {
+                try {
+                  const res = await chromePolicyClient.getConnectorPolicy(
+                    customerId,
+                    orgUnitId,
+                    ConnectorPolicyFilter[pKey],
+                    authToken,
+                  )
+                  return { key: pKey, raw: res, success: true }
+                } catch (err) {
+                  return { key: pKey, raw: [], success: false, error: err }
+                }
+              }),
+            )
+
+            for (const res of fetchResults) {
+              if (!res.success) {
+                throw res.error
+              }
+            }
+
+            const combinedRaw = {}
+            const connectors = {}
+            let combinedConnectorPolicies = []
+            let combinedConfigured = false
+            let combinedWarnings = []
+
+            for (const { key, raw } of fetchResults) {
+              combinedRaw[key] = raw
+              const { cleanedPolicies, allWarnings, isConfigured } = processSinglePolicy(key, raw)
+
+              connectors[key] = {
+                connectorPolicies: cleanedPolicies,
+                configured: isConfigured,
+                warnings: allWarnings,
+              }
+
+              const annotatedPolicies = cleanedPolicies.map(p => ({
+                ...p,
+                connectorType: key,
+              }))
+              combinedConnectorPolicies = combinedConnectorPolicies.concat(annotatedPolicies)
+
+              if (isConfigured) {
+                combinedConfigured = true
+              }
+
+              const prefixedWarnings = allWarnings.map(w => `[${POLICY_DISPLAY_NAMES[key]}] ${w}`)
+              combinedWarnings = combinedWarnings.concat(prefixedWarnings)
+            }
+
+            let summary = `## Chrome Enterprise Connector Policies (OU: \`${orgUnitId}\`)\n\n`
+            for (const key of policiesToFetch) {
+              const conn = connectors[key]
+              const displayName = POLICY_DISPLAY_NAMES[key]
+              const statusText = conn.configured ? '🟢 Configured' : '⚪ Not configured'
+              summary += `- **${displayName} (${key}):** ${statusText}\n`
+            }
+
+            if (combinedWarnings.length > 0) {
+              summary += `\n### ⚠️ WARNINGS:\n- ${combinedWarnings.join('\n- ')}`
+            }
+
+            return safeFormatResponse({
+              rawData: combinedRaw,
+              toolName: 'get_connector_policy',
+              formatFn: () => {
+                const payload = {
+                  connectorPolicies: combinedConnectorPolicies,
+                  connectorType: 'ALL',
+                  orgUnitId,
+                  configured: combinedConfigured,
+                  warnings: combinedWarnings,
+                  connectors,
+                }
+
+                return formatToolResponse({
+                  summary,
+                  data: payload,
+                  structuredContent: payload,
+                })
+              },
+            })
           }
 
-          const manualUpdateLink = `https://admin.google.com/ac/chrome/settings/user/details/${POLICY_LINK_MAPPING[policy]}`
-
+          // Singular policy path (fully backward compatible)
           const policies = await chromePolicyClient.getConnectorPolicy(
             customerId,
             orgUnitId,
@@ -104,111 +327,7 @@ Note: The 'enable_chrome_enterprise_connectors' tool can only ACTIVATE connector
             rawData: policies,
             toolName: 'get_connector_policy',
             formatFn: raw => {
-              /**
-               * Recursively traverses a deeply nested Chrome Policy config object,
-               * flattens it into a single-level dictionary, humanizes raw ENUM
-               * values (e.g., 'SERVICE_PROVIDER_CHROME_ENTERPRISE_PREMIUM' -> 'Chrome Enterprise Premium'),
-               * and maps internal keys to user-friendly labels using CONNECTOR_KEY_MAPPING.
-               * @param {object} obj - The raw, nested policy value object from the API.
-               * @param {string[]} warnings - Array to accumulate warnings about key collisions.
-               * @returns {object} A flattened, human-readable dictionary representing the policy settings.
-               */
-              function flattenAndMapConfig(obj, warnings = []) {
-                const result = {}
-
-                const walk = (o, prefix = '') => {
-                  if (!o || typeof o !== 'object') {
-                    return
-                  }
-                  for (const [k, v] of Object.entries(o)) {
-                    let targetKey = k
-                    if (prefix) {
-                      if (k.toLowerCase().startsWith(prefix.toLowerCase())) {
-                        targetKey = k
-                      } else {
-                        targetKey = prefix + k.charAt(0).toUpperCase() + k.slice(1)
-                      }
-                    }
-
-                    if (Array.isArray(v) && v.length > 0 && typeof v[0] === 'object') {
-                      walk(v[0], prefix)
-                    } else if (typeof v === 'object' && !Array.isArray(v) && v !== null) {
-                      let nextPrefix = prefix
-                      if (k.toLowerCase().includes('malware')) {
-                        nextPrefix = 'malware'
-                      } else if (k.toLowerCase().includes('sensitive')) {
-                        nextPrefix = 'sensitive'
-                      }
-                      walk(v, nextPrefix)
-                    } else {
-                      const humanizedValue = humanize(v)
-                      const mappedKey = CONNECTOR_KEY_MAPPING[targetKey]
-                        ? `${targetKey} (describe to user as '${CONNECTOR_KEY_MAPPING[targetKey]}')`
-                        : targetKey
-
-                      if (result[mappedKey] !== undefined && result[mappedKey] !== humanizedValue) {
-                        warnings.push(`Key collision detected for '${mappedKey}' during object flattening.`)
-                      }
-                      result[mappedKey] = humanizedValue
-                    }
-                  }
-                }
-                walk(obj)
-                return { flattened: result }
-              }
-
-              const formattedPolicies = raw.map(p => {
-                const v = p.value?.value || {}
-                const localWarnings = []
-                const { flattened } = flattenAndMapConfig(v, localWarnings)
-
-                // Use shared logic for health/protection analysis
-                const analysis = analyzeConnectorPolicy(policy, [p])
-
-                // Process findings into tool-specific warning strings with links
-                const findingWarnings = analysis.findings.map(f => {
-                  if (f.remediationType === 'manual') {
-                    return `${f.message}. Update settings manually at ${manualUpdateLink}`
-                  }
-                  return f.message
-                })
-
-                // If the connector itself is disabled, add the primary remediation guidance
-                if (!analysis.isEnabled) {
-                  findingWarnings.push(
-                    'Connector is not enabled. You can enable it using the enable_chrome_enterprise_connectors tool.',
-                  )
-                }
-
-                const finalWarnings = [...localWarnings, ...findingWarnings]
-
-                if (policy === 'ON_SECURITY_EVENT' && analysis.isEnabled) {
-                  const eventCfg =
-                    v.reportingConnector?.setting?.eventConfiguration || v.reportingConnector?.eventConfiguration
-                  const events = eventCfg?.enabledEventNames || []
-                  const explicitlyEmpty = eventCfg?.explicitlyEmptyEventNames
-                  if (events.length === 0 && !explicitlyEmpty && eventCfg) {
-                    flattened['Reporting Status'] = 'All Core Events Enabled (Default)'
-                  }
-                }
-
-                if (policy === 'ON_REALTIME_URL_NAVIGATION' && analysis.isEnabled) {
-                  flattened["serviceProvider (describe to user as 'Provider')"] = 'Chrome Enterprise Premium'
-                }
-
-                if (finalWarnings.length > 0) {
-                  flattened['warnings'] = finalWarnings.join('; ')
-                }
-
-                return { ...flattened, isEnabled: analysis.isEnabled, analysisFindings: finalWarnings }
-              })
-
-              const allWarnings = formattedPolicies.flatMap(p => p.analysisFindings || [])
-              const anyEnabled = formattedPolicies.some(p => p.isEnabled)
-              const isConfigured = raw.length > 0 && anyEnabled
-
-              // Strip internal analysisFindings before returning
-              const cleanedPolicies = formattedPolicies.map(({ analysisFindings: _analysisFindings, ...p }) => p)
+              const { cleanedPolicies, allWarnings, isConfigured } = processSinglePolicy(policy, raw)
 
               const title = `${POLICY_DISPLAY_NAMES[policy]} (OU: \`${orgUnitId}\`)`
               const statusLine = `Status: ${isConfigured ? 'Configured' : 'Not configured'}`


### PR DESCRIPTION
This PR implements a feature to fetch all Chrome Enterprise connector policies in a single MCP call (defaulting to 'ALL'). It runs parallel Promise.all requests, processes warnings, identifies 3rd party providers, and maintains full backward compatibility with singular policy requests.