### PR TITLE
chore: union-merge CHANGELOG.md to avoid release PR conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union


### PR DESCRIPTION
Adds `CHANGELOG.md merge=union` to a new `.gitattributes`. With the union merge driver, both sides' new lines are kept instead of producing conflict markers — appropriate for an append-only release log.

## Why now

release-please rebuilds CHANGELOG.md from scratch each time its release branch is regenerated, so the bot never hits a conflict. With the Google CLA blocking the bot's commits, a human has to re-author each release PR (see #185 for 1.4.0). The manually-authored branch goes stale against new feature/fix commits on main and hits append-at-top conflicts in CHANGELOG.md every time.

## Long-term fix

#156 enables the centralized release-please App, which (per its description) "automatically manages release PRs and tags, bypassing the Google CLA bot naturally." Once that lands, the bot owns CHANGELOG.md and humans never edit it. This `.gitattributes` line is still useful as defense-in-depth for the rare case of a manual edit.

## Test plan

- [x] `union` is a built-in git merge driver — no additional config required beyond the `.gitattributes` line.
- [ ] Verifiable on the next release-please cycle if #156 has not yet landed: a CHANGELOG-touching commit on main between release-PR rebases will concatenate cleanly instead of producing conflict markers.
