### PR TITLE
fix(api): resolve Licensing API auth remediation bypass

### DIFF
--- a/lib/api/admin_sdk_client.js
+++ b/lib/api/admin_sdk_client.js
@@ -229,7 +229,7 @@ function handleLicensingError(error, operationDescription) {
       )
     }
     throw new Error(
-      `Access denied to Licensing API. The account may not have permission to access licensing information.`,
+      `PERMISSION_DENIED: Access denied to Licensing API. The account may not have permission to access licensing information.`,
     )
   }
   handleApiError(error, TAGS.API, operationDescription)

--- a/test/local/admin_sdk.test.js
+++ b/test/local/admin_sdk.test.js
@@ -313,10 +313,10 @@ describe('Admin SDK API', () => {
       )
     })
 
-    test('When access is denied to Licensing API, then it returns a descriptive error message', async () => {
+    test('When access is denied to Licensing API, then it returns proactive auth remediation instructions', async () => {
       const mockCheckUserCepLicense = mock.fn(async () => {
         throw new Error(
-          'Access denied to Licensing API. The account may not have permission to access licensing information.',
+          'PERMISSION_DENIED: Access denied to Licensing API. The account may not have permission to access licensing information.',
         )
       })
 
@@ -346,7 +346,8 @@ describe('Admin SDK API', () => {
       const result = await handler({ userId: 'user@example.com' }, {})
 
       assert.strictEqual(mockCheckUserCepLicense.mock.callCount(), 1)
-      assert.match(result.content[0].text, /Error: Access denied to Licensing API/)
+      assert.match(result.content[0].text, /Permission denied\. Your account lacks/)
+      assert.match(result.content[0].text, /gcloud auth application-default login/)
     })
   })
 })

--- a/test/local/check_cep_subscription.test.js
+++ b/test/local/check_cep_subscription.test.js
@@ -144,10 +144,10 @@ describe('check_cep_subscription Tool', () => {
     )
   })
 
-  test('When access is denied, then it returns error message', async () => {
+  test('When access is denied, then it returns proactive auth remediation instructions', async () => {
     const mockCheckCepSubscription = mock.fn(async () => {
       throw new Error(
-        'Access denied to Licensing API. The account may not have permission to access licensing information.',
+        'PERMISSION_DENIED: Access denied to Licensing API. The account may not have permission to access licensing information.',
       )
     })
 
@@ -177,7 +177,8 @@ describe('check_cep_subscription Tool', () => {
     const result = await handler({ customerId: 'C0123' }, {})
 
     assert.strictEqual(mockCheckCepSubscription.mock.callCount(), 1)
-    assert.match(result.content[0].text, /Error: Access denied to Licensing API/)
+    assert.match(result.content[0].text, /Permission denied\. Your account lacks/)
+    assert.match(result.content[0].text, /gcloud auth application-default login/)
   })
 })
 


### PR DESCRIPTION
# fix(api): resolve Licensing API auth remediation bypass

In AdminSdkClient, handleLicensingError catches Licensing API 403 errors
and re-throws a customized Error object. Because the custom error
message did not contain recognized authorization failure keywords
(such as PERMISSION_DENIED), the guardedToolCall wrapper failed to
detect the authorization issue, swallowing the error and bypassing the
proactive auth remediation instructions.

Corrects this bypass by prepending PERMISSION_DENIED to the custom
error message. Re-aligns check_cep_subscription.test.js and
admin_sdk.test.js unit assertions to expect Hono's standard proactive
auth remediation instructions instead of raw error logs.
