### PR TITLE
fix: reduce excessive output in get_customer_id tool

### DIFF
--- a/test/local/admin_sdk.test.js
+++ b/test/local/admin_sdk.test.js
@@ -59,7 +59,7 @@ describe('Admin SDK API', () => {
       assert.strictEqual(mockGetCustomerId.mock.callCount(), 1)
       assert.ok(result.content[0].text.includes('Customer ID: `C0123`'))
       assert.ok(result.content[1].text.includes('```json'))
-      assert.ok(result.content[1].text.includes('"id": "C0123"'))
+      assert.ok(result.content[1].text.includes('"customerId": "C0123"'))
     })
 
     test('When getCustomerId API call fails, then it returns an error message', async () => {

--- a/tools/definitions/get_customer_id.js
+++ b/tools/definitions/get_customer_id.js
@@ -27,7 +27,7 @@ import { logger } from '../../lib/util/logger.js'
  * Registers the 'get_customer_id' tool with the MCP server.
  * @param {import('@modelcontextprotocol/sdk/server/mcp.js').McpServer} server - The MCP server instance.
  * @param {object} options - Configuration options for the tool.
- * @param {import('../../lib/api/admin_sdk_client.js').AdminSdkClient} options.adminSdkClient - The Admin SDK client instance.
+ * @param {import('../../lib/api/interfaces/admin_sdk_client.js').AdminSdkClient} options.adminSdkClient - The Admin SDK client instance.
  * @param {object} sessionState - The session state object for caching.
  * @returns {void}
  */
@@ -43,6 +43,8 @@ This ID (often starting with 'C') is required as a parameter for many other Chro
       inputSchema: {},
       outputSchema: z.looseObject({
         customerId: z.string().nullable().describe('The unique customer ID.'),
+        customerDomain: z.string().optional().nullable().describe('The primary domain of the customer.'),
+        language: z.string().optional().nullable().describe('The default language for the customer.'),
       }),
     },
     guardedToolCall(
@@ -62,7 +64,7 @@ This ID (often starting with 'C') is required as a parameter for many other Chro
 
           if (!customer) {
             logger.error(`${TAGS.MCP} get_customer_id tool: Could not retrieve customer ID.`)
-            const sc = { customerId: null }
+            const sc = { customerId: null, customerDomain: null, language: null }
             return formatToolResponse({
               summary: 'Could not retrieve customer ID.',
               data: sc,
@@ -70,7 +72,11 @@ This ID (often starting with 'C') is required as a parameter for many other Chro
             })
           }
           logger.debug(`${TAGS.MCP} Successfully retrieved customer ID: ${customer.id}`)
-          const sc = { customerId: customer.id, ...customer }
+          const sc = {
+            customerId: customer.id,
+            customerDomain: customer.customerDomain,
+            language: customer.language,
+          }
           return formatToolResponse({
             summary: `Customer ID: \`${customer.id}\`
 


### PR DESCRIPTION
### Motivation
The `get_customer_id` tool was returning the entire Admin SDK Customer resource, which contains many fields (postal addresses, phone numbers, creation times) irrelevant to Chrome Enterprise Premium tasks. This excessive output creates unnecessary noise and distraction for both users and agents.

### Changes
- Restricted `outputSchema` in `get_customer_id.js` to only 3 essential fields: `customerId`, `customerDomain`, and `language`.
- Updated the handler to surgically return only these fields, removing the previous `...customer` spread.
- Updated `admin_sdk.test.js` to align with the new `customerId` key.

### Technical Notes
- Kept `.passthrough()` on the Zod schema to satisfy the project's SDK compatibility requirements.
- Made `customerDomain` and `language` optional in the schema to ensure compatibility with existing mock data in the test suite.

Verified with `npm run presubmit`.