### PR TITLE
test(ts): prepare infrastructure for TypeScript migration (Phase 2.5)

### DIFF
--- a/test/helpers/mock-utils.js
+++ b/test/helpers/mock-utils.js
@@ -1,0 +1,21 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file TypeScript Migration Exports Shim (Tombstone) for test/helpers/mock-utils.js.
+ */
+
+export * from './mock-utils.ts'

--- a/test/helpers/mock-utils.ts
+++ b/test/helpers/mock-utils.ts
@@ -1,0 +1,77 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import esmockReal from 'esmock'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+/**
+ * Robustly extracts the caller's file path from a stack trace.
+ * @returns {string} The absolute path of the calling module.
+ */
+function getCallerPath() {
+  const stack = new Error().stack.split('\n')
+  // We look for the first line that isn't this file or a Node internal.
+  const thisFile = fileURLToPath(import.meta.url)
+
+  for (let i = 2; i < stack.length; i++) {
+    const line = stack[i]
+    const match =
+      line.match(/file:\/\/\/([^:]+)/) || line.match(/\(([^:]+):\d+:\d+\)/) || line.match(/at\s+([^:]+):\d+:\d+/)
+    if (match) {
+      const p = match[1].startsWith('/') ? match[1] : '/' + match[1]
+      if (p !== thisFile && !p.includes('node:internal')) {
+        return p
+      }
+    }
+  }
+  throw new Error('Could not determine caller path from stack trace')
+}
+
+/**
+ * TODO: Remove this entire wrapper and revert to raw 'esmock' once the migration
+ * is complete (Phase 4) and all test import paths point directly to .ts files.
+ *
+ * Enhanced esmock wrapper that handles .js -> .ts resolution automatically.
+ */
+export async function esmock(moduleId, mocks = {}, globals = {}) {
+  const callerPath = getCallerPath()
+  const callerUrl = pathToFileURL(callerPath).href
+
+  const resolve = async id => {
+    if (typeof id !== 'string' || (!id.startsWith('.') && !id.startsWith('/'))) {
+      return id
+    }
+
+    // Use import.meta.resolve to find the actual file on disk.
+    // This handles the .js -> .ts mapping correctly via tsx.
+    try {
+      const resolvedUrl = await import.meta.resolve(id, callerUrl)
+      // esmock works best with absolute paths (no file:/// prefix)
+      return fileURLToPath(resolvedUrl)
+    } catch {
+      // Fallback to manual resolution if resolve fails
+      return id
+    }
+  }
+
+  const resolvedId = await resolve(moduleId)
+  const resolvedMocks = {}
+  for (const [key, value] of Object.entries(mocks)) {
+    resolvedMocks[await resolve(key)] = value
+  }
+
+  return esmockReal(resolvedId, resolvedMocks, globals)
+}

--- a/test/local/admin_sdk.test.js
+++ b/test/local/admin_sdk.test.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 import assert from 'node:assert/strict'
 import { describe, test, mock, beforeEach } from 'node:test'
-import esmock from 'esmock'
+import { esmock } from '../helpers/mock-utils.js'
 
 describe('Admin SDK API', () => {
   let server

--- a/test/local/auth-oauth-cache-fallback.test.js
+++ b/test/local/auth-oauth-cache-fallback.test.js
@@ -22,7 +22,7 @@ limitations under the License.
 
 import { describe, test, before, after } from 'node:test'
 import assert from 'node:assert/strict'
-import esmock from 'esmock'
+import { esmock } from '../helpers/mock-utils.js'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import os from 'node:os'

--- a/test/local/auth.test.js
+++ b/test/local/auth.test.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 import assert from 'node:assert/strict'
 import { describe, test, mock } from 'node:test'
-import esmock from 'esmock'
+import { esmock } from '../helpers/mock-utils.js'
 
 function createMockExecFile(...handlers) {
   return mock.fn((cmd, args, opts, cb) => {

--- a/test/local/check_cep_subscription.test.js
+++ b/test/local/check_cep_subscription.test.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 import assert from 'node:assert/strict'
 import { describe, test, mock, beforeEach } from 'node:test'
-import esmock from 'esmock'
+import { esmock } from '../helpers/mock-utils.js'
 import { AdminSdkClient } from '../../lib/api/admin_sdk_client.js'
 
 describe('check_cep_subscription Tool', () => {

--- a/test/local/chromemanagement.test.js
+++ b/test/local/chromemanagement.test.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 import assert from 'node:assert/strict'
 import { describe, test, mock, beforeEach } from 'node:test'
-import esmock from 'esmock'
+import { esmock } from '../helpers/mock-utils.js'
 
 describe('Chrome Management API', () => {
   let server

--- a/test/local/chromepolicy.test.js
+++ b/test/local/chromepolicy.test.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 import assert from 'node:assert/strict'
 import { describe, test, mock } from 'node:test'
-import esmock from 'esmock'
+import { esmock } from '../helpers/mock-utils.js'
 
 describe('ChromePolicyClient', () => {
   test('When resolvePolicy is called, then it returns resolved policies from the API', async () => {

--- a/test/local/cloudidentity.test.js
+++ b/test/local/cloudidentity.test.js
@@ -20,7 +20,7 @@ limitations under the License.
 
 import assert from 'node:assert/strict'
 import { describe, test, mock, beforeEach } from 'node:test'
-import esmock from 'esmock'
+import { esmock } from '../helpers/mock-utils.js'
 import { setupCloudIdentityHandler } from './mock-utils.js'
 import { FeatureFlags } from '../../lib/util/feature_flags.js'
 

--- a/test/local/create_default_dlp_rules.test.js
+++ b/test/local/create_default_dlp_rules.test.js
@@ -20,7 +20,7 @@ limitations under the License.
 
 import assert from 'node:assert/strict'
 import { describe, test, mock, beforeEach } from 'node:test'
-import esmock from 'esmock'
+import { esmock } from '../helpers/mock-utils.js'
 import { setupCloudIdentityHandler } from './mock-utils.js'
 
 describe('create_default_dlp_rules Tool', () => {

--- a/test/local/detector_validation.test.js
+++ b/test/local/detector_validation.test.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 import assert from 'node:assert/strict'
 import { describe, test, mock } from 'node:test'
-import esmock from 'esmock'
+import { esmock } from '../helpers/mock-utils.js'
 import { WORKSPACE_RULE_LIMITS, AGENT_DISPLAY_NAME_PREFIX } from '../../lib/util/chrome_dlp_constants.js'
 
 describe('Tool Input Validation', () => {

--- a/test/local/extension_tools.test.js
+++ b/test/local/extension_tools.test.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 import assert from 'node:assert/strict'
 import { describe, test, mock, beforeEach } from 'node:test'
-import esmock from 'esmock'
+import { esmock } from '../helpers/mock-utils.js'
 
 const SEB_EXTENSION_ID = 'ekajlcmdfcigmdbphhifahdfjbkciflj'
 const INSTALL_TYPE_SCHEMA = 'chrome.users.apps.InstallType'

--- a/test/local/helpers.test.js
+++ b/test/local/helpers.test.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { describe, test, before } from 'node:test'
 import assert from 'node:assert/strict'
-import esmock from 'esmock'
+import { esmock } from '../helpers/mock-utils.js'
 import { logger, LogLevel } from '../../lib/util/logger.js'
 
 describe('Helpers', () => {

--- a/test/local/jwt-verifier.test.js
+++ b/test/local/jwt-verifier.test.js
@@ -21,7 +21,7 @@ limitations under the License.
 
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import esmock from 'esmock'
+import { esmock } from '../helpers/mock-utils.js'
 
 import { parseExpectedAudience } from '../../lib/util/credential/jwt_verifier.js'
 

--- a/test/local/knowledge_structure.test.js
+++ b/test/local/knowledge_structure.test.js
@@ -32,7 +32,7 @@ describe('Knowledge Folder Structure', () => {
     const pattern = /^\d+-/
 
     for (const file of files) {
-      if (file.startsWith('.') || file === 'README.md' || file === 'instructions.js') {
+      if (file.startsWith('.') || file === 'README.md' || file.startsWith('instructions.')) {
         continue
       }
 

--- a/test/local/mock-utils.js
+++ b/test/local/mock-utils.js
@@ -12,7 +12,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-*/ import esmock from 'esmock'
+*/ import { esmock } from '../helpers/mock-utils.js'
 
 export async function setupCloudIdentityHandler(server, toolName, clientMethods) {
   const MockCloudIdentityClient = class {

--- a/test/local/service_usage.test.js
+++ b/test/local/service_usage.test.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { describe, test, mock, beforeEach } from 'node:test'
 import assert from 'node:assert'
-import esmock from 'esmock'
+import { esmock } from '../helpers/mock-utils.js'
 import { SERVICE_NAMES } from '../../lib/constants.js'
 
 describe('check_and_enable_cep_api tool', () => {

--- a/test/unit/mcp-server-state-isolation.test.js
+++ b/test/unit/mcp-server-state-isolation.test.js
@@ -60,7 +60,14 @@ describe('HTTP per-request session state isolation', () => {
     const { fn: recorder, captured } = makeRecorder()
     const handler = createMcpPostHandler({}, recorder)
     const fakeReq = { body: {}, on: () => {} }
-    const fakeRes = { on: () => {}, headersSent: false, status: () => fakeRes, json: () => {} }
+    const fakeRes = {
+      on: () => {},
+      headersSent: false,
+      status: () => fakeRes,
+      json: () => {},
+      writeHead: () => {},
+      end: () => {},
+    }
 
     await handler(fakeReq, fakeRes)
     await handler(fakeReq, fakeRes)
@@ -75,7 +82,14 @@ describe('HTTP per-request session state isolation', () => {
     const { fn: recorder, captured } = makeRecorder()
     const sseTransports = {}
     const handler = createSseHandler({}, sseTransports, recorder)
-    const fakeRes = { on: () => {}, headersSent: false }
+    const fakeRes = {
+      on: () => {},
+      headersSent: false,
+      status: () => fakeRes,
+      json: () => {},
+      writeHead: () => {},
+      end: () => {},
+    }
 
     await handler({}, fakeRes)
     await handler({}, fakeRes)


### PR DESCRIPTION
Intermediate PR to harden test infrastructure before full TypeScript migration.

Includes:
- Extension-agnostic `esmock` wrapper to handle hybrid .js/.ts resolution.
- Fix for `writeHead` TypeError in server isolation tests.
- Allowlist update for `instructions.ts` in knowledge structure tests.
- TODOs to revert these shim-specific test helpers in Phase 4.

Depends on #197.