### PR TITLE
fix: add configurable timeouts deep scanning guidance

### DIFF
--- a/.github/expected-tarball.txt
+++ b/.github/expected-tarball.txt
@@ -23,6 +23,7 @@ lib/knowledge/10-chrome-policy-management.md
 lib/knowledge/11-dlp-rule-reference.doc.js
 lib/knowledge/12-security-posture-guide.md
 lib/knowledge/15-rule-quality-guidelines.md
+lib/knowledge/16-configurable-timeouts.md
 lib/knowledge/21-dlp-limits.md
 lib/knowledge/22-dlp-data-masking.md
 lib/knowledge/23-insider-risk-monitoring.md

--- a/lib/knowledge/16-configurable-timeouts.md
+++ b/lib/knowledge/16-configurable-timeouts.md
@@ -1,9 +1,8 @@
 ---
-summary: 'Guide for configuring timeout deadlines (evaluation time limit) for Data Loss Prevention (DLP) and malware scans, including the paste action. Covers UI navigation paths, Admin privileges required, and background scan behavior. Keywords: Configurable timeouts, evaluation time limit, deep scanning protection settings, scan deadline, paste deadline.'
+summary: 'Guide for configuring timeout deadlines (evaluation time limit) for Data Loss Prevention (DLP) and malware scans, including the paste action. Covers UI navigation paths, Admin privileges required, and background scan behavior. Keywords: Configurable timeouts, evaluation time limit, deep scanning protection settings, Chrome Enterprise Security Services, Chrome Enterprise Premium, scan deadline, paste deadline.'
 title: 'Configurable Timeout Deadlines for Deep Scanning'
 articleId: 16
 url: 'https://support.google.com/chrome/a/answer/16493390?hl=en'
 ---
 
-This article is now hosted on the official Google Workspace Knowledge Base.
-The 'get_document' tool will automatically fetch the latest version for you.
+This article is now hosted on the official Google Workspace Knowledge Base. The 'get_document' tool will automatically fetch the latest version for you.

--- a/lib/knowledge/16-configurable-timeouts.md
+++ b/lib/knowledge/16-configurable-timeouts.md
@@ -1,0 +1,19 @@
+---
+summary: 'Guide for configuring timeout deadlines (evaluation time limit) for Data Loss Prevention (DLP) and malware scans, including the paste action. Covers UI navigation paths, Admin privileges required, and background scan behavior. Keywords: Configurable timeouts, evaluation time limit, deep scanning protection settings, scan deadline, paste deadline.'
+title: 'Configurable Timeout Deadlines for Deep Scanning'
+articleId: 16
+url: 'https://support.google.com/chrome/a/answer/16493390?hl=en'
+---
+
+As an administrator with the Chrome Enterprise Security Services privilege and a Chrome Enterprise Premium subscription, you can set a timeout deadline for Data Loss Prevention (DLP) and malware scans, which includes the paste action, in the Google Admin console.
+
+To set a timeout deadline:
+
+1. Sign in to the Google Admin console with an administrator account.
+2. Navigate to Menu > Apps > Additional Google Services.
+3. Click Chrome Enterprise Security Services.
+4. Click Deep scanning protection settings.
+5. Click Edit.
+6. For the evaluation time limit for file upload, download, print, or ChromeOS file transfer action, enter a time limit in seconds (e.g., 8.5).
+
+This configurable deadline allows you to control how long users wait for scans before the action is allowed to proceed, with the scan continuing in the background. The General Availability (GA) UI for this feature includes support for malware, DLP, and paste deadline.

--- a/lib/knowledge/16-configurable-timeouts.md
+++ b/lib/knowledge/16-configurable-timeouts.md
@@ -5,15 +5,5 @@ articleId: 16
 url: 'https://support.google.com/chrome/a/answer/16493390?hl=en'
 ---
 
-As an administrator with the Chrome Enterprise Security Services privilege and a Chrome Enterprise Premium subscription, you can set a timeout deadline for Data Loss Prevention (DLP) and malware scans, which includes the paste action, in the Google Admin console.
-
-To set a timeout deadline:
-
-1. Sign in to the Google Admin console with an administrator account.
-2. Navigate to Menu > Apps > Additional Google Services.
-3. Click Chrome Enterprise Security Services.
-4. Click Deep scanning protection settings.
-5. Click Edit.
-6. For the evaluation time limit for file upload, download, print, or ChromeOS file transfer action, enter a time limit in seconds (e.g., 8.5).
-
-This configurable deadline allows you to control how long users wait for scans before the action is allowed to proceed, with the scan continuing in the background. The General Availability (GA) UI for this feature includes support for malware, DLP, and paste deadline.
+This article is now hosted on the official Google Workspace Knowledge Base.
+The 'get_document' tool will automatically fetch the latest version for you.

--- a/test/evals/cases/knowledge/k35-configurable_timeouts.eval.js
+++ b/test/evals/cases/knowledge/k35-configurable_timeouts.eval.js
@@ -25,5 +25,5 @@ export default {
   ],
   prompt: 'Can you walk me through the steps to set a time limit for paste action ?',
   goldenResponse:
-    'As an administrator with the Chrome Enterprise Security Services privilege and a Chrome Enterprise Premium subscription, you can set a timeout deadline for Data Loss Prevention (DLP) and malware scans, which includes the paste action, in the Google Admin console by navigating to Menu > Apps > Additional Google Services > Chrome Enterprise Security Services > Deep scanning protection settings. Click Edit, set the evaluation time limit in seconds, and save. Note that the analysis provider option is labeled exactly as Chrome Enterprise Premium.',
+    'As an administrator with the Chrome Enterprise Security Services privilege and a Chrome Enterprise Premium subscription, you can set a timeout deadline for Data Loss Prevention (DLP) and malware scans, which includes the paste action, in the Google Admin console by navigating to Menu > Apps > Additional Google Services > Chrome Enterprise Security Services > Deep scanning protection settings. Click Edit, set the evaluation time limit in seconds, and save.',
 }

--- a/test/evals/cases/knowledge/k35-configurable_timeouts.eval.js
+++ b/test/evals/cases/knowledge/k35-configurable_timeouts.eval.js
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export default {
+  id: 'k35',
+  priority: 'P2',
+  tags: ['configurable-timeouts', 'deep-scanning'],
+  requiredPatterns: [
+    'Chrome Enterprise Security Services',
+    'Deep scanning protection settings',
+    'Chrome Enterprise Premium',
+  ],
+  prompt: 'Can you walk me through the steps to set a time limit for paste action ?',
+  goldenResponse:
+    'As an administrator with the Chrome Enterprise Security Services privilege and a Chrome Enterprise Premium subscription, you can set a timeout deadline for Data Loss Prevention (DLP) and malware scans, which includes the paste action, in the Google Admin console by navigating to Menu > Apps > Additional Google Services > Chrome Enterprise Security Services > Deep scanning protection settings. Click Edit, set the evaluation time limit in seconds, and save. Note that the analysis provider option is labeled exactly as Chrome Enterprise Premium.',
+}

--- a/test/local/knowledge_search.test.js
+++ b/test/local/knowledge_search.test.js
@@ -69,4 +69,18 @@ describe('Knowledge Tools Real Database Integration', () => {
 
     assert.ok(docText.includes('Chrome Enterprise Premium'), 'Full content should include the policy text')
   })
+
+  test('When searched for configurable timeouts, then search_content finds the dedicated article', async () => {
+    const searchHandler = handlers['search_content']
+    const getDocHandler = handlers['get_document']
+
+    const searchResult = await searchHandler({ query: 'timeout deadline' }, { requestInfo: {} })
+    const documents = searchResult.structuredContent.documents
+    const article = documents.find(d => d.title.includes('Configurable Timeout Deadlines'))
+    assert.ok(article, 'Should find the configurable timeouts article')
+
+    const docResult = await getDocHandler({ filename: article.filename }, { requestInfo: {} })
+    const docText = docResult.content[0].text
+    assert.ok(docText.includes('Deep scanning protection settings'), 'Should include exact UI path grounding')
+  })
 })


### PR DESCRIPTION
Resolves Buganizer issue 499040194 comment #3 by grounding deep scanning protection settings timeout configuration paths. Adds a dedicated golden knowledge article, a local database integration unit test, and a knowledge evaluation case.