### PR TITLE
test(evals): add evaluation case for evidence locker paste limitations

### DIFF
--- a/test/evals/cases/knowledge/k36-evidence_locker_paste.eval.js
+++ b/test/evals/cases/knowledge/k36-evidence_locker_paste.eval.js
@@ -1,0 +1,25 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export default {
+  id: 'k36',
+  priority: 'P2',
+  tags: ['evidence-locker', 'paste'],
+  requiredPatterns: ['Evidence Locker'],
+  prompt: 'Can I use Evidence Locker to log pasted text or with a URL filtering rule?',
+  goldenResponse:
+    'Evidence Locker is a Chrome Enterprise Premium feature used to capture and inspect files triggering security alerts by saving them to a GCS bucket. It works with DLP rules for File Uploads, File Downloads, and Printing. However, Evidence Locker cannot be used with standard URL filtering rules as they do not scan content, and it is explicitly not supported for content pasted actions to avoid storing sensitive data like accidentally pasted passwords.',
+}

--- a/test/evals/cases/knowledge/k36-evidence_locker_paste.eval.js
+++ b/test/evals/cases/knowledge/k36-evidence_locker_paste.eval.js
@@ -21,5 +21,5 @@ export default {
   requiredPatterns: ['Evidence Locker'],
   prompt: 'Can I use Evidence Locker to log pasted text or with a URL filtering rule?',
   goldenResponse:
-    'Evidence Locker is a Chrome Enterprise Premium feature used to capture and inspect files triggering security alerts by saving them to a GCS bucket. It works with DLP rules for File Uploads, File Downloads, and Printing. However, Evidence Locker cannot be used with standard URL filtering rules as they do not scan content, and it is explicitly not supported for content pasted actions to avoid storing sensitive data like accidentally pasted passwords.',
+    'Evidence Locker is a Chrome Enterprise Premium feature used to capture and inspect files triggering security alerts by saving them to a GCS bucket. It works with DLP rules for File Uploads, File Downloads, and Printing. However, Evidence Locker cannot be used with standard URL filtering rules as they do not scan content, and it is explicitly not supported for content pasted actions.',
 }

--- a/test/local/knowledge_search.test.js
+++ b/test/local/knowledge_search.test.js
@@ -83,4 +83,12 @@ describe('Knowledge Tools Real Database Integration', () => {
     const docText = docResult.content[0].text
     assert.ok(docText.includes('Deep scanning protection settings'), 'Should include exact UI path grounding')
   })
+
+  test('When searched for Evidence Locker paste, then search_content finds the evidence locker article', async () => {
+    const searchHandler = handlers['search_content']
+    const searchResult = await searchHandler({ query: 'Evidence Locker paste' }, { requestInfo: {} })
+    const documents = searchResult.structuredContent.documents
+    const article = documents.find(d => d.title.includes('Evidence Locker'))
+    assert.ok(article, 'Should find the Evidence Locker setup guide')
+  })
 })


### PR DESCRIPTION
Adds evaluation case k36 and local knowledge search tests verifying that the agent correctly explains Evidence Locker trigger support limitations (unsupported on paste and URL filtering rules).