### PR TITLE
feat(ci): configure Kokoro CI testing and enable central release-please bot

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,0 +1,2 @@
+handleGHRelease: true
+manifest: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,20 +1,26 @@
-name: Release
+name: release-please
+
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+
 permissions:
   contents: write
   pull-requests: write
-concurrency:
-  group: release-please
-  cancel-in-progress: false
+
 jobs:
   release-please:
-    name: Release Please
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
-        id: release
+      - name: Generate Ephemeral GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
         with:
-          config-file: release-please-config.json
-          manifest-file: .release-please-manifest.json
+          app-id: ${{ secrets.CEP_MCP_RELEASER_APP_ID }}
+          private-key: ${{ secrets.CEP_MCP_RELEASER }}
+
+      - name: Run Release Please
+        uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -6,10 +6,7 @@
   "mcpServers": {
     "chrome-enterprise-premium": {
       "command": "npx",
-      "args": [
-        "-y",
-        "@google/chrome-enterprise-premium-mcp@^1.4.0"
-      ]
+      "args": ["-y", "@google/chrome-enterprise-premium-mcp@^1.4.0"]
     }
   }
 }

--- a/kokoro/build.sh
+++ b/kokoro/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+set -x
+
+BUILD_ROOT="${KOKORO_ARTIFACTS_DIR}/github/chrome-enterprise-premium-mcp"
+cd "${BUILD_ROOT}"
+
+echo "Installing dependencies..."
+npm ci
+
+echo "Running presubmit checks..."
+npm run presubmit
+
+echo "Build completed successfully."

--- a/kokoro/continuous.cfg
+++ b/kokoro/continuous.cfg
@@ -1,0 +1,5 @@
+# -*- protobuffer -*-
+# proto-file: google3/devtools/kokoro/config/proto/build.proto
+# proto-message: BuildConfig
+
+build_file: "github/chrome-enterprise-premium-mcp/kokoro/build.sh"

--- a/kokoro/presubmit.cfg
+++ b/kokoro/presubmit.cfg
@@ -1,0 +1,5 @@
+# -*- protobuffer -*-
+# proto-file: google3/devtools/kokoro/config/proto/build.proto
+# proto-message: BuildConfig
+
+build_file: "github/chrome-enterprise-premium-mcp/kokoro/build.sh"

--- a/test/local/extension_version.test.js
+++ b/test/local/extension_version.test.js
@@ -1,0 +1,55 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import test from 'node:test'
+import assert from 'node:assert'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+test('gemini-extension.json package version matches package.json version', () => {
+  const packageJsonPath = path.resolve(__dirname, '../../package.json')
+  const extensionJsonPath = path.resolve(__dirname, '../../gemini-extension.json')
+
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+  const extensionJson = JSON.parse(fs.readFileSync(extensionJsonPath, 'utf8'))
+
+  const currentVersion = packageJson.version
+
+  const args = extensionJson.mcpServers['chrome-enterprise-premium'].args
+  assert.ok(Array.isArray(args), 'args must be an array')
+
+  const packageArg = args.find(arg => arg.startsWith('@google/chrome-enterprise-premium-mcp@'))
+  assert.ok(packageArg, 'Could not find @google/chrome-enterprise-premium-mcp dependency in args')
+
+  const rangeString = packageArg.split('@').pop()
+  assert.ok(rangeString, 'Could not extract version range from argument')
+
+  assert.ok(rangeString.startsWith('^'), 'Version range must start with ^ for semantic versioning')
+  const rangeVersion = rangeString.slice(1)
+  const [rMajor, rMinor, rPatch] = rangeVersion.split('.').map(Number)
+  const [cMajor, cMinor, cPatch] = currentVersion.split('.').map(Number)
+
+  assert.strictEqual(cMajor, rMajor, `Major version mismatch: current ${cMajor} must match range ${rMajor}`)
+
+  if (cMinor === rMinor) {
+    assert.ok(cPatch >= rPatch, `Patch version is older than range: current ${cPatch} must be >= ${rPatch}`)
+  } else {
+    assert.ok(cMinor > rMinor, `Minor version is older than range: current ${cMinor} must be > ${rMinor}`)
+  }
+})


### PR DESCRIPTION
Migrates CI testing to secure Kokoro containers and enables automated versioning/changelogs via the cep-mcp-releaser GitHub App. Replaces outdated PR #156 configuration. See b/510066717 for full technical details.