### PR TITLE
fix(cli): support 'auth' prefix for subcommands

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -28,7 +28,13 @@ import { runServer } from '../mcp-server.js'
  * @returns {Promise<void>} Resolves when the chosen command finishes.
  */
 async function main() {
-  const sub = process.argv[2]
+  const args = process.argv.slice(2)
+  let sub = args[0]
+
+  if (sub === 'auth' && args[1]) {
+    sub = args[1]
+  }
+
   if (sub === 'auth-status') {
     const { runAuthStatusCommand } = await import('../lib/util/credential/cli_commands.js')
     return runAuthStatusCommand()


### PR DESCRIPTION
Enhances the CLI dispatcher to support the `auth` prefix for subcommands (e.g., `auth login`, `auth auth-status`).

### Why:
- **Documentation Alignment:** The README and other docs use `mcp auth login` and `mcp auth-status`. Previously, the CLI only recognized `login` and `auth-status` directly, causing `auth login` to fall through and mistakenly start the MCP server.
- **Improved UX:** Allows for a more grouped command structure while maintaining backward compatibility for direct subcommand calls.