### PR TITLE
fix(evals): update agent model and add catastrophic-failure alarm

### DIFF
--- a/.github/workflows/agent-evals.yml
+++ b/.github/workflows/agent-evals.yml
@@ -48,6 +48,20 @@ jobs:
           path: results/
           retention-days: 30
 
+      # Catastrophic-failure check is independent of drift comparison. The
+      # trigger is zero passing cases. The most likely cause for that is
+      # infrastructure failure (model id removed upstream, expired key, proxy
+      # outage), not a real regression. Runs whether or not a baseline exists.
+      - name: Check for catastrophic failure
+        id: infra
+        if: hashFiles('results/eval-latest.json') != ''
+        run: |
+          set +e
+          node test/evals/infra-check.js results/eval-latest.json \
+            | tee infra-output.txt \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
       # Drift detection only runs once a baseline is checked in. Before then,
       # the workflow just produces and uploads results.
       - name: Diff vs baseline
@@ -104,6 +118,49 @@ jobs:
               --body-file "$BODY_FILE"
           fi
 
-      - name: Fail on regression
-        if: steps.diff.outputs.exit_code == '1'
+      # Separate alarm from drift, with a distinct title so the two issue
+      # streams are independent. Uses the same find-or-create pattern.
+      - name: Open or update infrastructure-failure issue
+        if: steps.infra.outputs.exit_code == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TITLE='Eval infrastructure failure'
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          BODY_FILE=$(mktemp)
+          {
+            echo "The daily Agent Evals cron run had zero passing cases. The most likely cause is an infrastructure failure (model id removed upstream, expired API key, proxy outage), not a real regression."
+            echo
+            echo "**Run:** [${{ github.run_id }}]($RUN_URL)"
+            echo "**Triggered by:** ${{ github.event_name }}"
+            echo
+            echo '```'
+            cat infra-output.txt
+            echo '```'
+            echo
+            echo "Download \`results/eval-latest.json\` from the run's artifacts for the full per-case detail."
+          } > "$BODY_FILE"
+
+          EXISTING=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --label auto:evals \
+            --search "\"$TITLE\" in:title" \
+            --json number \
+            --jq '.[0].number')
+
+          if [ -n "$EXISTING" ]; then
+            echo "Updating existing issue #$EXISTING"
+            gh issue comment "$EXISTING" --repo "${{ github.repository }}" --body-file "$BODY_FILE"
+          else
+            echo "Opening new infrastructure-failure issue"
+            gh issue create \
+              --repo "${{ github.repository }}" \
+              --title "$TITLE" \
+              --label auto:evals \
+              --body-file "$BODY_FILE"
+          fi
+
+      - name: Fail on regression or catastrophic failure
+        if: steps.diff.outputs.exit_code == '1' || steps.infra.outputs.exit_code == '1'
         run: exit 1

--- a/test/evals/infra-check.js
+++ b/test/evals/infra-check.js
@@ -1,0 +1,147 @@
+/* eslint-disable n/no-process-exit */
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file Catastrophic-failure detector for eval runs.
+ *
+ * A catastrophic run is one where zero cases passed. The most common cause is
+ * an infrastructure failure (model id removed upstream, expired API key,
+ * proxy outage), not a real eval regression. Drift detection in diff.js is
+ * about pass-rate deltas; this script is the separate alarm for the
+ * "nothing worked at all" case.
+ *
+ * Usage: node test/evals/infra-check.js <results.json>
+ *
+ * Exit codes: 0 = not catastrophic (or no results file); 1 = catastrophic;
+ * 2 = bad input.
+ */
+
+import fs from 'node:fs'
+
+const USAGE = 'Usage: node test/evals/infra-check.js <results.json>'
+
+/**
+ * Truncates a string for display, with a trailing ellipsis when shortened.
+ * @param {string} s
+ * @param {number} max
+ * @returns {string}
+ */
+function truncate(s, max) {
+  if (s.length <= max) {
+    return s
+  }
+  return s.slice(0, max - 1) + '…'
+}
+
+/**
+ * Collects every error message from a results object, regardless of whether
+ * the run was bucketed as TRANSIENT or FAIL (with an "Agent error:" body).
+ * @param {object} data - Parsed eval results JSON.
+ * @returns {string[]}
+ */
+function collectErrorMessages(data) {
+  const messages = []
+  for (const evaluation of data.evaluations || []) {
+    for (const run of evaluation.runs || []) {
+      if (run.transient && typeof run.transient.message === 'string') {
+        messages.push(run.transient.message)
+        continue
+      }
+      if (typeof run.responseText === 'string' && run.responseText.startsWith('Agent error:')) {
+        messages.push(run.responseText)
+      }
+    }
+  }
+  return messages
+}
+
+/**
+ * Groups identical message prefixes and returns the top N by count.
+ * @param {string[]} messages
+ * @param {number} topN
+ * @returns {{ prefix: string, count: number }[]}
+ */
+function topMessages(messages, topN) {
+  const counts = new Map()
+  for (const msg of messages) {
+    const prefix = truncate(msg, 240)
+    counts.set(prefix, (counts.get(prefix) || 0) + 1)
+  }
+  return [...counts.entries()]
+    .map(([prefix, count]) => ({ prefix, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, topN)
+}
+
+/**
+ * CLI entry point.
+ * @returns {void}
+ */
+function main() {
+  const args = process.argv.slice(2)
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(USAGE)
+    process.exit(0)
+  }
+  if (args.length !== 1) {
+    console.error(`infra-check: expected 1 argument, got ${args.length}\n${USAGE}`)
+    process.exit(2)
+  }
+
+  const [resultsPath] = args
+  let raw
+  try {
+    raw = fs.readFileSync(resultsPath, 'utf8')
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      console.error(`infra-check: results file not found: ${resultsPath}`)
+      process.exit(2)
+    }
+    throw err
+  }
+  const data = JSON.parse(raw)
+
+  const summary = data.summary || {}
+  const { passed = 0, failed = 0, transient = 0, total = 0 } = summary
+  if (total === 0) {
+    console.error('infra-check: results contain zero runs; nothing to check')
+    process.exit(2)
+  }
+
+  if (passed > 0) {
+    process.exit(0)
+  }
+
+  const errors = collectErrorMessages(data)
+  const top = topMessages(errors, 3)
+
+  console.log(`Catastrophic eval failure: 0 of ${total} cases passed.`)
+  console.log(`Breakdown: ${passed} pass, ${failed} fail, ${transient} transient.`)
+  console.log('')
+  if (top.length === 0) {
+    console.log('No agent or judge error messages were recorded against the failing runs.')
+    console.log('Likely cause is a non-API failure path; inspect the raw results file.')
+  } else {
+    console.log(`Most common error message${top.length === 1 ? '' : 's'}:`)
+    for (const { prefix, count } of top) {
+      console.log(`  (${count}×) ${prefix}`)
+    }
+  }
+  process.exit(1)
+}
+
+main()

--- a/test/evals/lib/agent.js
+++ b/test/evals/lib/agent.js
@@ -25,7 +25,7 @@ limitations under the License.
 import { GoogleGenerativeAI } from '@google/generative-ai'
 import { buildServerInstructions } from '../../../lib/knowledge/instructions.js'
 
-const MODEL_NAME = 'gemini-2.5-flash'
+const MODEL_NAME = 'gemini-3.1-flash-lite-preview'
 const MAX_TURNS = 15
 
 /**

--- a/test/evals/run.js
+++ b/test/evals/run.js
@@ -272,7 +272,10 @@ async function main() {
           transient = { source: TransientSource.AGENT, message: agentOutcome.error.message }
         }
       } catch (err) {
-        responseText = `Agent error: ${err.message}`
+        // A non-retryable upstream error (404, auth, bad request) is an
+        // infrastructure failure, not an eval result. Pass-rate is over
+        // PASS+FAIL only; with transient set, the case is not counted.
+        transient = { source: TransientSource.AGENT, message: `Agent error: ${err.message}` }
       }
 
       const actualToolNames = toolCalls.map(tc => tc.name)


### PR DESCRIPTION
## Summary

- Repoint eval agent model from retired `gemini-2.5-flash` to `gemini-3.1-flash-lite-preview` (the model the judge already uses)
- Classify non-retryable agent errors as TRANSIENT so a fully broken run is INCONCLUSIVE, not a noisy drift regression
- Add a separate catastrophic-failure detector and a separate "Eval infrastructure failure" issue stream, with the dominant error message in the body

## Why

The Agent Evals cron has been red since 2026-05-09. Every case 404'd against `gemini-2.5-flash`, which is no longer in the v1beta ListModels response. The runner classified each 404 as FAIL (the `catch` block at `run.js:274-276` wrote the error string to `responseText`; the judge then judged the error string and predictably failed it). FAIL is in the pass-rate denominator, so the run was indistinguishable from a real regression in the diff even though the model never ran. The drift-issue comments contained only `0% pass rate`, a list of every case ID, and no error message context.

Two structural problems followed:

1. Without a fix, the same noise recurs on the next model-id removal. The fix is to bucket non-retryable agent errors as TRANSIENT so the existing INCONCLUSIVE ceiling (>20% transient -> skip diff) handles them.
2. Even with INCONCLUSIVE skipping the drift comparison, a fully broken run is silent. The fix is a separate "catastrophic" detector that exits non-zero on `passed === 0`, with its own issue stream and the dominant error message in the body.

## Test plan

- [x] `node test/evals/infra-check.js .../eval-latest.json` exits 1 with a usable summary on the current broken artifact from run #25797101722 (`(101x) Agent error: ... 404 Not Found ...`)
- [x] `node --check` passes on all changed JS
- [x] `node test/evals/run.js --dry-run --id b01` still loads the eval config
- [ ] After merge: manual `workflow_dispatch` run against `main` to confirm green end-to-end
- [ ] Existing drift issue #194 can be closed once the next scheduled run succeeds
