### PR TITLE
feat(auth): wrapper pre-flight + cep_auth tool for agent-led sign-in

### DIFF
--- a/.github/expected-tarball.txt
+++ b/.github/expected-tarball.txt
@@ -45,6 +45,7 @@ lib/util/banner.js
 lib/util/cel_validator.js
 lib/util/chrome_dlp_constants.js
 lib/util/connector_policy_helper.js
+lib/util/credential/auth_login.js
 lib/util/credential/bearer_verifier.js
 lib/util/credential/cli_commands.js
 lib/util/credential/index.js
@@ -60,6 +61,7 @@ lib/util/logger.js
 mcp-server.js
 package.json
 prompts/README.md
+prompts/definitions/auth.js
 prompts/definitions/expert.js
 prompts/definitions/health.js
 prompts/definitions/optimize.js
@@ -67,6 +69,7 @@ prompts/definitions/shared.js
 prompts/index.js
 prompts/system-prompt.md
 tools/README.md
+tools/definitions/auth.js
 tools/definitions/check_and_enable_cep_api.js
 tools/definitions/check_cep_subscription.js
 tools/definitions/check_seb_extension_status.js

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ npm install
 Run `mcp auth login` and approve consent in the browser. The CLI caches
 the access token at `~/.config/cep-mcp/tokens.json`.
 
+If a tool call runs and the cached token has expired, the agent will
+offer to sign you in. It does this by calling the `cep_auth` tool, which
+opens a browser tab for consent and stores the new token in the same
+place.
+
 To use a custom OAuth client in a Cloud project of your own, set
 `CEP_OAUTH_CLIENT_ID` and `CEP_OAUTH_CLIENT_SECRET` and re-run
 `mcp auth login`. See

--- a/lib/util/credential/auth_login.js
+++ b/lib/util/credential/auth_login.js
@@ -1,0 +1,380 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file Shared building blocks for the agent-initiated sign-in flow.
+ *
+ * Two callers consume this module: the `cep_auth` tool (which runs the
+ * browser-and-loopback flow on behalf of the agent) and `tools/utils/wrapper.js`
+ * (which calls `isTokenLocallyValid` as a cheap pre-flight before every tool
+ * handler). The CLI keeps its own flow in `oauth_flow.js#runLoginFlow` because
+ * it reads the pasted redirect URL from stdin — something a tool handler in
+ * stdio mode cannot do (stdin is owned by the MCP transport).
+ */
+
+/* eslint-disable require-atomic-updates */
+/* `pendingAuth` is intentionally single-flight: a fresh `startToolAuth` replaces
+   any in-flight pending state, and `completeToolAuth` consumes it. The reassign-
+   after-await pattern that triggers this rule is the intended behavior. */
+
+import { randomBytes } from 'node:crypto'
+import { OAuth2Client } from 'google-auth-library'
+import { TokenCache } from './token_cache.js'
+import { startLoopbackServer } from './loopback_server.js'
+import { resolveOAuthClientConfig } from './oauth_client_config.js'
+import { defaultOpenBrowser } from './oauth_flow.js'
+import { SCOPES } from '../../constants.js'
+
+const DEFAULT_AWAIT_CALLBACK_MS = 90_000
+const PENDING_TTL_MS = 5 * 60 * 1000
+
+let pendingAuth = null
+
+/**
+ * @typedef {object} TokenValidity
+ * @property {boolean} ok True when the cache holds a non-expired access token.
+ * @property {'missing'|'expired'|'malformed'} [reason] The failure mode when `ok` is false.
+ * @property {Date|null} [expiresAt] The token's expiry timestamp, when known.
+ */
+
+/**
+ * Reads the OAuth token cache and reports whether it holds a usable access
+ * token. Local check only — does not call Google.
+ * @param {object} [opts] Optional overrides for tests.
+ * @param {number} [opts.now] The "now" timestamp in ms; defaults to Date.now().
+ * @param {string} [opts.cachePath] The cache file path; defaults to TokenCache.defaultPath().
+ * @returns {Promise<TokenValidity>} Whether the cache holds a usable token, and why not when not.
+ */
+export async function isTokenLocallyValid({ now = Date.now(), cachePath = TokenCache.defaultPath() } = {}) {
+  const cache = new TokenCache(cachePath)
+  const tokens = await cache.read()
+  if (!tokens) {
+    return { ok: false, reason: 'missing' }
+  }
+  if (!tokens.access_token) {
+    return { ok: false, reason: 'malformed' }
+  }
+  if (!tokens.expiry_date) {
+    return { ok: true, expiresAt: null }
+  }
+  const expiresAt = new Date(tokens.expiry_date)
+  if (expiresAt.getTime() < now) {
+    return { ok: false, reason: 'expired', expiresAt }
+  }
+  return { ok: true, expiresAt }
+}
+
+/**
+ * Reports whether this process can plausibly launch a desktop browser.
+ * Conservative — when in doubt, returns true and lets the launch attempt fail.
+ * @param {object} [opts] Optional overrides for tests.
+ * @param {object} [opts.env] The environment to inspect; defaults to process.env.
+ * @param {string} [opts.platform] The OS platform string; defaults to process.platform.
+ * @returns {boolean} True when a browser is likely launchable.
+ */
+export function canLaunchBrowser({ env = process.env, platform = process.platform } = {}) {
+  if (env.SSH_CONNECTION || env.SSH_TTY) {
+    return false
+  }
+  if (platform === 'linux' && !env.DISPLAY && !env.WAYLAND_DISPLAY) {
+    return false
+  }
+  return true
+}
+
+/**
+ * @typedef {object} StartToolAuthResult
+ * @property {'completed'|'awaiting'} status The outcome of the start call.
+ * @property {string} [authUrl] The consent URL; present when status is 'awaiting'.
+ * @property {boolean} [browserAttempted] Whether a browser launch was attempted; present when status is 'awaiting'.
+ * @property {boolean} [browserOpened] Whether a browser process spawned successfully; present when status is 'awaiting'.
+ * @property {'managed'|'custom'} [source] Which OAuth client was resolved.
+ * @property {Date|null} [expiresAt] For 'completed', when the new token expires; for 'awaiting', when this pending sign-in expires.
+ */
+
+/**
+ * Starts the agent-initiated sign-in flow. Generates state and PKCE, starts
+ * the loopback callback server, best-effort opens the browser, and waits a
+ * short window for the callback. If the callback fires within the window the
+ * code is exchanged and the cache written; otherwise the pending sign-in is
+ * stashed in module state and the caller receives the consent URL so the
+ * agent can prompt the user to paste it back.
+ * @param {object} [opts] Injection points for testability.
+ * @param {object} [opts.env] The environment; defaults to process.env.
+ * @param {(url: string) => Promise<boolean>} [opts.openBrowser] Best-effort browser launcher.
+ * @param {(args: {env: object}) => boolean} [opts.browserAvailable] Browser-availability check.
+ * @param {() => Promise<object>} [opts.startServer] Loopback-server factory.
+ * @param {(cfg: object) => OAuth2Client} [opts.oauth2ClientFactory] OAuth client factory.
+ * @param {(env: object) => object} [opts.configResolver] OAuth client-config resolver.
+ * @param {string} [opts.cachePath] Token cache path.
+ * @param {string[]} [opts.scopes] Scopes to request on the consent screen.
+ * @param {number} [opts.awaitCallbackMs] How long to wait for the callback before returning the paste-back path.
+ * @returns {Promise<StartToolAuthResult>} The flow result — either 'completed' (signed in) or 'awaiting' (URL ready for paste-back).
+ */
+export async function startToolAuth({
+  env = process.env,
+  openBrowser = defaultOpenBrowser,
+  browserAvailable = canLaunchBrowser,
+  startServer = startLoopbackServer,
+  oauth2ClientFactory = cfg => new OAuth2Client(cfg),
+  configResolver = resolveOAuthClientConfig,
+  cachePath = TokenCache.defaultPath(),
+  scopes = Object.values(SCOPES),
+  awaitCallbackMs = readTimeoutMs(env),
+} = {}) {
+  const config = configResolver(env)
+  if (pendingAuth) {
+    await pendingAuth.cancel().catch(() => {})
+    pendingAuth = null
+  }
+
+  const server = await startServer()
+  const oauth2 = oauth2ClientFactory({
+    clientId: config.clientId,
+    clientSecret: config.clientSecret,
+    redirectUri: server.redirectUri,
+  })
+  const { codeVerifier, codeChallenge } = await oauth2.generateCodeVerifierAsync()
+  const state = randomBytes(16).toString('hex')
+  const authUrl = oauth2.generateAuthUrl({
+    access_type: 'online',
+    prompt: 'consent',
+    scope: scopes,
+    state,
+    code_challenge: codeChallenge,
+    code_challenge_method: 'S256',
+  })
+
+  const pending = {
+    state,
+    codeVerifier,
+    oauth2,
+    server,
+    scopes,
+    cachePath,
+    expiresAt: Date.now() + PENDING_TTL_MS,
+    cancel: async () => {
+      try {
+        await server.stop()
+      } catch {
+        /* ignore */
+      }
+    },
+  }
+  pendingAuth = pending
+
+  const browserAttempted = browserAvailable({ env })
+  let browserOpened = false
+  if (browserAttempted) {
+    try {
+      browserOpened = (await openBrowser(authUrl)) === true
+    } catch {
+      browserOpened = false
+    }
+  }
+
+  const callbackPromise = server.waitForCode().then(r => ({ kind: 'callback', ...r }))
+  let timeoutHandle
+  const timeoutPromise = new Promise(resolve => {
+    timeoutHandle = setTimeout(() => resolve({ kind: 'timeout' }), awaitCallbackMs)
+  })
+  const winner = await Promise.race([callbackPromise, timeoutPromise])
+  clearTimeout(timeoutHandle)
+
+  if (winner.kind === 'callback') {
+    if (winner.error) {
+      pendingAuth = null
+      await pending.cancel()
+      throw mapCallbackError(winner.error)
+    }
+    if (winner.state !== state) {
+      pendingAuth = null
+      await pending.cancel()
+      throw makeError(
+        'STATE_MISMATCH',
+        'Sign-in failed: state mismatch. The callback came from a different sign-in attempt.',
+      )
+    }
+    if (!winner.code) {
+      pendingAuth = null
+      await pending.cancel()
+      throw makeError('NO_CODE', 'Sign-in failed: the callback URL had no `code` parameter.')
+    }
+    const tokens = await exchangeAndCache({ oauth2, code: winner.code, codeVerifier, scopes, cachePath })
+    pendingAuth = null
+    await pending.cancel()
+    return {
+      status: 'completed',
+      source: config.source,
+      expiresAt: tokens.expiry_date ? new Date(tokens.expiry_date) : null,
+    }
+  }
+
+  // Timeout — leave loopback running so a late callback or a pasted-back URL still works.
+  setTimeout(() => {
+    if (pendingAuth === pending) {
+      pendingAuth = null
+      pending.cancel()
+    }
+  }, PENDING_TTL_MS).unref?.()
+
+  return {
+    status: 'awaiting',
+    authUrl,
+    browserAttempted,
+    browserOpened,
+    source: config.source,
+    expiresAt: new Date(pending.expiresAt),
+  }
+}
+
+/**
+ * Completes the agent-initiated sign-in by exchanging a pasted-back redirect
+ * URL for a token. Requires a prior `startToolAuth` in the same process.
+ * @param {object} opts The completion parameters.
+ * @param {string} opts.redirectUrl The full URL the browser was redirected to.
+ * @returns {Promise<{status: 'completed', expiresAt: Date|null}>} The completion result.
+ * @throws {Error} With `.code` set to one of: NO_PENDING_AUTH, BAD_REDIRECT_URL, NO_CODE, STATE_MISMATCH, plus any error thrown by the token exchange.
+ */
+export async function completeToolAuth({ redirectUrl }) {
+  if (!pendingAuth) {
+    throw makeError('NO_PENDING_AUTH', 'No sign-in is in progress. Run the cep_auth tool with no arguments first.')
+  }
+  let parsed
+  try {
+    parsed = new URL(redirectUrl)
+  } catch {
+    throw makeError(
+      'BAD_REDIRECT_URL',
+      `That doesn't look like a redirect URL. Expected http://127.0.0.1:PORT/?code=...&state=... — got: ${truncate(redirectUrl, 80)}`,
+    )
+  }
+  const code = parsed.searchParams.get('code')
+  const returnedState = parsed.searchParams.get('state')
+  const callbackError = parsed.searchParams.get('error')
+  if (callbackError) {
+    throw mapCallbackError(callbackError)
+  }
+  if (!code) {
+    throw makeError(
+      'NO_CODE',
+      'No `code` parameter found in the URL. The full URL should contain `?code=...&state=...`.',
+    )
+  }
+  if (returnedState !== pendingAuth.state) {
+    throw makeError(
+      'STATE_MISMATCH',
+      'State mismatch. The URL is from a different sign-in attempt. Run the cep_auth tool with no arguments to start over.',
+    )
+  }
+  const pending = pendingAuth
+  const tokens = await exchangeAndCache({
+    oauth2: pending.oauth2,
+    code,
+    codeVerifier: pending.codeVerifier,
+    scopes: pending.scopes,
+    cachePath: pending.cachePath,
+  })
+  pendingAuth = null
+  await pending.cancel()
+  return {
+    status: 'completed',
+    expiresAt: tokens.expiry_date ? new Date(tokens.expiry_date) : null,
+  }
+}
+
+/**
+ * For tests: clears the module-scoped pending-auth state.
+ * @returns {Promise<void>} Resolves once any in-flight pending sign-in is cancelled.
+ */
+export async function _resetPendingAuthForTests() {
+  if (pendingAuth) {
+    await pendingAuth.cancel().catch(() => {})
+    pendingAuth = null
+  }
+}
+
+/**
+ * Exchanges an OAuth authorization code for tokens and writes them to the cache.
+ * @param {object} args The exchange parameters.
+ * @param {object} args.oauth2 The OAuth2Client to use for the exchange.
+ * @param {string} args.code The authorization code from the consent callback.
+ * @param {string} args.codeVerifier The PKCE code verifier matching the challenge sent at consent.
+ * @param {string[]} args.scopes The scopes requested at consent (persisted into the cache).
+ * @param {string} args.cachePath The token cache file path.
+ * @returns {Promise<object>} The token object returned by the exchange.
+ */
+async function exchangeAndCache({ oauth2, code, codeVerifier, scopes, cachePath }) {
+  const result = await oauth2.getToken({ code, codeVerifier })
+  const tokens = result.tokens
+  const cache = new TokenCache(cachePath)
+  await cache.write({ ...tokens, scope: scopes.join(' ') })
+  return tokens
+}
+
+/**
+ * Reads the callback-wait timeout from the environment, falling back to the default.
+ * @param {object} env The environment to read CEP_AUTH_TIMEOUT_MS from.
+ * @returns {number} The timeout in milliseconds.
+ */
+function readTimeoutMs(env) {
+  const raw = env.CEP_AUTH_TIMEOUT_MS
+  if (!raw) {
+    return DEFAULT_AWAIT_CALLBACK_MS
+  }
+  const n = Number(raw)
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_AWAIT_CALLBACK_MS
+}
+
+/**
+ * Creates an Error with a `.code` field for callers to switch on.
+ * @param {string} code The error code (e.g., 'STATE_MISMATCH').
+ * @param {string} message The human-readable error message.
+ * @returns {Error} The constructed error.
+ */
+function makeError(code, message) {
+  const err = new Error(message)
+  err.code = code
+  return err
+}
+
+/**
+ * Maps an OAuth callback `error=...` parameter to an Error with a stable code.
+ * @param {string} code The raw error parameter from the callback URL.
+ * @returns {Error} The mapped error.
+ */
+function mapCallbackError(code) {
+  if (code === 'access_denied') {
+    return makeError(
+      'ACCESS_DENIED',
+      'Consent declined. Run the cep_auth tool with no arguments when ready to try again.',
+    )
+  }
+  return makeError('CALLBACK_ERROR', `Sign-in failed at the consent step: ${code}`)
+}
+
+/**
+ * Returns the input truncated to at most `n` characters with a trailing ellipsis.
+ * @param {string} s The string to truncate.
+ * @param {number} n The maximum length before truncation.
+ * @returns {string} The truncated string.
+ */
+function truncate(s, n) {
+  if (typeof s !== 'string') {
+    return String(s)
+  }
+  return s.length > n ? `${s.slice(0, n)}...` : s
+}

--- a/lib/util/credential/oauth_flow.js
+++ b/lib/util/credential/oauth_flow.js
@@ -31,7 +31,7 @@ import { SCOPES, MANAGED_OAUTH_CLIENT_ID, MANAGED_OAUTH_CLIENT_SECRET } from '..
  * @param {string} url The URL to open.
  * @returns {Promise<void>} Resolves once the browser process spawns.
  */
-function defaultOpenBrowser(url) {
+export function defaultOpenBrowser(url) {
   let cmd
   let args
   if (process.env.BROWSER) {

--- a/prompts/definitions/auth.js
+++ b/prompts/definitions/auth.js
@@ -1,0 +1,56 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file Prompt definition for the '/cep:auth' command.
+ *
+ * Intentionally thin — the prompt just points the agent at the `cep_auth`
+ * tool, which does all the work.
+ */
+
+/**
+ * MCP prompt name for the sign-in command.
+ */
+export const AUTH_PROMPT_NAME = 'cep:auth'
+
+/**
+ * Registers the '/cep:auth' prompt with the MCP server.
+ * @param {import('@modelcontextprotocol/sdk/server/mcp.js').McpServer} server - The MCP server instance
+ */
+export const registerAuthPrompt = server => {
+  server.registerPrompt(
+    AUTH_PROMPT_NAME,
+    {
+      description: 'Sign in to the Chrome Enterprise Premium MCP server.',
+      arguments: [],
+    },
+    async () => ({
+      messages: [
+        {
+          role: 'user',
+          content: {
+            type: 'text',
+            text: `The user wants to sign in. Call the **cep_auth** tool with no arguments to start.
+
+- If the tool returns status="completed", the access token is cached and you're done.
+- If the tool returns status="awaiting" with nextAction="paste-redirect-url", show the user the authUrl from the response, ask them to open it in a browser and complete sign-in, then ask them to paste the full URL the browser is redirected to (it looks like \`http://127.0.0.1:PORT/?code=...&state=...\` and the page may show "connection refused" — that's expected). Call **cep_auth** again with that pasted URL as the redirectUrl argument.
+- If the tool returns status="error", relay the message to the user.`,
+          },
+        },
+      ],
+    }),
+  )
+}

--- a/prompts/index.js
+++ b/prompts/index.js
@@ -23,6 +23,7 @@ limitations under the License.
 import { registerHealthPrompt } from './definitions/health.js'
 import { registerOptimizePrompt } from './definitions/optimize.js'
 import { registerExpertPrompt } from './definitions/expert.js'
+import { registerAuthPrompt } from './definitions/auth.js'
 
 /**
  * Registers all prompts with the MCP server.
@@ -32,4 +33,5 @@ export function registerPrompts(server) {
   registerHealthPrompt(server)
   registerOptimizePrompt(server)
   registerExpertPrompt(server)
+  registerAuthPrompt(server)
 }

--- a/test/integration/server/mcp-server.test.js
+++ b/test/integration/server/mcp-server.test.js
@@ -75,6 +75,7 @@ describe('MCP Server in stdio mode', () => {
     assert.deepStrictEqual(
       toolNames.sort(),
       [
+        'cep_auth',
         'check_cep_subscription',
         'check_seb_extension_status',
         'check_user_cep_license',

--- a/test/integration/server/prompts.test.js
+++ b/test/integration/server/prompts.test.js
@@ -57,7 +57,7 @@ describe('MCP Prompts', () => {
     const result = await client.listPrompts()
     const promptNames = result.prompts.map(p => p.name).sort()
 
-    assert.deepStrictEqual(promptNames, ['cep:health', 'cep:expert', 'cep:optimize'].sort())
+    assert.deepStrictEqual(promptNames, ['cep:health', 'cep:expert', 'cep:optimize', 'cep:auth'].sort())
   })
 
   test('When cep:health prompt is requested, then it returns its content', async () => {
@@ -93,5 +93,14 @@ describe('MCP Prompts', () => {
 
     assert.ok(result.messages)
     assert.ok(result.messages[0].content.text.includes('Chrome Enterprise Premium (CEP) Technical Agent'))
+  })
+
+  test('When cep:auth prompt is requested, then it points the agent at the cep_auth tool', async () => {
+    const result = await client.getPrompt({ name: 'cep:auth' })
+
+    assert.ok(result.messages)
+    const text = result.messages[0].content.text
+    assert.match(text, /cep_auth/)
+    assert.match(text, /paste-redirect-url/)
   })
 })

--- a/test/local/auth-tool.test.js
+++ b/test/local/auth-tool.test.js
@@ -1,0 +1,134 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import assert from 'node:assert/strict'
+import { describe, test, mock, beforeEach } from 'node:test'
+import esmock from 'esmock'
+
+async function loadToolWithMocks({ startToolAuth, completeToolAuth }) {
+  return esmock('../../tools/definitions/auth.js', {
+    '../../lib/util/credential/auth_login.js': {
+      startToolAuth,
+      completeToolAuth,
+    },
+  })
+}
+
+describe('cep_auth Tool', () => {
+  let server
+  let handler
+
+  beforeEach(() => {
+    server = { registerTool: mock.fn() }
+    handler = null
+  })
+
+  async function register(mocks) {
+    const { registerAuthTool } = await loadToolWithMocks(mocks)
+    registerAuthTool(server)
+    const call = server.registerTool.mock.calls.find(c => c.arguments[0] === 'cep_auth')
+    assert.ok(call, 'cep_auth was not registered')
+    handler = call.arguments[2]
+  }
+
+  test('When cep_auth is invoked and the loopback callback completes during the wait, then it returns status=completed', async () => {
+    const future = new Date(Date.now() + 3_600_000)
+    const startToolAuth = mock.fn(async () => ({
+      status: 'completed',
+      source: 'managed',
+      expiresAt: future,
+    }))
+    const completeToolAuth = mock.fn()
+    await register({ startToolAuth, completeToolAuth })
+
+    const result = await handler({}, {})
+
+    assert.strictEqual(result.isError, undefined)
+    assert.strictEqual(result.structuredContent.status, 'completed')
+    assert.strictEqual(result.structuredContent.expiresAt, future.toISOString())
+    assert.match(result.content[0].text, /Signed in/)
+    assert.strictEqual(startToolAuth.mock.callCount(), 1)
+    assert.strictEqual(completeToolAuth.mock.callCount(), 0)
+  })
+
+  test('When cep_auth is invoked and the wait window expires, then it returns status=awaiting with the consent URL and paste-redirect-url next action', async () => {
+    const startToolAuth = mock.fn(async () => ({
+      status: 'awaiting',
+      authUrl: 'https://accounts.google.com/o/oauth2/v2/auth?state=ABC',
+      browserAttempted: false,
+      browserOpened: false,
+      expiresAt: new Date(Date.now() + 300_000),
+      source: 'managed',
+    }))
+    const completeToolAuth = mock.fn()
+    await register({ startToolAuth, completeToolAuth })
+
+    const result = await handler({}, {})
+
+    assert.strictEqual(result.structuredContent.status, 'awaiting')
+    assert.strictEqual(result.structuredContent.nextAction, 'paste-redirect-url')
+    assert.strictEqual(result.structuredContent.authUrl, 'https://accounts.google.com/o/oauth2/v2/auth?state=ABC')
+    assert.ok(result.structuredContent.agentHint?.length > 0)
+    assert.match(result.content[0].text, /Open this URL/)
+    assert.match(result.content[0].text, /accounts\.google\.com/)
+  })
+
+  test('When cep_auth is invoked with a valid redirectUrl, then it calls completeToolAuth and returns status=completed', async () => {
+    const future = new Date(Date.now() + 3_600_000)
+    const startToolAuth = mock.fn()
+    const completeToolAuth = mock.fn(async () => ({ status: 'completed', expiresAt: future }))
+    await register({ startToolAuth, completeToolAuth })
+
+    const result = await handler({ redirectUrl: 'http://127.0.0.1:55555/?code=ABC&state=XYZ' }, {})
+
+    assert.strictEqual(result.structuredContent.status, 'completed')
+    assert.strictEqual(completeToolAuth.mock.callCount(), 1)
+    assert.deepStrictEqual(completeToolAuth.mock.calls[0].arguments, [
+      { redirectUrl: 'http://127.0.0.1:55555/?code=ABC&state=XYZ' },
+    ])
+    assert.strictEqual(startToolAuth.mock.callCount(), 0)
+  })
+
+  test('When cep_auth fails internally, then it returns isError=true and forwards the error code in structuredContent', async () => {
+    const startToolAuth = mock.fn()
+    const completeToolAuth = mock.fn(async () => {
+      const err = new Error('State mismatch.')
+      err.code = 'STATE_MISMATCH'
+      throw err
+    })
+    await register({ startToolAuth, completeToolAuth })
+
+    const result = await handler({ redirectUrl: 'http://127.0.0.1:1/?code=x&state=wrong' }, {})
+
+    assert.strictEqual(result.isError, true)
+    assert.strictEqual(result.structuredContent.status, 'error')
+    assert.strictEqual(result.structuredContent.code, 'STATE_MISMATCH')
+    assert.match(result.content[0].text, /Sign-in failed/)
+  })
+
+  test('When cep_auth is invoked with an inbound Bearer token, then it refuses with a BEARER_INBOUND error', async () => {
+    const startToolAuth = mock.fn()
+    const completeToolAuth = mock.fn()
+    await register({ startToolAuth, completeToolAuth })
+
+    const result = await handler({}, { requestInfo: { headers: { authorization: 'Bearer abc' } } })
+
+    assert.strictEqual(result.isError, true)
+    assert.strictEqual(result.structuredContent.code, 'BEARER_INBOUND')
+    assert.strictEqual(startToolAuth.mock.callCount(), 0)
+    assert.strictEqual(completeToolAuth.mock.callCount(), 0)
+  })
+})

--- a/test/local/auth_login.test.js
+++ b/test/local/auth_login.test.js
@@ -1,0 +1,379 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import assert from 'node:assert/strict'
+import { describe, test, beforeEach, afterEach } from 'node:test'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import os from 'node:os'
+import {
+  isTokenLocallyValid,
+  canLaunchBrowser,
+  startToolAuth,
+  completeToolAuth,
+  _resetPendingAuthForTests,
+} from '../../lib/util/credential/auth_login.js'
+
+function tmpCachePath() {
+  return path.join(os.tmpdir(), `cep-auth-login-test-${process.pid}-${Math.random().toString(16).slice(2)}.json`)
+}
+
+async function writeCache(cachePath, body) {
+  await fs.mkdir(path.dirname(cachePath), { recursive: true })
+  await fs.writeFile(cachePath, JSON.stringify(body), { mode: 0o600 })
+}
+
+describe('isTokenLocallyValid', () => {
+  let cachePath
+  beforeEach(() => {
+    cachePath = tmpCachePath()
+  })
+  afterEach(async () => {
+    await fs.unlink(cachePath).catch(() => {})
+  })
+
+  test('When the cache file is missing, then it returns { ok: false, reason: missing }', async () => {
+    const result = await isTokenLocallyValid({ cachePath })
+    assert.deepStrictEqual(result, { ok: false, reason: 'missing' })
+  })
+
+  test('When the cache has no access_token, then it returns { ok: false, reason: malformed }', async () => {
+    await writeCache(cachePath, { expiry_date: Date.now() + 60_000 })
+    const result = await isTokenLocallyValid({ cachePath })
+    assert.deepStrictEqual(result, { ok: false, reason: 'malformed' })
+  })
+
+  test('When the cache has an expired access_token, then it returns { ok: false, reason: expired } with the expiry date', async () => {
+    const expired = Date.now() - 5_000
+    await writeCache(cachePath, { access_token: 'tok', expiry_date: expired })
+    const result = await isTokenLocallyValid({ cachePath })
+    assert.strictEqual(result.ok, false)
+    assert.strictEqual(result.reason, 'expired')
+    assert.ok(result.expiresAt instanceof Date)
+    assert.strictEqual(result.expiresAt.getTime(), expired)
+  })
+
+  test('When the cache has a fresh access_token, then it returns { ok: true } with the expiry date', async () => {
+    const future = Date.now() + 60_000
+    await writeCache(cachePath, { access_token: 'tok', expiry_date: future })
+    const result = await isTokenLocallyValid({ cachePath })
+    assert.strictEqual(result.ok, true)
+    assert.strictEqual(result.expiresAt.getTime(), future)
+  })
+
+  test('When the cache has an access_token without expiry_date, then it returns { ok: true, expiresAt: null }', async () => {
+    await writeCache(cachePath, { access_token: 'tok' })
+    const result = await isTokenLocallyValid({ cachePath })
+    assert.deepStrictEqual(result, { ok: true, expiresAt: null })
+  })
+})
+
+describe('canLaunchBrowser', () => {
+  test('When SSH_CONNECTION is set, then it returns false', () => {
+    assert.strictEqual(canLaunchBrowser({ env: { SSH_CONNECTION: '10.0.0.1 22' }, platform: 'darwin' }), false)
+  })
+
+  test('When SSH_TTY is set, then it returns false', () => {
+    assert.strictEqual(canLaunchBrowser({ env: { SSH_TTY: '/dev/pts/0' }, platform: 'linux' }), false)
+  })
+
+  test('When the platform is Linux without DISPLAY or WAYLAND_DISPLAY, then it returns false', () => {
+    assert.strictEqual(canLaunchBrowser({ env: {}, platform: 'linux' }), false)
+  })
+
+  test('When the platform is Linux with DISPLAY, then it returns true', () => {
+    assert.strictEqual(canLaunchBrowser({ env: { DISPLAY: ':0' }, platform: 'linux' }), true)
+  })
+
+  test('When the platform is darwin without SSH, then it returns true', () => {
+    assert.strictEqual(canLaunchBrowser({ env: {}, platform: 'darwin' }), true)
+  })
+
+  test('When the platform is win32 without SSH, then it returns true', () => {
+    assert.strictEqual(canLaunchBrowser({ env: {}, platform: 'win32' }), true)
+  })
+})
+
+/* Shared fakes for the startToolAuth / completeToolAuth tests. */
+function makeFakeServer({ codePromise } = {}) {
+  let stopped = false
+  return {
+    redirectUri: 'http://127.0.0.1:55555/',
+    waitForCode: () => codePromise ?? new Promise(() => {}),
+    stop: async () => {
+      stopped = true
+    },
+    wasStopped: () => stopped,
+  }
+}
+
+function makeFakeOAuth2Client({ codeVerifier = 'V', codeChallenge = 'C', authUrl = 'https://auth/' } = {}) {
+  const calls = { getToken: [] }
+  return {
+    client: {
+      async generateCodeVerifierAsync() {
+        return { codeVerifier, codeChallenge }
+      },
+      generateAuthUrl(opts) {
+        calls.lastAuthUrlOpts = opts
+        return `${authUrl}?state=${opts.state}&challenge=${opts.code_challenge}`
+      },
+      async getToken({ code, codeVerifier: cv }) {
+        calls.getToken.push({ code, codeVerifier: cv })
+        return { tokens: { access_token: 'tok-' + code, expiry_date: Date.now() + 3_600_000, token_type: 'Bearer' } }
+      },
+    },
+    calls,
+  }
+}
+
+const FAKE_CONFIG = { clientId: 'fake-client', clientSecret: 'fake-secret', source: 'managed' }
+
+describe('startToolAuth', () => {
+  let cachePath
+  beforeEach(async () => {
+    cachePath = tmpCachePath()
+    await _resetPendingAuthForTests()
+  })
+  afterEach(async () => {
+    await _resetPendingAuthForTests()
+    await fs.unlink(cachePath).catch(() => {})
+  })
+
+  test('When startToolAuth times out before the callback fires, then it returns status=awaiting with the consent URL', async () => {
+    const { client } = makeFakeOAuth2Client()
+    const server = makeFakeServer({ codePromise: new Promise(() => {}) /* never resolves */ })
+    const result = await startToolAuth({
+      env: { SSH_CONNECTION: 'x' /* force headless */ },
+      browserAvailable: () => false,
+      openBrowser: async () => false,
+      startServer: async () => server,
+      oauth2ClientFactory: () => client,
+      configResolver: () => FAKE_CONFIG,
+      cachePath,
+      scopes: ['scope-a'],
+      awaitCallbackMs: 25,
+    })
+    assert.strictEqual(result.status, 'awaiting')
+    assert.match(result.authUrl, /state=[a-f0-9]{32}/)
+    assert.match(result.authUrl, /challenge=C/)
+    assert.strictEqual(result.browserAttempted, false)
+    assert.strictEqual(result.browserOpened, false)
+  })
+
+  test('When the loopback callback fires before timeout with a matching state, then it exchanges the code and writes the cache', async () => {
+    const { client, calls } = makeFakeOAuth2Client()
+    let receivedState
+    const codePromise = new Promise(resolve => {
+      // Resolve once we know the generated state.
+      setImmediate(() => {
+        resolve({ code: 'good-code', state: receivedState })
+      })
+    })
+    const server = makeFakeServer({ codePromise })
+    /* Capture the state generated by the auth URL so the fake callback echoes it back. */
+    const captureClient = {
+      ...client,
+      generateAuthUrl(opts) {
+        receivedState = opts.state
+        return client.generateAuthUrl(opts)
+      },
+    }
+    const result = await startToolAuth({
+      env: { SSH_CONNECTION: 'x' },
+      browserAvailable: () => false,
+      openBrowser: async () => false,
+      startServer: async () => server,
+      oauth2ClientFactory: () => captureClient,
+      configResolver: () => FAKE_CONFIG,
+      cachePath,
+      scopes: ['scope-a'],
+      awaitCallbackMs: 1000,
+    })
+    assert.strictEqual(result.status, 'completed')
+    assert.strictEqual(calls.getToken.length, 1)
+    assert.strictEqual(calls.getToken[0].code, 'good-code')
+    const cached = JSON.parse(await fs.readFile(cachePath, 'utf8'))
+    assert.strictEqual(cached.access_token, 'tok-good-code')
+    assert.strictEqual(cached.scope, 'scope-a')
+  })
+
+  test('When the loopback callback returns a mismatched state, then startToolAuth rejects without writing the cache', async () => {
+    const { client } = makeFakeOAuth2Client()
+    const codePromise = Promise.resolve({ code: 'evil', state: 'attacker-state' })
+    const server = makeFakeServer({ codePromise })
+    await assert.rejects(
+      startToolAuth({
+        env: { SSH_CONNECTION: 'x' },
+        browserAvailable: () => false,
+        openBrowser: async () => false,
+        startServer: async () => server,
+        oauth2ClientFactory: () => client,
+        configResolver: () => FAKE_CONFIG,
+        cachePath,
+        scopes: ['scope-a'],
+        awaitCallbackMs: 1000,
+      }),
+      err => err.code === 'STATE_MISMATCH',
+    )
+    const exists = await fs
+      .stat(cachePath)
+      .then(() => true)
+      .catch(() => false)
+    assert.strictEqual(exists, false)
+  })
+
+  test('When the loopback callback returns access_denied, then startToolAuth rejects with ACCESS_DENIED', async () => {
+    const { client } = makeFakeOAuth2Client()
+    const codePromise = Promise.resolve({ error: 'access_denied' })
+    const server = makeFakeServer({ codePromise })
+    await assert.rejects(
+      startToolAuth({
+        env: { SSH_CONNECTION: 'x' },
+        browserAvailable: () => false,
+        openBrowser: async () => false,
+        startServer: async () => server,
+        oauth2ClientFactory: () => client,
+        configResolver: () => FAKE_CONFIG,
+        cachePath,
+        scopes: ['scope-a'],
+        awaitCallbackMs: 1000,
+      }),
+      err => err.code === 'ACCESS_DENIED',
+    )
+  })
+})
+
+describe('completeToolAuth', () => {
+  let cachePath
+  beforeEach(async () => {
+    cachePath = tmpCachePath()
+    await _resetPendingAuthForTests()
+  })
+  afterEach(async () => {
+    await _resetPendingAuthForTests()
+    await fs.unlink(cachePath).catch(() => {})
+  })
+
+  test('When completeToolAuth is called with no pending sign-in, then it rejects with NO_PENDING_AUTH', async () => {
+    await assert.rejects(
+      completeToolAuth({ redirectUrl: 'http://127.0.0.1:1/?code=x&state=y' }),
+      err => err.code === 'NO_PENDING_AUTH',
+    )
+  })
+
+  test('When completeToolAuth receives a valid redirectUrl after a pending sign-in, then it exchanges the code and writes the cache', async () => {
+    const { client, calls } = makeFakeOAuth2Client()
+    let capturedState
+    const captureClient = {
+      ...client,
+      generateAuthUrl(opts) {
+        capturedState = opts.state
+        return client.generateAuthUrl(opts)
+      },
+    }
+    const server = makeFakeServer({ codePromise: new Promise(() => {}) })
+    await startToolAuth({
+      env: { SSH_CONNECTION: 'x' },
+      browserAvailable: () => false,
+      openBrowser: async () => false,
+      startServer: async () => server,
+      oauth2ClientFactory: () => captureClient,
+      configResolver: () => FAKE_CONFIG,
+      cachePath,
+      scopes: ['scope-a'],
+      awaitCallbackMs: 25,
+    })
+    const result = await completeToolAuth({
+      redirectUrl: `http://127.0.0.1:55555/?code=pasted-code&state=${capturedState}`,
+    })
+    assert.strictEqual(result.status, 'completed')
+    assert.strictEqual(calls.getToken[0].code, 'pasted-code')
+    assert.strictEqual(calls.getToken[0].codeVerifier, 'V')
+    const cached = JSON.parse(await fs.readFile(cachePath, 'utf8'))
+    assert.strictEqual(cached.access_token, 'tok-pasted-code')
+  })
+
+  test('When completeToolAuth receives a redirectUrl with a mismatched state, then it rejects with STATE_MISMATCH and leaves the cache alone', async () => {
+    const { client } = makeFakeOAuth2Client()
+    const server = makeFakeServer({ codePromise: new Promise(() => {}) })
+    await startToolAuth({
+      env: { SSH_CONNECTION: 'x' },
+      browserAvailable: () => false,
+      openBrowser: async () => false,
+      startServer: async () => server,
+      oauth2ClientFactory: () => client,
+      configResolver: () => FAKE_CONFIG,
+      cachePath,
+      scopes: ['scope-a'],
+      awaitCallbackMs: 25,
+    })
+    await assert.rejects(
+      completeToolAuth({ redirectUrl: 'http://127.0.0.1:1/?code=x&state=wrong' }),
+      err => err.code === 'STATE_MISMATCH',
+    )
+    const exists = await fs
+      .stat(cachePath)
+      .then(() => true)
+      .catch(() => false)
+    assert.strictEqual(exists, false)
+  })
+
+  test('When completeToolAuth receives an unparseable redirectUrl, then it rejects with BAD_REDIRECT_URL', async () => {
+    const { client } = makeFakeOAuth2Client()
+    const server = makeFakeServer({ codePromise: new Promise(() => {}) })
+    await startToolAuth({
+      env: { SSH_CONNECTION: 'x' },
+      browserAvailable: () => false,
+      openBrowser: async () => false,
+      startServer: async () => server,
+      oauth2ClientFactory: () => client,
+      configResolver: () => FAKE_CONFIG,
+      cachePath,
+      scopes: ['scope-a'],
+      awaitCallbackMs: 25,
+    })
+    await assert.rejects(completeToolAuth({ redirectUrl: 'not a url' }), err => err.code === 'BAD_REDIRECT_URL')
+  })
+
+  test('When completeToolAuth receives a redirectUrl carrying an error parameter, then it rejects with the mapped code', async () => {
+    const { client } = makeFakeOAuth2Client()
+    let capturedState
+    const captureClient = {
+      ...client,
+      generateAuthUrl(opts) {
+        capturedState = opts.state
+        return client.generateAuthUrl(opts)
+      },
+    }
+    const server = makeFakeServer({ codePromise: new Promise(() => {}) })
+    await startToolAuth({
+      env: { SSH_CONNECTION: 'x' },
+      browserAvailable: () => false,
+      openBrowser: async () => false,
+      startServer: async () => server,
+      oauth2ClientFactory: () => captureClient,
+      configResolver: () => FAKE_CONFIG,
+      cachePath,
+      scopes: ['scope-a'],
+      awaitCallbackMs: 25,
+    })
+    await assert.rejects(
+      completeToolAuth({ redirectUrl: `http://127.0.0.1:1/?error=access_denied&state=${capturedState}` }),
+      err => err.code === 'ACCESS_DENIED',
+    )
+  })
+})

--- a/test/local/tool-registration.test.js
+++ b/test/local/tool-registration.test.js
@@ -24,6 +24,7 @@ import { registerTools } from '../../tools/index.js'
 import { FLAGS } from '../../lib/util/feature_flags.js'
 
 const CORE_TOOLS = [
+  'cep_auth',
   'check_and_enable_cep_api',
   'check_cep_subscription',
   'check_seb_extension_status',

--- a/test/local/utils.test.js
+++ b/test/local/utils.test.js
@@ -15,10 +15,49 @@ limitations under the License.
 */
 
 import assert from 'node:assert/strict'
-import { describe, test, mock, beforeEach } from 'node:test'
+import { describe, test, mock, beforeEach, afterEach } from 'node:test'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import os from 'node:os'
 import { validateAndGetOrgUnitId, resolveRootOrgUnitId } from '../../tools/utils/org-unit.js'
 import { commonTransform, guardedToolCall } from '../../tools/utils/wrapper.js'
 import { registerTools } from '../../tools/index.js'
+
+/* The wrapper now runs a local pre-flight against ~/.config/cep-mcp/tokens.json
+   before invoking the handler. Tests that exercise handler-side behavior
+   redirect HOME (or APPDATA on Windows) to a temp dir holding a synthetic
+   valid cache, so the pre-flight passes through. */
+function installSyntheticValidCache() {
+  const homeKey = process.platform === 'win32' ? 'APPDATA' : 'HOME'
+  const saved = process.env[homeKey]
+  const dir = path.join(os.tmpdir(), `cep-mcp-test-home-${process.pid}-${Math.random().toString(16).slice(2)}`)
+  const cacheDir = process.platform === 'win32' ? path.join(dir, 'cep-mcp') : path.join(dir, '.config', 'cep-mcp')
+  const cachePath = path.join(cacheDir, 'tokens.json')
+  return {
+    async setup() {
+      process.env[homeKey] = dir
+      await fs.mkdir(cacheDir, { recursive: true })
+      await fs.writeFile(
+        cachePath,
+        JSON.stringify({
+          access_token: 'synthetic-test-token',
+          token_type: 'Bearer',
+          scope: 'https://www.googleapis.com/auth/userinfo.email',
+          expiry_date: Date.now() + 3_600_000,
+        }),
+        { mode: 0o600 },
+      )
+    },
+    async teardown() {
+      if (saved === undefined) {
+        delete process.env[homeKey]
+      } else {
+        process.env[homeKey] = saved
+      }
+      await fs.rm(dir, { recursive: true, force: true })
+    },
+  }
+}
 
 describe('Tool Utils', () => {
   describe('commonTransform', () => {
@@ -47,11 +86,18 @@ describe('Tool Utils', () => {
 
   describe('guardedToolCall Infrastructure', () => {
     let server
+    let cacheFixture
 
-    beforeEach(() => {
+    beforeEach(async () => {
+      cacheFixture = installSyntheticValidCache()
+      await cacheFixture.setup()
       server = {
         registerTool: mock.fn(),
       }
+    })
+
+    afterEach(async () => {
+      await cacheFixture.teardown()
     })
 
     describe('Registration and Auto-Resolution', () => {
@@ -260,4 +306,114 @@ describe('Tool Utils', () => {
       assert.deepStrictEqual(result, customResponse)
     })
   })
+
+  /* eslint-disable require-atomic-updates */
+  /* The pre-flight tests serialize their own HOME-override setup and teardown
+     inside try/finally blocks; the lint rule's "process.env reassigned after
+     await" warnings are not actual races for these strictly-serial tests. */
+  describe('guardedToolCall Auth Pre-flight', () => {
+    let cacheFixture
+    let handler
+
+    beforeEach(async () => {
+      handler = mock.fn(async () => ({ content: [{ type: 'text', text: 'ok' }] }))
+    })
+
+    afterEach(async () => {
+      if (cacheFixture) {
+        await cacheFixture.teardown()
+        cacheFixture = null
+      }
+    })
+
+    test('When guardedToolCall runs with no inbound Bearer and no cached token, then it returns an authRequired response and does not invoke the handler', async () => {
+      const homeKey = process.platform === 'win32' ? 'APPDATA' : 'HOME'
+      const saved = process.env[homeKey]
+      const emptyHome = path.join(
+        os.tmpdir(),
+        `cep-mcp-empty-home-${process.pid}-${Math.random().toString(16).slice(2)}`,
+      )
+      await fs.mkdir(emptyHome, { recursive: true })
+      process.env[homeKey] = emptyHome
+      try {
+        const tool = guardedToolCall({ handler })
+        const result = await tool({}, {})
+        assert.strictEqual(result.isError, true)
+        assert.match(result.content[0].text, /Sign-in is needed/)
+        assert.match(result.content[0].text, /cep_auth/)
+        assert.strictEqual(result.structuredContent.authRequired.reason, 'missing')
+        assert.strictEqual(result.structuredContent.authRequired.nextAction, 'invoke-cep_auth')
+        assert.match(result.structuredContent.authRequired.docsUrl, /configuration\.md#authenticate-to-google-apis/)
+        assert.strictEqual(handler.mock.callCount(), 0)
+      } finally {
+        if (saved === undefined) {
+          delete process.env[homeKey]
+        } else {
+          process.env[homeKey] = saved
+        }
+        await fs.rm(emptyHome, { recursive: true, force: true })
+      }
+    })
+
+    test('When guardedToolCall runs with no inbound Bearer and an expired cached token, then the authRequired response carries reason=expired and the expiry timestamp', async () => {
+      const homeKey = process.platform === 'win32' ? 'APPDATA' : 'HOME'
+      const saved = process.env[homeKey]
+      const home = path.join(os.tmpdir(), `cep-mcp-expired-home-${process.pid}-${Math.random().toString(16).slice(2)}`)
+      const cacheDir = process.platform === 'win32' ? path.join(home, 'cep-mcp') : path.join(home, '.config', 'cep-mcp')
+      const cachePath = path.join(cacheDir, 'tokens.json')
+      const expiredAt = Date.now() - 60_000
+      await fs.mkdir(cacheDir, { recursive: true })
+      await fs.writeFile(cachePath, JSON.stringify({ access_token: 'stale', expiry_date: expiredAt }), { mode: 0o600 })
+      process.env[homeKey] = home
+      try {
+        const tool = guardedToolCall({ handler })
+        const result = await tool({}, {})
+        assert.strictEqual(result.isError, true)
+        assert.strictEqual(result.structuredContent.authRequired.reason, 'expired')
+        assert.strictEqual(result.structuredContent.authRequired.expiresAt, new Date(expiredAt).toISOString())
+        assert.strictEqual(handler.mock.callCount(), 0)
+      } finally {
+        if (saved === undefined) {
+          delete process.env[homeKey]
+        } else {
+          process.env[homeKey] = saved
+        }
+        await fs.rm(home, { recursive: true, force: true })
+      }
+    })
+
+    test('When guardedToolCall runs with an inbound Bearer token and no cache, then it skips the pre-flight and invokes the handler', async () => {
+      const homeKey = process.platform === 'win32' ? 'APPDATA' : 'HOME'
+      const saved = process.env[homeKey]
+      const emptyHome = path.join(
+        os.tmpdir(),
+        `cep-mcp-bearer-skip-home-${process.pid}-${Math.random().toString(16).slice(2)}`,
+      )
+      await fs.mkdir(emptyHome, { recursive: true })
+      process.env[homeKey] = emptyHome
+      try {
+        const tool = guardedToolCall({ handler })
+        const result = await tool({}, { requestInfo: { headers: { authorization: 'Bearer xyz' } } })
+        assert.strictEqual(handler.mock.callCount(), 1)
+        assert.strictEqual(result.content[0].text, 'ok')
+      } finally {
+        if (saved === undefined) {
+          delete process.env[homeKey]
+        } else {
+          process.env[homeKey] = saved
+        }
+        await fs.rm(emptyHome, { recursive: true, force: true })
+      }
+    })
+
+    test('When guardedToolCall runs with no inbound Bearer and a fresh cached token, then it invokes the handler', async () => {
+      cacheFixture = installSyntheticValidCache()
+      await cacheFixture.setup()
+      const tool = guardedToolCall({ handler })
+      const result = await tool({}, {})
+      assert.strictEqual(handler.mock.callCount(), 1)
+      assert.strictEqual(result.content[0].text, 'ok')
+    })
+  })
+  /* eslint-enable require-atomic-updates */
 })

--- a/test/run-integration.js
+++ b/test/run-integration.js
@@ -34,6 +34,8 @@ limitations under the License.
 import { join, resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
 import { findTestFiles } from './run-utils.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -43,6 +45,28 @@ const root = resolve(__dirname, '..')
 if (!process.env.CEP_LOG_LEVEL) {
   process.env.CEP_LOG_LEVEL = 'SILENT'
 }
+
+/* Tool-wrapper pre-flight reads ~/.config/cep-mcp/tokens.json before every
+   handler call. Redirect HOME so integration tests see a synthetic valid
+   cache instead of the dev's real (possibly expired) one. */
+const homeKey = process.platform === 'win32' ? 'APPDATA' : 'HOME'
+const fakeHome = fs.mkdtempSync(join(os.tmpdir(), 'cep-mcp-integration-home-'))
+const cacheDir = process.platform === 'win32' ? join(fakeHome, 'cep-mcp') : join(fakeHome, '.config', 'cep-mcp')
+fs.mkdirSync(cacheDir, { recursive: true })
+fs.writeFileSync(
+  join(cacheDir, 'tokens.json'),
+  JSON.stringify({
+    access_token: 'synthetic-integration-test-token',
+    token_type: 'Bearer',
+    scope: 'https://www.googleapis.com/auth/userinfo.email',
+    expiry_date: Date.now() + 3_600_000,
+  }),
+  { mode: 0o600 },
+)
+process.env[homeKey] = fakeHome
+process.on('exit', () => {
+  fs.rmSync(fakeHome, { recursive: true, force: true })
+})
 
 const backend = process.argv[2] || 'fake'
 

--- a/test/run-unit.js
+++ b/test/run-unit.js
@@ -28,6 +28,8 @@ limitations under the License.
 import { join, resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
 import { findTestFiles } from './run-utils.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -37,6 +39,30 @@ const root = resolve(__dirname, '..')
 if (!process.env.CEP_LOG_LEVEL) {
   process.env.CEP_LOG_LEVEL = 'SILENT'
 }
+
+/* Tool-wrapper pre-flight check (lib/util/credential/auth_login.js#isTokenLocallyValid)
+   reads the OAuth cache before every handler call. Redirect HOME (or APPDATA on
+   Windows) to a temp directory holding a synthetic valid cache so handler-side
+   tests don't depend on the dev's real cache state. Tests that target the
+   pre-flight itself override HOME inside their own setup. */
+const homeKey = process.platform === 'win32' ? 'APPDATA' : 'HOME'
+const fakeHome = fs.mkdtempSync(join(os.tmpdir(), 'cep-mcp-unit-home-'))
+const cacheDir = process.platform === 'win32' ? join(fakeHome, 'cep-mcp') : join(fakeHome, '.config', 'cep-mcp')
+fs.mkdirSync(cacheDir, { recursive: true })
+fs.writeFileSync(
+  join(cacheDir, 'tokens.json'),
+  JSON.stringify({
+    access_token: 'synthetic-unit-test-token',
+    token_type: 'Bearer',
+    scope: 'https://www.googleapis.com/auth/userinfo.email',
+    expiry_date: Date.now() + 3_600_000,
+  }),
+  { mode: 0o600 },
+)
+process.env[homeKey] = fakeHome
+process.on('exit', () => {
+  fs.rmSync(fakeHome, { recursive: true, force: true })
+})
 
 const testDirs = [join(root, 'test', 'local'), join(root, 'test', 'unit')]
 let testFiles = []

--- a/tools/definitions/auth.js
+++ b/tools/definitions/auth.js
@@ -1,0 +1,154 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file Tool definition for the agent-initiated sign-in flow (`cep_auth`).
+ *
+ * Not wrapped with `guardedToolCall` — that wrapper performs the auth
+ * pre-flight check and would refuse to invoke this tool when the cache is
+ * empty, which is exactly when this tool is needed.
+ */
+
+import { z } from 'zod'
+import { TAGS } from '../../lib/constants.js'
+import { logger } from '../../lib/util/logger.js'
+import { startToolAuth, completeToolAuth } from '../../lib/util/credential/auth_login.js'
+
+const TOOL_NAME = 'cep_auth'
+
+const AGENT_HINT =
+  'Show the user the authUrl and ask them to open it in a browser. After the browser is ' +
+  'redirected to a 127.0.0.1 URL (the page may show "connection refused" — that is expected), ' +
+  'ask the user to paste that full URL back. Then call cep_auth again with the pasted URL as ' +
+  'the redirectUrl argument.'
+
+/**
+ * Registers the `cep_auth` tool with the MCP server.
+ * @param {import('@modelcontextprotocol/sdk/server/mcp.js').McpServer} server The MCP server instance.
+ */
+export function registerAuthTool(server) {
+  logger.debug(`${TAGS.MCP} Registering '${TOOL_NAME}' tool...`)
+  server.registerTool(
+    TOOL_NAME,
+    {
+      description:
+        'Sign in to Google so the server can call the Workspace APIs. Call with no arguments to start. ' +
+        'If the response says nextAction is "paste-redirect-url", ask the user to paste the URL the ' +
+        'browser was redirected to, then call cep_auth again with that string as the redirectUrl argument.',
+      inputSchema: {
+        redirectUrl: z
+          .string()
+          .optional()
+          .describe(
+            'The full URL the browser was redirected to after consent (looks like http://127.0.0.1:PORT/?code=...&state=...). Omit to start a fresh sign-in.',
+          ),
+      },
+      outputSchema: z
+        .object({
+          status: z.enum(['completed', 'awaiting', 'error']),
+          authUrl: z.string().optional(),
+          nextAction: z.string().optional(),
+          message: z.string().optional(),
+          expiresAt: z.string().optional(),
+        })
+        .passthrough(),
+    },
+    async ({ redirectUrl }, context) => {
+      if (context?.requestInfo?.headers?.authorization) {
+        const msg =
+          'This server received an inbound Bearer token, so sign-in via cep_auth does not apply. ' +
+          'Refresh the Bearer token through your MCP client.'
+        return {
+          content: [{ type: 'text', text: msg }],
+          structuredContent: { status: 'error', code: 'BEARER_INBOUND', message: msg },
+          isError: true,
+        }
+      }
+      try {
+        if (redirectUrl !== undefined && redirectUrl !== '') {
+          const result = await completeToolAuth({ redirectUrl })
+          return successResponse(result)
+        }
+        const result = await startToolAuth({})
+        if (result.status === 'completed') {
+          return successResponse(result)
+        }
+        return awaitingResponse(result)
+      } catch (err) {
+        logger.error(`${TAGS.MCP} cep_auth failed:`, err?.message || err)
+        const message = err?.message || String(err)
+        return {
+          content: [{ type: 'text', text: `Sign-in failed: ${message}` }],
+          structuredContent: { status: 'error', code: err?.code, message },
+          isError: true,
+        }
+      }
+    },
+  )
+}
+
+/**
+ * Builds the "you're signed in" response.
+ * @param {{expiresAt?: Date|null, source?: string}} result The completed-auth result.
+ * @returns {object} MCP tool response with status=completed.
+ */
+function successResponse(result) {
+  const expiresAt = result.expiresAt instanceof Date ? result.expiresAt.toISOString() : null
+  const tail = expiresAt ? ` Token expires at ${expiresAt}.` : ''
+  return {
+    content: [{ type: 'text', text: `Signed in.${tail}` }],
+    structuredContent: { status: 'completed', expiresAt: expiresAt ?? undefined, source: result.source },
+  }
+}
+
+/**
+ * Builds the "waiting on the user to paste the URL back" response.
+ * @param {{authUrl: string, browserOpened: boolean, browserAttempted: boolean, expiresAt?: Date|null, source?: string}} result The awaiting-auth result.
+ * @returns {object} MCP tool response with status=awaiting and nextAction=paste-redirect-url.
+ */
+function awaitingResponse(result) {
+  const lines = []
+  if (result.browserOpened) {
+    lines.push('A browser tab should have opened for sign-in.')
+    lines.push(
+      "Once the browser is redirected to a 127.0.0.1 URL (the page may show a connection error — that's fine), paste that full URL back so the sign-in can complete.",
+    )
+    lines.push('')
+    lines.push('If the browser did not open, the consent URL is:')
+  } else {
+    lines.push('Open this URL in a browser and complete sign-in:')
+  }
+  lines.push('')
+  lines.push(result.authUrl)
+  lines.push('')
+  lines.push(
+    "Then paste the full URL the browser was redirected to (it looks like http://127.0.0.1:PORT/?code=...&state=...; the page may show a connection error — that's expected).",
+  )
+  const expiresAt = result.expiresAt instanceof Date ? result.expiresAt.toISOString() : undefined
+  return {
+    content: [{ type: 'text', text: lines.join('\n') }],
+    structuredContent: {
+      status: 'awaiting',
+      authUrl: result.authUrl,
+      nextAction: 'paste-redirect-url',
+      browserAttempted: result.browserAttempted,
+      browserOpened: result.browserOpened,
+      expiresAt,
+      source: result.source,
+      agentHint: AGENT_HINT,
+    },
+  }
+}

--- a/tools/index.js
+++ b/tools/index.js
@@ -45,6 +45,7 @@ import { registerCheckAndEnableCepApiTool } from './definitions/check_and_enable
 import { registerEnableChromeEnterpriseConnectorsTool } from './definitions/enable_chrome_enterprise_connectors.js'
 import { registerDiagnoseEnvironmentTool } from './definitions/diagnose_environment.js'
 import { registerKnowledgeTools } from './definitions/knowledge.js'
+import { registerAuthTool } from './definitions/auth.js'
 import { featureFlags, FLAGS } from '../lib/util/feature_flags.js'
 
 /**
@@ -113,4 +114,5 @@ export function registerTools(server, options = {}, sessionState) {
   }
 
   registerKnowledgeTools(server, { ...options, featureFlags: flags }, state)
+  registerAuthTool(server)
 }

--- a/tools/utils/wrapper.js
+++ b/tools/utils/wrapper.js
@@ -21,6 +21,38 @@ limitations under the License.
 import { TAGS } from '../../lib/constants.js'
 import { logger } from '../../lib/util/logger.js'
 import { validateAndGetOrgUnitId } from './org-unit.js'
+import { isTokenLocallyValid } from '../../lib/util/credential/auth_login.js'
+
+const MANUAL_AUTH_COMMAND = 'npx -y @google/chrome-enterprise-premium-mcp@latest auth login'
+const AUTH_DOCS_URL =
+  'https://github.com/google/chrome-enterprise-premium-mcp/blob/main/docs/configuration.md#authenticate-to-google-apis'
+
+/**
+ * Builds an MCP tool response signalling that sign-in is needed before any tool can run.
+ * @param {{reason: 'missing'|'expired'|'malformed', expiresAt?: Date|null}} validity The reason the pre-flight failed.
+ * @returns {object} MCP tool response with isError: true.
+ */
+function buildAuthRequiredResponse({ reason, expiresAt }) {
+  const reasonLabel = reason === 'expired' ? 'expired' : reason === 'malformed' ? 'unreadable' : 'missing'
+  const expiredAtNote = reason === 'expired' && expiresAt ? ` (expired at ${expiresAt.toISOString()})` : ''
+  const text =
+    `Sign-in is needed before this tool can run. The cached OAuth token is ${reasonLabel}${expiredAtNote}. ` +
+    'I can run the `cep_auth` tool to sign you in, or you can run ' +
+    `\`${MANUAL_AUTH_COMMAND}\` yourself.`
+  return {
+    content: [{ type: 'text', text }],
+    structuredContent: {
+      authRequired: {
+        reason,
+        expiresAt: expiresAt instanceof Date ? expiresAt.toISOString() : undefined,
+        nextAction: 'invoke-cep_auth',
+        manualCommand: MANUAL_AUTH_COMMAND,
+        docsUrl: AUTH_DOCS_URL,
+      },
+    },
+    isError: true,
+  }
+}
 
 /**
  * Generates a proactive remediation message for authentication errors.
@@ -40,12 +72,12 @@ function getAuthRemediationMessage(status, bearerInbound = false) {
   }
 
   if (status === 401) {
-    return 'Authentication required. Run `mcp auth login` to authorize the server (it caches the access token at ~/.config/cep-mcp/tokens.json), or set GOOGLE_APPLICATION_CREDENTIALS to a service-account key file.'
+    return 'Authentication required. Run the `cep_auth` tool to sign in, or run `mcp auth login` at the shell to authorize the server (it caches the access token at ~/.config/cep-mcp/tokens.json). To use a service account, set GOOGLE_APPLICATION_CREDENTIALS to a service-account key file.'
   }
 
   return `Permission denied. Your account lacks the required permissions or the necessary Google Cloud APIs are not enabled.
 
-1. **Re-authenticate with all required scopes:** Run \`mcp auth login\` to re-consent. The required scope set is defined in lib/constants.js#SCOPES.
+1. **Re-authenticate with all required scopes:** Run the \`cep_auth\` tool, or run \`mcp auth login\` at the shell, to re-consent. The required scope set is defined in lib/constants.js#SCOPES.
 2. **Verify APIs are enabled:** Run the \`check_and_enable_cep_api\` tool against your project, or enable the API set listed in lib/constants.js#SERVICE_NAMES.`
 }
 
@@ -132,6 +164,12 @@ export function guardedToolCall(
 ) {
   return async (params, context) => {
     const authToken = getAuthToken(context?.requestInfo)
+    if (!authToken) {
+      const validity = await isTokenLocallyValid()
+      if (!validity.ok) {
+        return buildAuthRequiredResponse(validity)
+      }
+    }
     try {
       const { apiClients, apiOptions } = options
       let currentParams = { ...params }


### PR DESCRIPTION
Adds a pre-flight check to `guardedToolCall` and a `cep_auth` tool the agent can call to sign the user in.

Before each tool handler, `guardedToolCall` reads `~/.config/cep-mcp/tokens.json` and compares `expiry_date` with the current time. If the token is missing or expired, the wrapper short-circuits the handler and returns a structured `authRequired` response: `reason`, `expiresAt`, `nextAction: invoke-cep_auth`, the `mcp auth login` shell command, and a docs URL. Updated the wrapper's post-401/403 text to mention `cep_auth` alongside `mcp auth login`.

The `cep_auth` tool exposes the installed-app OAuth flow that `mcp auth login` uses. Called with no arguments, it starts a loopback callback server, builds a consent URL with PKCE and a random `state`, opens the user's browser, and waits 90 seconds (`CEP_AUTH_TIMEOUT_MS`) for the callback. On success: code exchanged, cache written, `status: completed`. On timeout or headless host: `status: awaiting` with the consent URL and `nextAction: paste-redirect-url`; the loopback server stays bound for the five-minute `PENDING_TTL_MS`. On the agent's second call with `redirectUrl` set, the tool verifies `state`, parses the code, and completes the exchange.

`bin/cli.js auth login` is unchanged. The CLI's paste-back step reads from stdin, and stdio's MCP transport consumes stdin, so the CLI and the tool reuse helpers from `lib/util/credential/auth_login.js` but run different top-level flows. Registered a `/cep:auth` prompt alongside the existing `cep:*` prompts; its body contains instructions for the agent to call `cep_auth`.

## Prior art

The Workspace Gemini CLI extension's [`secure-browser-launcher.ts`](https://github.com/gemini-cli-extensions/workspace/blob/main/workspace-server/src/utils/secure-browser-launcher.ts) covers the same case. Three differences from this repo's `oauth_flow.js#defaultOpenBrowser`:

- Validates URL protocol (`http:` or `https:`) and uses `execFile` rather than a shell.
- Falls back across `xdg-open`, `gnome-open`, `kde-open`, `firefox`, `chromium`, and `google-chrome` on Linux, each with a five-second timeout.
- Headless heuristic also covers `CI`, `DEBIAN_FRONTEND=noninteractive`, a `BROWSER` blocklist, and `MIR_SOCKET`.

`cep_auth` calls `defaultOpenBrowser`, the same function `mcp auth login` calls, so browser-launch behavior is identical across the tool and CLI paths. To adopt Workspace's checks, change `defaultOpenBrowser`, not `cep_auth`.

## Test plan

- `npm run test:unit`: 435 pass / 0 fail. 29 BDD tests added across `auth_login`, `cep_auth`, and the wrapper pre-flight.
- `npm run test:integration:fake`: 28 pass / 3 skipped / 0 fail.
- `npm test`: green.
- Manual happy path: cleared the cache, ran a tool, accepted the sign-in offer, completed the browser flow, re-ran the tool.
- Manual headless: paste-back round-trip over SSH.

## Stacks on

PR #175 (`feat/npm-scripts`). After `#169 → #171 → #173 → #175` merge, GitHub re-bases this onto `main`.