### PR TITLE
test: add exact version matching check for gemini-extension.json

### DIFF
--- a/test/local/extension_version.test.js
+++ b/test/local/extension_version.test.js
@@ -30,6 +30,11 @@ test('gemini-extension.json package version matches package.json version', () =>
   const extensionJson = JSON.parse(fs.readFileSync(extensionJsonPath, 'utf8'))
 
   const currentVersion = packageJson.version
+  assert.strictEqual(
+    extensionJson.version,
+    currentVersion,
+    `gemini-extension.json version (${extensionJson.version}) must exactly match package.json version (${currentVersion})`,
+  )
 
   const args = extensionJson.mcpServers['chrome-enterprise-premium'].args
   assert.ok(Array.isArray(args), 'args must be an array')


### PR DESCRIPTION
Adds a strict version matching assertion between `package.json` and `gemini-extension.json` to ensure the extension metadata stays perfectly in sync.