### PR TITLE
fix(commitlint): disable body-max-line-length

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -16,4 +16,9 @@ limitations under the License.
 
 export default {
   extends: ['@commitlint/config-conventional'],
+  rules: {
+    // Dependabot bodies (release-notes URLs, dependency tables) and human
+    // commits that paste stack traces or URLs routinely exceed 100 chars.
+    'body-max-line-length': [0, 'always'],
+  },
 }


### PR DESCRIPTION
## Summary
- Disables `body-max-line-length` in `commitlint.config.js`.
- Dependabot's auto-generated bodies (release-notes URLs, dependency tables) routinely exceed the default 100-char limit, causing the **📝 Conventional commits** check to fail (e.g. #182). Human commits pasting stack traces or long URLs hit the same rule.
- The subject-level rules (`type-empty`, `subject-empty`, etc.) remain enforced — only the body line-length is relaxed.

## Test plan
- [ ] CI: this PR's own commit body is short, but the `commitlint-github-action` should pick up the new rule for subsequent PRs.
- [ ] Verify the next Dependabot PR passes the conventional-commits check.