### PR TITLE
feat(scripts): add npm run auth:login and auth:status

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,8 @@ npm install
 
 ```bash
 npm start             # Stdio mode (default)
+npm run auth:login    # Run the OAuth flow against the bundled or custom client
+npm run auth:status   # Show OAuth credential status
 npm run mcp-inspector # MCP Inspector (browser-based debugging UI)
 ```
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "prompts/"
   ],
   "scripts": {
+    "auth:login": "node bin/cli.js auth login",
+    "auth:status": "node bin/cli.js auth status",
     "eval": "CEP_BACKEND=fake node test/evals/run.js",
     "eval:agentic": "CEP_BACKEND=fake node test/evals/run.js --category inspection,troubleshooting,mutation,discovery,connectors",
     "eval:boundary": "CEP_BACKEND=fake node test/evals/run.js --category boundary",


### PR DESCRIPTION
## Summary
Re-bases the original change from #175 (which was merged into the `feat/oauth-docs` branch instead of `main`, so the scripts never actually landed). Cherry-pick of `9b3541b` onto a fresh branch from `main`.

Adds two `package.json` scripts plus a matching note in `CONTRIBUTING.md`:
- `npm run auth:login` → `node bin/cli.js auth login`
- `npm run auth:status` → `node bin/cli.js auth status`

Lets local-checkout contributors run the OAuth CLI without having to invoke `node bin/cli.js auth ...` directly. Installed users still get the `mcp` shim from the `bin` entry.

## Test plan
- [ ] `npm run auth:status` prints the expected status line.
- [ ] `npm run auth:login` opens the OAuth flow.