### PR TITLE
ci(release-please): add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
Adds `workflow_dispatch:` to the release-please workflow so it can be re-triggered manually from the Actions tab or via `gh workflow run release-please` — without needing a fresh push to main.

Useful when release-please state gets out of sync (e.g. after fixing the `autorelease: pending` → `autorelease: tagged` label mismatch).

## Test plan
- [ ] After merge, run `gh workflow run release-please -R google/chrome-enterprise-premium-mcp` and confirm a manual run appears in the Actions tab.