### PR TITLE
ci: opt into Node 24 runner for JavaScript actions to resolve deprecation warning

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,6 +9,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   release-please:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Resolves the GitHub Actions deprecation warning for Node 20 runners (`actions/create-github-app-token@v1` and `googleapis/release-please-action@v4`) by explicitly opting into the Node 24 runner via `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`.