### PR TITLE
fix(ci): install from public npm registry; only use Wombat for publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,12 +10,19 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+      # Install from the public npm registry. The Wombat Dressing Room only
+      # proxies packages this org has explicitly allowlisted, so using it for
+      # `npm ci` 404s on common dev deps (e.g. zod-to-json-schema).
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      # Re-run setup-node to point auth at Wombat for `npm publish` only.
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
           registry-url: 'https://wombat-dressing-room.appspot.com/'
-          cache: 'npm'
-      - run: npm ci
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.WOMBAT_NPM_PACKAGE_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,13 +15,13 @@ jobs:
       # `npm ci` 404s on common dev deps (e.g. zod-to-json-schema).
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       # Re-run setup-node to point auth at Wombat for `npm publish` only.
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://wombat-dressing-room.appspot.com/'
       - run: npm publish --access public
         env:


### PR DESCRIPTION
## Summary
The npm-publish job set Wombat Dressing Room as the registry for the entire job, which made \`npm ci\` route through Wombat and 404 on packages that aren't allowlisted there (e.g. \`zod-to-json-schema@3.25.2\`). Latest failure: https://github.com/google/chrome-enterprise-premium-mcp/actions/runs/25893075172/job/76100257998

Splits into two \`setup-node\` invocations: install from the public npm registry, then re-set the registry to Wombat for the publish step (where the auth token applies).

## Test plan
- [ ] Next release triggers npm-publish; \`npm ci\` succeeds and the publish step still authenticates against Wombat.