### PR TITLE
test(knowledge): stub axios in unit-suite knowledge_search tests

### DIFF
--- a/test/local/knowledge_search.test.js
+++ b/test/local/knowledge_search.test.js
@@ -14,21 +14,42 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { describe, test } from 'node:test'
+import { describe, test, before } from 'node:test'
 import assert from 'node:assert/strict'
-import { registerKnowledgeTools } from '../../tools/definitions/knowledge.js'
+import esmock from 'esmock'
 
 describe('Knowledge Tools Real Database Integration', () => {
   const handlers = {}
-  const server = {
-    registerTool: (name, description, handler) => {
-      handlers[name] = handler
-    },
-  }
+  const fetched = []
 
-  // Register tools using the default construction path (lib/knowledge directory)
-  // Enable search tools experiment flag for these tests.
-  registerKnowledgeTools(server, { featureFlags: { isEnabled: () => true } }, {})
+  // Stub axios so get_document never reaches Helpcenter — that hop is slow,
+  // racy, and dominates the unit-suite budget. The HTML we return is the
+  // smallest payload that includes the substrings the assertions probe for.
+  const stubHtml = `
+    <html><body>
+      <h1>Chrome Enterprise Premium</h1>
+      <p>Deep scanning protection settings live under Chrome Enterprise Security Services.</p>
+    </body></html>
+  `
+
+  before(async () => {
+    const { registerKnowledgeTools } = await esmock('../../tools/definitions/knowledge.js', {
+      axios: {
+        default: {
+          get: async url => {
+            fetched.push(url)
+            return { data: stubHtml }
+          },
+        },
+      },
+    })
+    const server = {
+      registerTool: (name, description, handler) => {
+        handlers[name] = handler
+      },
+    }
+    registerKnowledgeTools(server, { featureFlags: { isEnabled: () => true } }, {})
+  })
 
   test('When searched for Licensing, then search_content finds the overview document', async () => {
     const handler = handlers['search_content']


### PR DESCRIPTION
## Summary
The test `When searched for configurable timeouts, then search_content finds the dedicated article` was reaching Helpcenter via `axios.get` with a 10s ceiling. On slower CI runners it timed out, fell back to local stub content (which lacks the body text), and the substring assertion failed (e.g. https://github.com/google/chrome-enterprise-premium-mcp/actions/runs/25893158436).

This PR stubs `axios` via `esmock` so `get_document` never reaches the network during the unit suite. The canned HTML carries the substrings each assertion probes for. Suite duration drops from `~10s timeout-flake` to `~165ms`. No coverage lost — the `cleanHtml` + filename-resolution + tool-registration paths still exercise the real code; only the network hop is mocked.

## Test plan
- [x] `node --test test/local/knowledge_search.test.js` → 5/5 pass in 165ms.
- [x] Full `npm test` passes.