### PR TITLE
fix(ci): format gemini-extension.json; widen lint-staged to JSON+YAML

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -6,10 +6,7 @@
   "mcpServers": {
     "chrome-enterprise-premium": {
       "command": "npx",
-      "args": [
-        "-y",
-        "@google/chrome-enterprise-premium-mcp@^1.4.0"
-      ]
+      "args": ["-y", "@google/chrome-enterprise-premium-mcp@^1.4.0"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "lint-staged": {
     "*.{js,ts}": "eslint --fix",
-    "*.md": "prettier --write"
+    "*.{json,md,yml,yaml}": "prettier --write"
   },
   "dependencies": {
     "@dotenvx/dotenvx": "^1.66.0",


### PR DESCRIPTION
## Summary
The presubmit script runs `prettier --check .` on the entire tree, but the `lint-staged` config only ran prettier on `*.md`. JSON/YAML edits could land on `main` un-formatted, then trip presubmit later (most recently: `gemini-extension.json`).

Two changes:
- Reformat `gemini-extension.json` to satisfy the existing `prettier --check` gate.
- Expand the lint-staged glob from `*.md` to `*.{json,md,yml,yaml}` so JSON/YAML drift is caught at commit time.

## Test plan
- [x] `npx prettier --check .` passes locally.
- [x] `npm test` passes locally.
- [x] Verified the broadened lint-staged glob fires on this PR's own commit (the husky output above ran prettier on `package.json` and `gemini-extension.json` via the new `*.{json,md,yml,yaml}` rule).