### PR TITLE
test(sse): stub req.on in createSseHandler principal-forwarding test

### DIFF
--- a/test/unit/mcp-server-state-isolation.test.js
+++ b/test/unit/mcp-server-state-isolation.test.js
@@ -119,7 +119,7 @@ describe('HTTP per-request session state isolation', () => {
     const sseTransports = {}
     const handler = createSseHandler({}, sseTransports, recorder)
     const principal = { email: 'admin@example.com', sub: '12345', aud: 'a', iss: 'https://accounts.google.com' }
-    const fakeReq = { verifiedPrincipal: principal }
+    const fakeReq = { on: () => {}, verifiedPrincipal: principal }
     const fakeRes = { on: () => {}, headersSent: false }
 
     await handler(fakeReq, fakeRes)


### PR DESCRIPTION
## Summary
The sister test `createSseHandler passes a distinct sessionState to getServer per request` uses `fakeReq = { on: () => {} }`; the principal-forwarding test omitted the stub. Currently passes because the handler path under test doesn't call `req.on`, but the inconsistent stub would silently start failing if the handler ever attached a request listener. Match the pattern.

## Test plan
- [x] `node --test test/unit/mcp-server-state-isolation.test.js` — 6/6 pass.