### PR TITLE
chore(release-please): include chore/ci/docs/refactor/test in changelog

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,6 +9,16 @@
           "path": "gemini-extension.json",
           "jsonpath": "$.version"
         }
+      ],
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "chore", "section": "Miscellaneous Chores", "hidden": false },
+        { "type": "ci", "section": "Continuous Integration", "hidden": false },
+        { "type": "docs", "section": "Documentation", "hidden": false },
+        { "type": "refactor", "section": "Code Refactoring", "hidden": false },
+        { "type": "test", "section": "Tests", "hidden": false }
       ]
     }
   }


### PR DESCRIPTION
## Summary
By default release-please only surfaces `feat:` and `fix:` commits in the release notes; `chore:`, `ci:`, `docs:`, `refactor:`, `test:` are silently dropped. Recent example: PR #222 (release v1.5.1) shows only the one `fix(ci):` commit, even though `chore(deps): eslint 9 -> 10` and `ci: opt into Node 24 runner` also landed.

Adds an explicit `changelog-sections` block so non-`feat`/`fix` work shows up in the release PR. This does not affect version-bump behavior (only `feat`/`fix`/breaking still bump the version) — it just makes the changelog complete.

## Test plan
- [ ] After merge, the next push to main triggers release-please; the resulting/updated release PR includes sections for any `chore`/`ci`/`docs`/`refactor`/`test` commits since v1.5.1.