### PR TITLE
refactor(test): extract synthetic-cache setup into a shared helper

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -6,10 +6,7 @@
   "mcpServers": {
     "chrome-enterprise-premium": {
       "command": "npx",
-      "args": [
-        "-y",
-        "@google/chrome-enterprise-premium-mcp@^1.4.0"
-      ]
+      "args": ["-y", "@google/chrome-enterprise-premium-mcp@^1.4.0"]
     }
   }
 }

--- a/test/helpers/synthetic_token_cache.js
+++ b/test/helpers/synthetic_token_cache.js
@@ -1,0 +1,52 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import fs from 'node:fs'
+import os from 'node:os'
+import { join } from 'node:path'
+import { SCOPES } from '../../lib/constants.js'
+
+/**
+ * Redirects HOME (or APPDATA on Windows) to a temp directory containing a
+ * synthetic, valid OAuth token cache covering the full required scope set,
+ * and registers a cleanup hook for process exit. Used by test runners so the
+ * tool-wrapper pre-flight in `lib/util/credential/auth_login.js#isTokenLocallyValid`
+ * passes without reading the dev's real cache. Tests that target the
+ * pre-flight itself override HOME inside their own setup.
+ * @param {string} prefix - mkdtemp prefix used to disambiguate concurrent runners (e.g. 'cep-mcp-unit-home-').
+ * @returns {string} The fake HOME path that was written.
+ */
+export function setupSyntheticTokenCache(prefix) {
+  const homeKey = process.platform === 'win32' ? 'APPDATA' : 'HOME'
+  const fakeHome = fs.mkdtempSync(join(os.tmpdir(), prefix))
+  const cacheDir = process.platform === 'win32' ? join(fakeHome, 'cep-mcp') : join(fakeHome, '.config', 'cep-mcp')
+  fs.mkdirSync(cacheDir, { recursive: true })
+  fs.writeFileSync(
+    join(cacheDir, 'tokens.json'),
+    JSON.stringify({
+      access_token: 'synthetic-test-token',
+      token_type: 'Bearer',
+      scope: Object.values(SCOPES).join(' '),
+      expiry_date: Date.now() + 3_600_000,
+    }),
+    { mode: 0o600 },
+  )
+  process.env[homeKey] = fakeHome
+  process.on('exit', () => {
+    fs.rmSync(fakeHome, { recursive: true, force: true })
+  })
+  return fakeHome
+}

--- a/test/run-integration.js
+++ b/test/run-integration.js
@@ -34,10 +34,8 @@ limitations under the License.
 import { join, resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { execFileSync } from 'node:child_process'
-import fs from 'node:fs'
-import os from 'node:os'
 import { findTestFiles } from './run-utils.js'
-import { SCOPES } from '../lib/constants.js'
+import { setupSyntheticTokenCache } from './helpers/synthetic_token_cache.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const root = resolve(__dirname, '..')
@@ -47,27 +45,7 @@ if (!process.env.CEP_LOG_LEVEL) {
   process.env.CEP_LOG_LEVEL = 'SILENT'
 }
 
-/* Tool-wrapper pre-flight reads ~/.config/cep-mcp/tokens.json before every
-   handler call. Redirect HOME so integration tests see a synthetic valid
-   cache instead of the dev's real (possibly expired) one. */
-const homeKey = process.platform === 'win32' ? 'APPDATA' : 'HOME'
-const fakeHome = fs.mkdtempSync(join(os.tmpdir(), 'cep-mcp-integration-home-'))
-const cacheDir = process.platform === 'win32' ? join(fakeHome, 'cep-mcp') : join(fakeHome, '.config', 'cep-mcp')
-fs.mkdirSync(cacheDir, { recursive: true })
-fs.writeFileSync(
-  join(cacheDir, 'tokens.json'),
-  JSON.stringify({
-    access_token: 'synthetic-integration-test-token',
-    token_type: 'Bearer',
-    scope: Object.values(SCOPES).join(' '),
-    expiry_date: Date.now() + 3_600_000,
-  }),
-  { mode: 0o600 },
-)
-process.env[homeKey] = fakeHome
-process.on('exit', () => {
-  fs.rmSync(fakeHome, { recursive: true, force: true })
-})
+setupSyntheticTokenCache('cep-mcp-integration-home-')
 
 const backend = process.argv[2] || 'fake'
 

--- a/test/run-unit.js
+++ b/test/run-unit.js
@@ -28,10 +28,8 @@ limitations under the License.
 import { join, resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { execFileSync } from 'node:child_process'
-import fs from 'node:fs'
-import os from 'node:os'
 import { findTestFiles } from './run-utils.js'
-import { SCOPES } from '../lib/constants.js'
+import { setupSyntheticTokenCache } from './helpers/synthetic_token_cache.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const root = resolve(__dirname, '..')
@@ -43,29 +41,7 @@ if (!process.env.CEP_LOG_LEVEL) {
 
 process.env.CEP_BACKEND = 'fake'
 
-/* Tool-wrapper pre-flight check (lib/util/credential/auth_login.js#isTokenLocallyValid)
-   reads the OAuth cache before every handler call. Redirect HOME (or APPDATA on
-   Windows) to a temp directory holding a synthetic valid cache so handler-side
-   tests don't depend on the dev's real cache state. Tests that target the
-   pre-flight itself override HOME inside their own setup. */
-const homeKey = process.platform === 'win32' ? 'APPDATA' : 'HOME'
-const fakeHome = fs.mkdtempSync(join(os.tmpdir(), 'cep-mcp-unit-home-'))
-const cacheDir = process.platform === 'win32' ? join(fakeHome, 'cep-mcp') : join(fakeHome, '.config', 'cep-mcp')
-fs.mkdirSync(cacheDir, { recursive: true })
-fs.writeFileSync(
-  join(cacheDir, 'tokens.json'),
-  JSON.stringify({
-    access_token: 'synthetic-unit-test-token',
-    token_type: 'Bearer',
-    scope: Object.values(SCOPES).join(' '),
-    expiry_date: Date.now() + 3_600_000,
-  }),
-  { mode: 0o600 },
-)
-process.env[homeKey] = fakeHome
-process.on('exit', () => {
-  fs.rmSync(fakeHome, { recursive: true, force: true })
-})
+setupSyntheticTokenCache('cep-mcp-unit-home-')
 
 const testDirs = [join(root, 'test', 'local'), join(root, 'test', 'unit')]
 let testFiles = []


### PR DESCRIPTION
## Summary

Follow-up to #211. Both test runners (`test/run-unit.js`, `test/run-integration.js`) had the same ~25-line block redirecting `HOME` (or `APPDATA` on Windows) to a temp directory holding a synthetic valid OAuth token cache, so the tool-wrapper pre-flight passes for tests that don't care about auth.

Moved to `test/helpers/synthetic_token_cache.js` and called from each runner with a unique `mkdtemp` prefix.

No behavior change — pure dedupe.

## Future work (out of scope)

The deeper smell is that the pre-flight forces every test to deal with cache state at all. A cleaner shape is to make `isTokenLocallyValid` injectable so tests opt in via esmock instead of the runner setting global `HOME`. Left as a separate refactor since it touches the wrapper API.

## Test plan
- [x] `npm test` (unit + integration + smoke) passes locally.