### PR TITLE
feat(constants): add AUTH_STATUS and AUTH_NEXT_ACTION

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -6,10 +6,7 @@
   "mcpServers": {
     "chrome-enterprise-premium": {
       "command": "npx",
-      "args": [
-        "-y",
-        "@google/chrome-enterprise-premium-mcp@^1.4.0"
-      ]
+      "args": ["-y", "@google/chrome-enterprise-premium-mcp@^1.4.0"]
     }
   }
 }

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -93,6 +93,28 @@ export const TAGS = {
   MCP: '[mcp]',
 }
 
+/*
+ * Status values returned by the agent-initiated sign-in flow in
+ * lib/util/credential/auth_login.js (startToolAuth / completeToolAuth)
+ * and consumed by tools/utils/wrapper.js and tools/definitions/auth.js.
+ */
+export const AUTH_STATUS = Object.freeze({
+  COMPLETED: 'completed',
+  AWAITING: 'awaiting',
+  ERROR: 'error',
+})
+
+/*
+ * `nextAction` hints embedded in MCP tool responses so the agent knows
+ * which tool to call next when sign-in is needed. cep_auth emits
+ * PASTE_REDIRECT_URL when the headless paste-back path is in play;
+ * the wrapper emits INVOKE_CEP_AUTH when it short-circuits a handler.
+ */
+export const AUTH_NEXT_ACTION = Object.freeze({
+  INVOKE_CEP_AUTH: 'invoke-cep_auth',
+  PASTE_REDIRECT_URL: 'paste-redirect-url',
+})
+
 export const CLOUD_IDENTITY_SETTING_TYPES = {
   DLP_RULE: 'settings/rule.dlp',
   DETECTOR: 'settings/detector',


### PR DESCRIPTION
Folds the magic strings for the agent-initiated sign-in flow's `status` (`completed`, `awaiting`, `error`) and `nextAction` hints (`invoke-cep_auth`, `paste-redirect-url`) into frozen constants in `lib/constants.js`, ready to be used by `tools/utils/wrapper.js` and `tools/definitions/auth.js`.

Scope intentionally narrow. The wrapper-inline-auth attempt that this PR previously contained is redundant with #228, which already implements the proactive inline path through a relaxed wrapper gate plus `getAuthClient`. This PR is now just the constants extraction so the consumer files can switch off magic strings in whatever order makes sense.

## Test plan
- [x] `npm test` — green
- [ ] Confirm consumer PRs (#228 follow-ups, #232) pick up the constants