### PR TITLE
feat(cep_auth): name CEP MCP explicitly and disambiguate from Workspace MCP

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -6,10 +6,7 @@
   "mcpServers": {
     "chrome-enterprise-premium": {
       "command": "npx",
-      "args": [
-        "-y",
-        "@google/chrome-enterprise-premium-mcp@^1.4.0"
-      ]
+      "args": ["-y", "@google/chrome-enterprise-premium-mcp@^1.4.0"]
     }
   }
 }

--- a/tools/definitions/auth.js
+++ b/tools/definitions/auth.js
@@ -57,9 +57,11 @@ export function registerAuthTools(server, options, sessionState) {
     TOOL_NAME,
     {
       description:
-        'Sign in to Google so the server can call the Workspace APIs. Call with no arguments to start. ' +
-        'If the response says nextAction is "paste-redirect-url", ask the user to paste the URL the ' +
-        'browser was redirected to, then call cep_auth again with that string as the redirectUrl argument.',
+        'Sign in to Google for the Chrome Enterprise Premium (CEP) MCP server. ' +
+        'Use this tool ONLY for the CEP MCP server. The Google Workspace MCP server has its own separate auth tool — do not use this one for that. ' +
+        'Requests the CEP scope set: Chrome browser management, Chrome policy, Cloud Identity (DLP), Admin SDK reports, and Service Usage. ' +
+        'Call with no arguments to start the sign-in. ' +
+        'If the response sets `nextAction` to `paste-redirect-url`, ask the user to paste the URL the browser was redirected to, then call `cep_auth` again with that string as the `redirectUrl` argument.',
       inputSchema: {
         redirectUrl: z
           .string()

--- a/tools/definitions/auth.js
+++ b/tools/definitions/auth.js
@@ -58,7 +58,7 @@ export function registerAuthTools(server, options, sessionState) {
     {
       description:
         'Sign in to Google for the Chrome Enterprise Premium (CEP) MCP server. ' +
-        'Use this tool ONLY for the CEP MCP server. The Google Workspace MCP server has its own separate auth tool — do not use this one for that. ' +
+        'Use this tool ONLY for the CEP MCP server. The Google Workspace MCP server has its own separate auth tool—do not use this one for that. ' +
         'Requests the CEP scope set: Chrome browser management, Chrome policy, Cloud Identity (DLP), Admin SDK reports, and Service Usage. ' +
         'Call with no arguments to start the sign-in. ' +
         'If the response sets `nextAction` to `paste-redirect-url`, ask the user to paste the URL the browser was redirected to, then call `cep_auth` again with that string as the `redirectUrl` argument.',


### PR DESCRIPTION
## Summary

Shantanu reported agents calling the Google Workspace MCP server's `auth_login` tool against the CEP MCP server. The two tools have distinct names (`cep_auth` vs `auth_login`), so the confusion is description-driven: the prior `cep_auth` description read "Sign in to Google so the server can call the Workspace APIs", which agents interpret as a match for the Workspace MCP.

Tightens the description to:

- Name the Chrome Enterprise Premium MCP server explicitly.
- Call out that the Google Workspace MCP has its own separate auth tool and this one is not for it.
- List the scope set this tool requests (Chrome browser management, Chrome policy, Cloud Identity DLP, Admin SDK reports, Service Usage).

No behavior change. Description-only.

Per `thoughts.md`, this is the cheapest of three escalating disambiguation options. A rename to `cep_mcp_auth` or a cross-server `<server-id>_auth` convention is held until this tightened description has time to land and we see whether the confusion recurs.

## Test plan

- [x] `npm run lint` clean.
- [x] `npm test` passes.