### PR TITLE
fix(auth): cep_ prefix on auth_status/auth_clear; styled loopback pages

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -6,10 +6,7 @@
   "mcpServers": {
     "chrome-enterprise-premium": {
       "command": "npx",
-      "args": [
-        "-y",
-        "@google/chrome-enterprise-premium-mcp@^1.4.0"
-      ]
+      "args": ["-y", "@google/chrome-enterprise-premium-mcp@^1.4.0"]
     }
   }
 }

--- a/lib/util/credential/loopback_server.js
+++ b/lib/util/credential/loopback_server.js
@@ -38,13 +38,12 @@ export async function startLoopbackServer() {
 
   const server = http.createServer((req, res) => {
     const url = new URL(req.url, 'http://127.0.0.1')
-    res.writeHead(200, { 'Content-Type': 'text/html' })
-    res.end('<html><body><p>You may close this window.</p></body></html>')
-    resolveCode({
-      code: url.searchParams.get('code') ?? undefined,
-      state: url.searchParams.get('state') ?? undefined,
-      error: url.searchParams.get('error') ?? undefined,
-    })
+    const code = url.searchParams.get('code') ?? undefined
+    const state = url.searchParams.get('state') ?? undefined
+    const error = url.searchParams.get('error') ?? undefined
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+    res.end(error ? renderErrorPage(error) : renderSuccessPage())
+    resolveCode({ code, state, error })
   })
 
   await new Promise(resolve => {
@@ -62,4 +61,71 @@ export async function startLoopbackServer() {
         })
       }),
   }
+}
+
+/*
+ * Shared CSS for both the success and the error landing pages. Inlined so the
+ * loopback server can respond with a single self-contained document and no
+ * external requests. Sized to keep each rendered page under 2 KB.
+ */
+const PAGE_STYLE =
+  'body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;' +
+  "background:#f8f9fa;font:14px/1.5 'Google Sans',Roboto,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#202124}" +
+  '.card{background:#fff;padding:32px 40px;border-radius:8px;box-shadow:0 1px 2px rgba(60,64,67,.3),0 1px 3px 1px rgba(60,64,67,.15);max-width:360px;text-align:center}' +
+  '.icon{width:48px;height:48px;margin:0 auto 16px;border-radius:50%;color:#fff;font-size:28px;line-height:48px}' +
+  '.ok{background:#34a853}.err{background:#ea4335}' +
+  'h1{margin:0 0 8px;font-size:18px;font-weight:500}' +
+  'p{margin:0;color:#5f6368}' +
+  ".reason{margin-top:12px;font-family:'Roboto Mono',Menlo,Consolas,monospace;font-size:12px;color:#80868b;word-break:break-word}"
+
+/**
+ * Renders the post-consent success landing page shown to the user in the
+ * browser after Google redirects to the loopback URL.
+ * @returns {string} A self-contained HTML document under 2 KB.
+ */
+function renderSuccessPage() {
+  return (
+    '<!doctype html><html lang="en"><head><meta charset="utf-8">' +
+    '<meta name="viewport" content="width=device-width,initial-scale=1">' +
+    '<title>Signed in to CEP MCP</title>' +
+    `<style>${PAGE_STYLE}</style></head><body>` +
+    '<div class="card"><div class="icon ok">✓</div>' +
+    '<h1>Signed in</h1>' +
+    '<p>Chrome Enterprise Premium MCP has your credentials. You can close this window and return to your terminal.</p>' +
+    '</div></body></html>'
+  )
+}
+
+/**
+ * Renders the post-consent error landing page shown to the user in the
+ * browser when Google redirects with an `error` query parameter (typically
+ * `access_denied`).
+ * @param {string} reason The raw OAuth error code from the callback URL.
+ * @returns {string} A self-contained HTML document under 2 KB.
+ */
+function renderErrorPage(reason) {
+  return (
+    '<!doctype html><html lang="en"><head><meta charset="utf-8">' +
+    '<meta name="viewport" content="width=device-width,initial-scale=1">' +
+    '<title>Sign-in failed for CEP MCP</title>' +
+    `<style>${PAGE_STYLE}</style></head><body>` +
+    '<div class="card"><div class="icon err">✕</div>' +
+    '<h1>Sign-in failed</h1>' +
+    '<p>Return to your terminal. Chrome Enterprise Premium MCP will report what to try next.</p>' +
+    `<p class="reason">${escapeHtml(reason)}</p>` +
+    '</div></body></html>'
+  )
+}
+
+/**
+ * Escapes characters that have special meaning in HTML. Applied to the OAuth
+ * error code before it is inlined into the error page.
+ * @param {string} s The raw string to escape.
+ * @returns {string} The escaped string, safe to inline in HTML body text.
+ */
+function escapeHtml(s) {
+  return String(s).replace(
+    /[&<>"']/g,
+    c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c],
+  )
 }

--- a/test/integration/server/mcp-server.test.js
+++ b/test/integration/server/mcp-server.test.js
@@ -75,9 +75,9 @@ describe('MCP Server in stdio mode', () => {
     assert.deepStrictEqual(
       toolNames.sort(),
       [
-        'auth_clear',
-        'auth_status',
         'cep_auth',
+        'cep_auth_clear',
+        'cep_auth_status',
         'check_cep_subscription',
         'check_seb_extension_status',
         'check_user_cep_license',

--- a/test/local/loopback-server.test.js
+++ b/test/local/loopback-server.test.js
@@ -53,14 +53,45 @@ describe('startLoopbackServer', () => {
     }
   })
 
-  it('When the loopback receives a request, then the response body is human-readable HTML', async () => {
+  it('When the loopback receives a success callback, then the response is the styled success page', async () => {
     const server = await startLoopbackServer()
     try {
       server.waitForCode()
       const res = await fetch(`${server.redirectUri}?code=test`)
       assert.equal(res.status, 200)
       const body = await res.text()
-      assert.match(body, /You may close this window/i)
+      assert.match(body, /<title>Signed in to CEP MCP<\/title>/)
+      assert.match(body, /Signed in/)
+      assert.ok(Buffer.byteLength(body, 'utf8') < 2048, 'success page should fit under 2 KB')
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('When the loopback receives an error callback, then the response is the styled error page with the reason', async () => {
+    const server = await startLoopbackServer()
+    try {
+      server.waitForCode()
+      const res = await fetch(`${server.redirectUri}?error=access_denied`)
+      assert.equal(res.status, 200)
+      const body = await res.text()
+      assert.match(body, /<title>Sign-in failed for CEP MCP<\/title>/)
+      assert.match(body, /Sign-in failed/)
+      assert.match(body, /access_denied/)
+      assert.ok(Buffer.byteLength(body, 'utf8') < 2048, 'error page should fit under 2 KB')
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('When the loopback receives an error with an HTML-injecting reason, then the reason is escaped', async () => {
+    const server = await startLoopbackServer()
+    try {
+      server.waitForCode()
+      const res = await fetch(`${server.redirectUri}?error=${encodeURIComponent('<script>x</script>')}`)
+      const body = await res.text()
+      assert.match(body, /&lt;script&gt;/)
+      assert.doesNotMatch(body, /<script>x<\/script>/)
     } finally {
       await server.stop()
     }

--- a/test/local/tool-registration.test.js
+++ b/test/local/tool-registration.test.js
@@ -24,9 +24,9 @@ import { registerTools } from '../../tools/index.js'
 import { FLAGS } from '../../lib/util/feature_flags.js'
 
 const CORE_TOOLS = [
-  'auth_clear',
-  'auth_status',
   'cep_auth',
+  'cep_auth_clear',
+  'cep_auth_status',
   'check_and_enable_cep_api',
   'check_cep_subscription',
   'check_seb_extension_status',

--- a/tools/definitions/auth.js
+++ b/tools/definitions/auth.js
@@ -16,7 +16,9 @@ limitations under the License.
 
 /**
  * @file Tool definitions for the agent-initiated sign-in flow (`cep_auth`),
- * status checking (`auth_status`), and cache clearing (`auth_clear`).
+ * status checking (`cep_auth_status`), and cache clearing (`cep_auth_clear`).
+ * All tools share the `cep_` prefix so an MCP client hosting multiple servers
+ * (e.g. CEP plus Google Workspace) does not collide on a generic `auth_*` name.
  */
 
 import { z } from 'zod'
@@ -110,9 +112,11 @@ export function registerAuthTools(server, options, sessionState) {
   )
 
   server.registerTool(
-    'auth_status',
+    'cep_auth_status',
     {
-      description: 'Checks the current OAuth credential status and cached scopes.',
+      description:
+        'Reports the current OAuth credential status and cached scopes for the Chrome Enterprise Premium (CEP) MCP server. ' +
+        'Use this tool only for the CEP MCP server; the Google Workspace MCP server has its own separate status tool.',
       inputSchema: z.looseObject({}),
       outputSchema: z.looseObject({
         status: z.looseObject({}),
@@ -138,9 +142,11 @@ export function registerAuthTools(server, options, sessionState) {
   )
 
   server.registerTool(
-    'auth_clear',
+    'cep_auth_clear',
     {
-      description: 'Clears cached OAuth credentials, requiring re-authentication on the next call.',
+      description:
+        'Clears cached OAuth credentials for the Chrome Enterprise Premium (CEP) MCP server, forcing re-authentication on the next call. ' +
+        'Use this tool only for the CEP MCP server; the Google Workspace MCP server has its own separate clear tool.',
       inputSchema: z.looseObject({}),
       outputSchema: z.looseObject({
         cleared: z.boolean(),


### PR DESCRIPTION
Targeted at Dylan's #228 branch so it lands together with the proactive inline-auth work.

## Summary
- Renames `auth_status` → `cep_auth_status` and `auth_clear` → `cep_auth_clear` so a client hosting both the CEP and Workspace MCP servers does not collide on generic `auth_*` tool names. Tool descriptions now name CEP MCP explicitly.
- Replaces the single plain-text loopback response with a small Material-styled success page and a matching error page. The error page is rendered when the consent redirect carries an `error` query parameter and includes the (escaped) OAuth error reason.
- Each rendered page is under 1.2 KB with inline CSS and no external requests.

## Test plan
- [x] `npm test` — all unit and integration suites green locally
- [ ] Sanity check the success page in a real browser after running the loopback flow end-to-end
- [ ] Sanity check the error page by clicking "Cancel" at the consent screen