### PR TITLE
fix(ci): resolve zod v4 cache mismatch in daily evaluations

### DIFF
--- a/.github/workflows/agent-evals.yml
+++ b/.github/workflows/agent-evals.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
       - run: npm ci
 


### PR DESCRIPTION
Resolves GHA daily evaluations failure by upgrading Node.js runner version to 24 and adding a diagnostic Zod version check step.

Bug: b/514395431
Bug: b/493244463