### PR TITLE
fix(auth): pad authUrl line and tell agent to restate it in chat

### DIFF
--- a/test/local/auth-tool.test.js
+++ b/test/local/auth-tool.test.js
@@ -82,8 +82,25 @@ describe('cep_auth Tool', () => {
     assert.strictEqual(result.structuredContent.nextAction, 'paste-redirect-url')
     assert.strictEqual(result.structuredContent.authUrl, 'https://accounts.google.com/o/oauth2/v2/auth?state=ABC')
     assert.ok(result.structuredContent.agentHint?.length > 0)
+    assert.match(result.structuredContent.agentHint, /restate.*chat/i)
+    assert.match(result.structuredContent.agentHint, /outside.*tool-output box/i)
     assert.match(result.content[0].text, /Open this URL/)
     assert.match(result.content[0].text, /accounts\.google\.com/)
+    assert.ok(
+      result.content[0].text.split('\n').includes('  https://accounts.google.com/o/oauth2/v2/auth?state=ABC  '),
+      'authUrl line should be padded with two leading and two trailing spaces',
+    )
+  })
+
+  test('When cep_auth is registered, then its description tells the agent to restate the authUrl in chat outside the tool-output box', async () => {
+    const startToolAuth = mock.fn()
+    const completeToolAuth = mock.fn()
+    await register({ startToolAuth, completeToolAuth })
+
+    const call = server.registerTool.mock.calls.find(c => c.arguments[0] === 'cep_auth')
+    const { description } = call.arguments[1]
+    assert.match(description, /restate.*chat/i)
+    assert.match(description, /outside.*tool-output box/i)
   })
 
   test('When cep_auth is invoked with a valid redirectUrl, then it calls completeToolAuth and returns status=completed', async () => {

--- a/tools/definitions/auth.js
+++ b/tools/definitions/auth.js
@@ -31,10 +31,11 @@ import { guardedToolCall, formatToolResponse } from '../utils/wrapper.js'
 const TOOL_NAME = 'cep_auth'
 
 const AGENT_HINT =
-  'Show the user the authUrl and ask them to open it in a browser. After the browser is ' +
-  'redirected to a 127.0.0.1 URL (the page may show "connection refused" — that is expected), ' +
-  'ask the user to paste that full URL back. Then call cep_auth again with the pasted URL as ' +
-  'the redirectUrl argument.'
+  'Show the user the authUrl and ask them to open it in a browser. Restate the authUrl in your ' +
+  'chat reply on its own line, outside any tool-output box, because long URLs can clip against ' +
+  'a box border during selection. After the browser is redirected to a 127.0.0.1 URL (the page ' +
+  'may show "connection refused" — that is expected), ask the user to paste that full URL back. ' +
+  'Then call cep_auth again with the pasted URL as the redirectUrl argument.'
 
 /**
  * Registers the authentication tools with the MCP server (alias for registerAuthTools).
@@ -59,7 +60,9 @@ export function registerAuthTools(server, options, sessionState) {
       description:
         'Sign in to Google so the server can call the Workspace APIs. Call with no arguments to start. ' +
         'If the response says nextAction is "paste-redirect-url", ask the user to paste the URL the ' +
-        'browser was redirected to, then call cep_auth again with that string as the redirectUrl argument.',
+        'browser was redirected to, then call cep_auth again with that string as the redirectUrl argument. ' +
+        'When the response includes an authUrl, restate that URL in your chat reply on its own line, ' +
+        'outside any tool-output box, because long URLs can clip against a box border during selection.',
       inputSchema: {
         redirectUrl: z
           .string()
@@ -197,7 +200,7 @@ function awaitingResponse(result) {
     lines.push('Open this URL in a browser and complete sign-in:')
   }
   lines.push('')
-  lines.push(result.authUrl)
+  lines.push(`  ${result.authUrl}  `)
   lines.push('')
   lines.push(
     "Then paste the full URL the browser was redirected to (it looks like http://127.0.0.1:PORT/?code=...&state=...; the page may show a connection error — that's expected).",


### PR DESCRIPTION
The `cep_auth` tool emits the consent URL inside an MCP text block, which Gemini CLI renders in a Unicode-bordered box where long URLs clip against the right border on selection. This pads the URL line with two leading and two trailing spaces and adds a restate-in-chat instruction to both the tool description and `AGENT_HINT`, so the agent mirrors the URL outside the box where selection is clean.

Closes #238