### PR TITLE
feat(auth): boxed consent URL and Chrome activation on macOS

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -6,10 +6,7 @@
   "mcpServers": {
     "chrome-enterprise-premium": {
       "command": "npx",
-      "args": [
-        "-y",
-        "@google/chrome-enterprise-premium-mcp@^1.4.0"
-      ]
+      "args": ["-y", "@google/chrome-enterprise-premium-mcp@^1.4.0"]
     }
   }
 }

--- a/lib/util/credential/auth_login.js
+++ b/lib/util/credential/auth_login.js
@@ -31,6 +31,7 @@ limitations under the License.
    after-await pattern that triggers this rule is the intended behavior. */
 
 import { randomBytes } from 'node:crypto'
+import fsSync from 'node:fs'
 import { OAuth2Client } from 'google-auth-library'
 import { TokenCache } from './token_cache.js'
 import { startLoopbackServer } from './loopback_server.js'
@@ -97,17 +98,39 @@ export async function isTokenLocallyValid({
 /**
  * Reports whether this process can plausibly launch a desktop browser.
  * Conservative — when in doubt, returns true and lets the launch attempt fail.
+ * Returns false on SSH sessions, Linux without a display server, and common
+ * container indicators (`/.dockerenv`, `docker`/`kubepods` in `/proc/1/cgroup`).
  * @param {object} [opts] Optional overrides for tests.
  * @param {object} [opts.env] The environment to inspect; defaults to process.env.
  * @param {string} [opts.platform] The OS platform string; defaults to process.platform.
+ * @param {{existsSync: (p: string) => boolean, readFileSync: (p: string, enc: string) => string}} [opts.fs] Filesystem accessor; defaults to node:fs.
  * @returns {boolean} True when a browser is likely launchable.
  */
-export function canLaunchBrowser({ env = process.env, platform = process.platform } = {}) {
+export function canLaunchBrowser({ env = process.env, platform = process.platform, fs = fsSync } = {}) {
   if (env.SSH_CONNECTION || env.SSH_TTY) {
     return false
   }
   if (platform === 'linux' && !env.DISPLAY && !env.WAYLAND_DISPLAY) {
     return false
+  }
+  if (platform === 'linux' || platform === 'darwin') {
+    try {
+      if (fs.existsSync('/.dockerenv')) {
+        return false
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+  if (platform === 'linux') {
+    try {
+      const cgroup = fs.readFileSync('/proc/1/cgroup', 'utf8')
+      if (/\b(?:docker|kubepods)\b/.test(cgroup)) {
+        return false
+      }
+    } catch {
+      /* ignore */
+    }
   }
   return true
 }

--- a/lib/util/credential/oauth_flow.js
+++ b/lib/util/credential/oauth_flow.js
@@ -48,7 +48,7 @@ function emitTerminalBell(stream = process.stderr) {
  * Returns `false` (without launching) when `canLaunchBrowser()` reports a
  * headless environment, so the caller can show the paste-URL fallback.
  * Honours `$BROWSER` by passing it through to `open` as the `app.name`.
- * Writes a single BEL to stderr on TTY launch.
+ * Writes a single BEL to stderr on TTY when the launch child exits 0.
  * @param {string} url The URL to open.
  * @param {object} [deps] Injection points for tests.
  * @param {(target: string, opts?: object) => Promise<import('node:child_process').ChildProcess>} [deps.openImpl] The `open`-package function; defaults to the real import.
@@ -70,13 +70,18 @@ export async function defaultOpenBrowser(
   } catch {
     return false
   }
-  emitTerminalBell(attentionStream)
   if (!child || typeof child.on !== 'function') {
     return false
   }
   return new Promise(resolve => {
     child.on('error', () => resolve(false))
-    child.on('exit', code => resolve(code === 0))
+    child.on('exit', code => {
+      const ok = code === 0
+      if (ok) {
+        emitTerminalBell(attentionStream)
+      }
+      resolve(ok)
+    })
     child.unref?.()
   })
 }

--- a/lib/util/credential/oauth_flow.js
+++ b/lib/util/credential/oauth_flow.js
@@ -59,16 +59,179 @@ export function _resetChromeDetectionCacheForTests() {
 }
 
 /**
+ * Best-effort detection of whether a given binary is on PATH on POSIX systems.
+ * Returns false on any failure.
+ * @param {string} bin The binary to look up.
+ * @param {(cmd: string, args: string[], opts: object) => {status: number|null}} spawnSyncImpl Sync spawn used for the lookup.
+ * @returns {boolean} True when `command -v <bin>` exits 0.
+ */
+function hasOnPath(bin, spawnSyncImpl) {
+  try {
+    const result = spawnSyncImpl('sh', ['-c', `command -v ${bin}`], { stdio: 'ignore', timeout: 1500 })
+    return result.status === 0
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Best-effort activation of the foreground browser window after a launch. All
+ * spawns are detached and unref'd; errors are silenced. Never blocks the
+ * caller and never rejects.
+ * @param {object} opts Activation parameters.
+ * @param {string} opts.cmd The launch command that was used (informs which browser to activate).
+ * @param {(c: string, a: string[], o: object) => import('node:child_process').ChildProcess} opts.spawnImpl Async spawn used for activation.
+ * @param {(c: string, a: string[], o: object) => {status: number|null}} opts.spawnSyncImpl Sync spawn used for PATH probes.
+ * @param {string} opts.platform The OS platform string.
+ * @returns {void}
+ */
+function bringBrowserToFront({ cmd, spawnImpl, spawnSyncImpl, platform }) {
+  const safeSpawn = (c, a) => {
+    try {
+      const child = spawnImpl(c, a, { detached: true, stdio: 'ignore' })
+      child.on?.('error', () => {})
+      child.unref?.()
+    } catch {
+      /* ignore */
+    }
+  }
+  if (platform === 'darwin') {
+    const appName = macAppNameForCommand(cmd)
+    if (appName) {
+      safeSpawn('osascript', ['-e', `tell application "${appName}" to activate`])
+    }
+    return
+  }
+  if (platform === 'win32') {
+    const title = winAppActivateTitleForCommand(cmd)
+    if (title) {
+      safeSpawn('powershell', [
+        '-NoProfile',
+        '-Command',
+        `(New-Object -ComObject WScript.Shell).AppActivate('${title}')`,
+      ])
+    }
+    return
+  }
+  if (platform === 'linux') {
+    if (hasOnPath('wmctrl', spawnSyncImpl)) {
+      const match = linuxWmctrlTitleForCommand(cmd) || 'chrome'
+      safeSpawn('wmctrl', ['-a', match])
+    }
+  }
+}
+
+/**
+ * Maps a launch command/binary to a macOS application bundle name for `osascript ... activate`.
+ * @param {string} cmd The launch command name (e.g., 'Google Chrome', 'firefox').
+ * @returns {string} The macOS application name to activate.
+ */
+function macAppNameForCommand(cmd) {
+  const lower = (cmd || '').toLowerCase()
+  if (lower.includes('chrome')) {
+    return 'Google Chrome'
+  }
+  if (lower.includes('firefox')) {
+    return 'Firefox'
+  }
+  if (lower.includes('safari')) {
+    return 'Safari'
+  }
+  if (lower.includes('edge') || lower.includes('msedge')) {
+    return 'Microsoft Edge'
+  }
+  // `open` with no -a: the user's default browser. AppleScript can't target an
+  // unknown app, so we fall back to Chrome — the most common default on
+  // managed Workspace fleets — and silently no-op when it isn't installed.
+  return 'Google Chrome'
+}
+
+/**
+ * Maps a launch command/binary to a Windows window title for AppActivate.
+ * @param {string} cmd The launch command name.
+ * @returns {string} The window title substring AppActivate should target.
+ */
+function winAppActivateTitleForCommand(cmd) {
+  const lower = (cmd || '').toLowerCase()
+  if (lower.includes('firefox')) {
+    return 'Firefox'
+  }
+  if (lower.includes('msedge') || lower.includes('edge')) {
+    return 'Edge'
+  }
+  if (lower.includes('chrome')) {
+    return 'Chrome'
+  }
+  return 'Chrome'
+}
+
+/**
+ * Maps a launch command/binary to a wmctrl title substring (case-insensitive).
+ * @param {string} cmd The launch command name.
+ * @returns {?string} The wmctrl `-a` substring, or null when no specific match is known.
+ */
+function linuxWmctrlTitleForCommand(cmd) {
+  const lower = (cmd || '').toLowerCase()
+  if (lower.includes('firefox')) {
+    return 'firefox'
+  }
+  if (lower.includes('chromium')) {
+    return 'chromium'
+  }
+  if (lower.includes('chrome')) {
+    return 'chrome'
+  }
+  return null
+}
+
+/**
+ * Emits best-effort terminal-attention hints to stderr when stderr is a TTY:
+ * an ASCII BEL (audio cue), then an OSC 9 desktop notification recognised by
+ * iTerm2 and a handful of other terminals. Harmless escape sequences elsewhere.
+ * @param {{isTTY?: boolean, write: (s: string) => void}} [stream] The output stream; defaults to process.stderr.
+ * @returns {void}
+ */
+function emitTerminalAttention(stream = process.stderr) {
+  if (!stream.isTTY) {
+    return
+  }
+  try {
+    stream.write('\x07')
+    stream.write('\x1b]9;Sign in to Google in your browser\x07')
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
  * Opens the given URL in the user's default browser, with a few platform-aware
  * preferences. Returns `false` (without spawning) on SSH/headless/container
  * environments so the caller can show the paste-URL fallback. Respects
  * `$BROWSER`. On macOS, when `$BROWSER` is unset and Google Chrome is
- * installed, activates Chrome by name so the new tab comes forward.
+ * installed, activates Chrome by name so the new tab comes forward. After the
+ * launch attempt, also fires a best-effort window-activation spawn (osascript
+ * on macOS, PowerShell AppActivate on Windows, wmctrl on Linux when present)
+ * and writes a BEL + OSC 9 attention hint to stderr.
  * @param {string} url The URL to open.
+ * @param {object} [deps] Injection points for tests.
+ * @param {(c: string, a: string[], o: object) => import('node:child_process').ChildProcess} [deps.spawnImpl] Async spawn; defaults to node:child_process spawn.
+ * @param {(c: string, a: string[], o: object) => {status: number|null}} [deps.spawnSyncImpl] Sync spawn used for PATH probes; defaults to node:child_process spawnSync.
+ * @param {string} [deps.platform] OS platform; defaults to process.platform.
+ * @param {{isTTY?: boolean, write: (s: string) => void}} [deps.attentionStream] Stream for BEL/OSC 9 hints; defaults to process.stderr.
+ * @param {() => boolean} [deps.canLaunch] Headless/SSH check; defaults to canLaunchBrowser.
  * @returns {Promise<boolean>} Resolves true when the spawn exits 0, false otherwise.
  */
-export function defaultOpenBrowser(url) {
-  if (!canLaunchBrowser()) {
+export function defaultOpenBrowser(
+  url,
+  {
+    spawnImpl = spawn,
+    spawnSyncImpl = spawnSync,
+    platform = process.platform,
+    attentionStream = process.stderr,
+    canLaunch = canLaunchBrowser,
+  } = {},
+) {
+  if (!canLaunch()) {
     return Promise.resolve(false)
   }
   let cmd
@@ -76,10 +239,10 @@ export function defaultOpenBrowser(url) {
   if (process.env.BROWSER) {
     cmd = process.env.BROWSER
     args = [url]
-  } else if (process.platform === 'win32') {
+  } else if (platform === 'win32') {
     cmd = 'cmd'
     args = ['/c', 'start', '', url]
-  } else if (process.platform === 'darwin') {
+  } else if (platform === 'darwin') {
     if (isChromeOnMac()) {
       cmd = 'open'
       args = ['-a', 'Google Chrome', url]
@@ -91,11 +254,24 @@ export function defaultOpenBrowser(url) {
     cmd = 'xdg-open'
     args = [url]
   }
+  // On macOS the activation target depends on which app `open` will launch.
+  // `$BROWSER` (when set) names that binary directly; otherwise the macOS
+  // branch above forces Chrome when present and falls back to the user's
+  // default. Pass the most specific signal we have.
+  const activationCmd = process.env.BROWSER || (platform === 'darwin' && args[0] === '-a' ? args[1] : cmd)
   return new Promise(resolve => {
-    const child = spawn(cmd, args, { detached: true, stdio: 'ignore' })
+    let child
+    try {
+      child = spawnImpl(cmd, args, { detached: true, stdio: 'ignore' })
+    } catch {
+      resolve(false)
+      return
+    }
     child.on('error', () => resolve(false))
     child.on('exit', code => resolve(code === 0))
-    child.unref()
+    child.unref?.()
+    bringBrowserToFront({ cmd: activationCmd, spawnImpl, spawnSyncImpl, platform })
+    emitTerminalAttention(attentionStream)
   })
 }
 
@@ -115,16 +291,21 @@ export function printConsentUrl(url, stream = process.stderr) {
   }
   const CYAN = '\x1b[1;36m'
   const RESET = '\x1b[0m'
+  // OSC 8 hyperlink wrap: clickable in modern terminals, invisible elsewhere.
+  // Zero visible width, so box-padding still uses raw url.length.
+  const linkOpen = `\x1b]8;;${url}\x1b\\`
+  const linkClose = '\x1b]8;;\x1b\\'
+  const linkedUrl = `${linkOpen}${url}${linkClose}`
   const label = 'Open this URL in your browser to sign in:'
   const width = Math.max(label.length, url.length) + 2
   const top = '╔' + '═'.repeat(width) + '╗'
   const bot = '╚' + '═'.repeat(width) + '╝'
-  const pad = text => '║ ' + text + ' '.repeat(width - text.length - 1) + '║'
+  const pad = (text, visibleLen = text.length) => '║ ' + text + ' '.repeat(width - visibleLen - 1) + '║'
   stream.write('\n')
   stream.write(`${CYAN}${top}${RESET}\n`)
   stream.write(`${CYAN}${pad(label)}${RESET}\n`)
   stream.write(`${CYAN}║${' '.repeat(width)}║${RESET}\n`)
-  stream.write(`${CYAN}${pad(url)}${RESET}\n`)
+  stream.write(`${CYAN}${pad(linkedUrl, url.length)}${RESET}\n`)
   stream.write(`${CYAN}${bot}${RESET}\n\n`)
 }
 

--- a/lib/util/credential/oauth_flow.js
+++ b/lib/util/credential/oauth_flow.js
@@ -18,260 +18,66 @@ limitations under the License.
  * @file Managed OAuth flow credential factory.
  */
 
-import { spawn, spawnSync } from 'node:child_process'
 import readline from 'node:readline'
+import open from 'open'
 import { OAuth2Client } from 'google-auth-library'
 import { TokenCache } from './token_cache.js'
 import { startLoopbackServer } from './loopback_server.js'
 import { canLaunchBrowser } from './auth_login.js'
 import { SCOPES, MANAGED_OAUTH_CLIENT_ID, MANAGED_OAUTH_CLIENT_SECRET } from '../../constants.js'
 
-/* Process-lifetime cache for the macOS Chrome-presence probe. */
-let chromeOnMacCache
-
 /**
- * Probes for Google Chrome on macOS via `mdfind`, caching the result for the
- * lifetime of the process. Returns false on probe failure.
- * @returns {boolean} True when a Chrome bundle is registered with Launch Services.
- */
-function isChromeOnMac() {
-  if (chromeOnMacCache !== undefined) {
-    return chromeOnMacCache
-  }
-  try {
-    const result = spawnSync('mdfind', ['kMDItemCFBundleIdentifier == "com.google.Chrome"'], {
-      encoding: 'utf8',
-      timeout: 1500,
-    })
-    chromeOnMacCache = result.status === 0 && typeof result.stdout === 'string' && result.stdout.trim().length > 0
-  } catch {
-    chromeOnMacCache = false
-  }
-  return chromeOnMacCache
-}
-
-/**
- * For tests: clears the process-lifetime Chrome-detection cache.
+ * Writes a single ASCII BEL to stderr when stderr is a TTY. Audible cue that
+ * the consent URL is ready; harmless elsewhere.
+ * @param {{isTTY?: boolean, write: (s: string) => void}} [stream] Output stream; defaults to process.stderr.
  * @returns {void}
  */
-export function _resetChromeDetectionCacheForTests() {
-  chromeOnMacCache = undefined
-}
-
-/**
- * Best-effort detection of whether a given binary is on PATH on POSIX systems.
- * Returns false on any failure.
- * @param {string} bin The binary to look up.
- * @param {(cmd: string, args: string[], opts: object) => {status: number|null}} spawnSyncImpl Sync spawn used for the lookup.
- * @returns {boolean} True when `command -v <bin>` exits 0.
- */
-function hasOnPath(bin, spawnSyncImpl) {
-  try {
-    const result = spawnSyncImpl('sh', ['-c', `command -v ${bin}`], { stdio: 'ignore', timeout: 1500 })
-    return result.status === 0
-  } catch {
-    return false
-  }
-}
-
-/**
- * Best-effort activation of the foreground browser window after a launch. All
- * spawns are detached and unref'd; errors are silenced. Never blocks the
- * caller and never rejects.
- * @param {object} opts Activation parameters.
- * @param {string} opts.cmd The launch command that was used (informs which browser to activate).
- * @param {(c: string, a: string[], o: object) => import('node:child_process').ChildProcess} opts.spawnImpl Async spawn used for activation.
- * @param {(c: string, a: string[], o: object) => {status: number|null}} opts.spawnSyncImpl Sync spawn used for PATH probes.
- * @param {string} opts.platform The OS platform string.
- * @returns {void}
- */
-function bringBrowserToFront({ cmd, spawnImpl, spawnSyncImpl, platform }) {
-  const safeSpawn = (c, a) => {
-    try {
-      const child = spawnImpl(c, a, { detached: true, stdio: 'ignore' })
-      child.on?.('error', () => {})
-      child.unref?.()
-    } catch {
-      /* ignore */
-    }
-  }
-  if (platform === 'darwin') {
-    const appName = macAppNameForCommand(cmd)
-    if (appName) {
-      safeSpawn('osascript', ['-e', `tell application "${appName}" to activate`])
-    }
-    return
-  }
-  if (platform === 'win32') {
-    const title = winAppActivateTitleForCommand(cmd)
-    if (title) {
-      safeSpawn('powershell', [
-        '-NoProfile',
-        '-Command',
-        `(New-Object -ComObject WScript.Shell).AppActivate('${title}')`,
-      ])
-    }
-    return
-  }
-  if (platform === 'linux') {
-    if (hasOnPath('wmctrl', spawnSyncImpl)) {
-      const match = linuxWmctrlTitleForCommand(cmd) || 'chrome'
-      safeSpawn('wmctrl', ['-a', match])
-    }
-  }
-}
-
-/**
- * Maps a launch command/binary to a macOS application bundle name for `osascript ... activate`.
- * @param {string} cmd The launch command name (e.g., 'Google Chrome', 'firefox').
- * @returns {string} The macOS application name to activate.
- */
-function macAppNameForCommand(cmd) {
-  const lower = (cmd || '').toLowerCase()
-  if (lower.includes('chrome')) {
-    return 'Google Chrome'
-  }
-  if (lower.includes('firefox')) {
-    return 'Firefox'
-  }
-  if (lower.includes('safari')) {
-    return 'Safari'
-  }
-  if (lower.includes('edge') || lower.includes('msedge')) {
-    return 'Microsoft Edge'
-  }
-  // `open` with no -a: the user's default browser. AppleScript can't target an
-  // unknown app, so we fall back to Chrome — the most common default on
-  // managed Workspace fleets — and silently no-op when it isn't installed.
-  return 'Google Chrome'
-}
-
-/**
- * Maps a launch command/binary to a Windows window title for AppActivate.
- * @param {string} cmd The launch command name.
- * @returns {string} The window title substring AppActivate should target.
- */
-function winAppActivateTitleForCommand(cmd) {
-  const lower = (cmd || '').toLowerCase()
-  if (lower.includes('firefox')) {
-    return 'Firefox'
-  }
-  if (lower.includes('msedge') || lower.includes('edge')) {
-    return 'Edge'
-  }
-  if (lower.includes('chrome')) {
-    return 'Chrome'
-  }
-  return 'Chrome'
-}
-
-/**
- * Maps a launch command/binary to a wmctrl title substring (case-insensitive).
- * @param {string} cmd The launch command name.
- * @returns {?string} The wmctrl `-a` substring, or null when no specific match is known.
- */
-function linuxWmctrlTitleForCommand(cmd) {
-  const lower = (cmd || '').toLowerCase()
-  if (lower.includes('firefox')) {
-    return 'firefox'
-  }
-  if (lower.includes('chromium')) {
-    return 'chromium'
-  }
-  if (lower.includes('chrome')) {
-    return 'chrome'
-  }
-  return null
-}
-
-/**
- * Emits best-effort terminal-attention hints to stderr when stderr is a TTY:
- * an ASCII BEL (audio cue), then an OSC 9 desktop notification recognised by
- * iTerm2 and a handful of other terminals. Harmless escape sequences elsewhere.
- * @param {{isTTY?: boolean, write: (s: string) => void}} [stream] The output stream; defaults to process.stderr.
- * @returns {void}
- */
-function emitTerminalAttention(stream = process.stderr) {
+function emitTerminalBell(stream = process.stderr) {
   if (!stream.isTTY) {
     return
   }
   try {
     stream.write('\x07')
-    stream.write('\x1b]9;Sign in to Google in your browser\x07')
   } catch {
     /* ignore */
   }
 }
 
 /**
- * Opens the given URL in the user's default browser, with a few platform-aware
- * preferences. Returns `false` (without spawning) on SSH/headless/container
- * environments so the caller can show the paste-URL fallback. Respects
- * `$BROWSER`. On macOS, when `$BROWSER` is unset and Google Chrome is
- * installed, activates Chrome by name so the new tab comes forward. After the
- * launch attempt, also fires a best-effort window-activation spawn (osascript
- * on macOS, PowerShell AppActivate on Windows, wmctrl on Linux when present)
- * and writes a BEL + OSC 9 attention hint to stderr.
+ * Opens the given URL in the user's default browser via the `open` package.
+ * Returns `false` (without launching) when `canLaunchBrowser()` reports a
+ * headless environment, so the caller can show the paste-URL fallback.
+ * Honours `$BROWSER` by passing it through to `open` as the `app.name`.
+ * Writes a single BEL to stderr on TTY launch.
  * @param {string} url The URL to open.
  * @param {object} [deps] Injection points for tests.
- * @param {(c: string, a: string[], o: object) => import('node:child_process').ChildProcess} [deps.spawnImpl] Async spawn; defaults to node:child_process spawn.
- * @param {(c: string, a: string[], o: object) => {status: number|null}} [deps.spawnSyncImpl] Sync spawn used for PATH probes; defaults to node:child_process spawnSync.
- * @param {string} [deps.platform] OS platform; defaults to process.platform.
- * @param {{isTTY?: boolean, write: (s: string) => void}} [deps.attentionStream] Stream for BEL/OSC 9 hints; defaults to process.stderr.
+ * @param {(target: string, opts?: object) => Promise<import('node:child_process').ChildProcess>} [deps.openImpl] The `open`-package function; defaults to the real import.
+ * @param {{isTTY?: boolean, write: (s: string) => void}} [deps.attentionStream] Stream for the BEL cue; defaults to process.stderr.
  * @param {() => boolean} [deps.canLaunch] Headless/SSH check; defaults to canLaunchBrowser.
- * @returns {Promise<boolean>} Resolves true when the spawn exits 0, false otherwise.
+ * @returns {Promise<boolean>} Resolves true when the launch child exits 0, false otherwise.
  */
-export function defaultOpenBrowser(
+export async function defaultOpenBrowser(
   url,
-  {
-    spawnImpl = spawn,
-    spawnSyncImpl = spawnSync,
-    platform = process.platform,
-    attentionStream = process.stderr,
-    canLaunch = canLaunchBrowser,
-  } = {},
+  { openImpl = open, attentionStream = process.stderr, canLaunch = canLaunchBrowser } = {},
 ) {
   if (!canLaunch()) {
-    return Promise.resolve(false)
+    return false
   }
-  let cmd
-  let args
-  if (process.env.BROWSER) {
-    cmd = process.env.BROWSER
-    args = [url]
-  } else if (platform === 'win32') {
-    cmd = 'cmd'
-    args = ['/c', 'start', '', url]
-  } else if (platform === 'darwin') {
-    if (isChromeOnMac()) {
-      cmd = 'open'
-      args = ['-a', 'Google Chrome', url]
-    } else {
-      cmd = 'open'
-      args = [url]
-    }
-  } else {
-    cmd = 'xdg-open'
-    args = [url]
+  const opts = process.env.BROWSER ? { app: { name: process.env.BROWSER } } : undefined
+  let child
+  try {
+    child = await openImpl(url, opts)
+  } catch {
+    return false
   }
-  // On macOS the activation target depends on which app `open` will launch.
-  // `$BROWSER` (when set) names that binary directly; otherwise the macOS
-  // branch above forces Chrome when present and falls back to the user's
-  // default. Pass the most specific signal we have.
-  const activationCmd = process.env.BROWSER || (platform === 'darwin' && args[0] === '-a' ? args[1] : cmd)
+  emitTerminalBell(attentionStream)
+  if (!child || typeof child.on !== 'function') {
+    return false
+  }
   return new Promise(resolve => {
-    let child
-    try {
-      child = spawnImpl(cmd, args, { detached: true, stdio: 'ignore' })
-    } catch {
-      resolve(false)
-      return
-    }
     child.on('error', () => resolve(false))
     child.on('exit', code => resolve(code === 0))
     child.unref?.()
-    bringBrowserToFront({ cmd: activationCmd, spawnImpl, spawnSyncImpl, platform })
-    emitTerminalAttention(attentionStream)
   })
 }
 

--- a/lib/util/credential/oauth_flow.js
+++ b/lib/util/credential/oauth_flow.js
@@ -18,20 +18,59 @@ limitations under the License.
  * @file Managed OAuth flow credential factory.
  */
 
-import { spawn } from 'node:child_process'
+import { spawn, spawnSync } from 'node:child_process'
 import readline from 'node:readline'
 import { OAuth2Client } from 'google-auth-library'
 import { TokenCache } from './token_cache.js'
 import { startLoopbackServer } from './loopback_server.js'
+import { canLaunchBrowser } from './auth_login.js'
 import { SCOPES, MANAGED_OAUTH_CLIENT_ID, MANAGED_OAUTH_CLIENT_SECRET } from '../../constants.js'
 
+/* Process-lifetime cache for the macOS Chrome-presence probe. */
+let chromeOnMacCache
+
 /**
- * Opens the given URL in the user's default browser. Respects BROWSER env var.
- * Falls back to xdg-open (Linux), open (macOS), or start (Windows).
+ * Probes for Google Chrome on macOS via `mdfind`, caching the result for the
+ * lifetime of the process. Returns false on probe failure.
+ * @returns {boolean} True when a Chrome bundle is registered with Launch Services.
+ */
+function isChromeOnMac() {
+  if (chromeOnMacCache !== undefined) {
+    return chromeOnMacCache
+  }
+  try {
+    const result = spawnSync('mdfind', ['kMDItemCFBundleIdentifier == "com.google.Chrome"'], {
+      encoding: 'utf8',
+      timeout: 1500,
+    })
+    chromeOnMacCache = result.status === 0 && typeof result.stdout === 'string' && result.stdout.trim().length > 0
+  } catch {
+    chromeOnMacCache = false
+  }
+  return chromeOnMacCache
+}
+
+/**
+ * For tests: clears the process-lifetime Chrome-detection cache.
+ * @returns {void}
+ */
+export function _resetChromeDetectionCacheForTests() {
+  chromeOnMacCache = undefined
+}
+
+/**
+ * Opens the given URL in the user's default browser, with a few platform-aware
+ * preferences. Returns `false` (without spawning) on SSH/headless/container
+ * environments so the caller can show the paste-URL fallback. Respects
+ * `$BROWSER`. On macOS, when `$BROWSER` is unset and Google Chrome is
+ * installed, activates Chrome by name so the new tab comes forward.
  * @param {string} url The URL to open.
- * @returns {Promise<void>} Resolves once the browser process spawns.
+ * @returns {Promise<boolean>} Resolves true when the spawn exits 0, false otherwise.
  */
 export function defaultOpenBrowser(url) {
+  if (!canLaunchBrowser()) {
+    return Promise.resolve(false)
+  }
   let cmd
   let args
   if (process.env.BROWSER) {
@@ -41,8 +80,13 @@ export function defaultOpenBrowser(url) {
     cmd = 'cmd'
     args = ['/c', 'start', '', url]
   } else if (process.platform === 'darwin') {
-    cmd = 'open'
-    args = [url]
+    if (isChromeOnMac()) {
+      cmd = 'open'
+      args = ['-a', 'Google Chrome', url]
+    } else {
+      cmd = 'open'
+      args = [url]
+    }
   } else {
     cmd = 'xdg-open'
     args = [url]
@@ -53,6 +97,35 @@ export function defaultOpenBrowser(url) {
     child.on('exit', code => resolve(code === 0))
     child.unref()
   })
+}
+
+/**
+ * Writes the consent URL to stderr. On a TTY, the URL appears inside a
+ * bright-cyan Unicode box so it stands out in a busy shell. On non-TTY
+ * callers (MCP transports, log capture, piped output), a plain
+ * `Open this URL to consent:\n\n<url>\n\n` block is written instead.
+ * @param {string} url The consent URL to display.
+ * @param {{isTTY?: boolean, write: (chunk: string) => void}} [stream] The output stream; defaults to process.stderr.
+ * @returns {void}
+ */
+export function printConsentUrl(url, stream = process.stderr) {
+  if (!stream.isTTY) {
+    stream.write(`\nOpen this URL to consent:\n\n${url}\n\n`)
+    return
+  }
+  const CYAN = '\x1b[1;36m'
+  const RESET = '\x1b[0m'
+  const label = 'Open this URL in your browser to sign in:'
+  const width = Math.max(label.length, url.length) + 2
+  const top = '╔' + '═'.repeat(width) + '╗'
+  const bot = '╚' + '═'.repeat(width) + '╝'
+  const pad = text => '║ ' + text + ' '.repeat(width - text.length - 1) + '║'
+  stream.write('\n')
+  stream.write(`${CYAN}${top}${RESET}\n`)
+  stream.write(`${CYAN}${pad(label)}${RESET}\n`)
+  stream.write(`${CYAN}║${' '.repeat(width)}║${RESET}\n`)
+  stream.write(`${CYAN}${pad(url)}${RESET}\n`)
+  stream.write(`${CYAN}${bot}${RESET}\n\n`)
 }
 
 /**
@@ -269,7 +342,7 @@ export function oauthFlowCredential({
         if (onStatusUpdate) {
           onStatusUpdate(`Authentication required. Opening browser to consent URL: ${consentUrl}`)
         }
-        process.stderr.write(`\nOpen this URL to consent:\n\n${consentUrl}\n\n`)
+        printConsentUrl(consentUrl)
         const opened = await openBrowser(consentUrl)
         if (opened) {
           process.stderr.write('Tried to launch your default browser.\n')

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "google-auth-library": "^10.6.2",
         "googleapis": "^171.4.0",
         "gray-matter": "^4.0.3",
+        "open": "^10.2.0",
         "zod": "^4.4.3"
       },
       "bin": {
@@ -41,7 +42,7 @@
         "prettier-plugin-packagejson": "^3.0.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1038,6 +1039,21 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -1460,6 +1476,46 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -3029,6 +3085,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -3056,6 +3127,24 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-obj": {
@@ -3090,6 +3179,21 @@
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3611,6 +3715,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4044,6 +4166,18 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/safe-buffer": {
@@ -4636,6 +4770,21 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "google-auth-library": "^10.6.2",
     "googleapis": "^171.4.0",
     "gray-matter": "^4.0.3",
+    "open": "^10.2.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -77,6 +78,6 @@
     "prettier-plugin-packagejson": "^3.0.2"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   }
 }

--- a/test/local/auth_login.test.js
+++ b/test/local/auth_login.test.js
@@ -82,28 +82,65 @@ describe('isTokenLocallyValid', () => {
 })
 
 describe('canLaunchBrowser', () => {
+  /* Default fs stub: no /.dockerenv and no docker/kubepods cgroup. */
+  const fsClean = { existsSync: () => false, readFileSync: () => '' }
+
   test('When SSH_CONNECTION is set, then it returns false', () => {
-    assert.strictEqual(canLaunchBrowser({ env: { SSH_CONNECTION: '10.0.0.1 22' }, platform: 'darwin' }), false)
+    assert.strictEqual(
+      canLaunchBrowser({ env: { SSH_CONNECTION: '10.0.0.1 22' }, platform: 'darwin', fs: fsClean }),
+      false,
+    )
   })
 
   test('When SSH_TTY is set, then it returns false', () => {
-    assert.strictEqual(canLaunchBrowser({ env: { SSH_TTY: '/dev/pts/0' }, platform: 'linux' }), false)
+    assert.strictEqual(canLaunchBrowser({ env: { SSH_TTY: '/dev/pts/0' }, platform: 'linux', fs: fsClean }), false)
   })
 
   test('When the platform is Linux without DISPLAY or WAYLAND_DISPLAY, then it returns false', () => {
-    assert.strictEqual(canLaunchBrowser({ env: {}, platform: 'linux' }), false)
+    assert.strictEqual(canLaunchBrowser({ env: {}, platform: 'linux', fs: fsClean }), false)
   })
 
   test('When the platform is Linux with DISPLAY, then it returns true', () => {
-    assert.strictEqual(canLaunchBrowser({ env: { DISPLAY: ':0' }, platform: 'linux' }), true)
+    assert.strictEqual(canLaunchBrowser({ env: { DISPLAY: ':0' }, platform: 'linux', fs: fsClean }), true)
   })
 
   test('When the platform is darwin without SSH, then it returns true', () => {
-    assert.strictEqual(canLaunchBrowser({ env: {}, platform: 'darwin' }), true)
+    assert.strictEqual(canLaunchBrowser({ env: {}, platform: 'darwin', fs: fsClean }), true)
   })
 
   test('When the platform is win32 without SSH, then it returns true', () => {
-    assert.strictEqual(canLaunchBrowser({ env: {}, platform: 'win32' }), true)
+    assert.strictEqual(canLaunchBrowser({ env: {}, platform: 'win32', fs: fsClean }), true)
+  })
+
+  test('When /.dockerenv exists on Linux, then it returns false', () => {
+    const fs = { existsSync: p => p === '/.dockerenv', readFileSync: () => '' }
+    assert.strictEqual(canLaunchBrowser({ env: { DISPLAY: ':0' }, platform: 'linux', fs }), false)
+  })
+
+  test('When /proc/1/cgroup names docker on Linux, then it returns false', () => {
+    const fs = {
+      existsSync: () => false,
+      readFileSync: () => '12:cpu:/docker/abc123\n11:memory:/docker/abc123\n',
+    }
+    assert.strictEqual(canLaunchBrowser({ env: { DISPLAY: ':0' }, platform: 'linux', fs }), false)
+  })
+
+  test('When /proc/1/cgroup names kubepods on Linux, then it returns false', () => {
+    const fs = {
+      existsSync: () => false,
+      readFileSync: () => '0::/kubepods.slice/kubepods-besteffort.slice\n',
+    }
+    assert.strictEqual(canLaunchBrowser({ env: { DISPLAY: ':0' }, platform: 'linux', fs }), false)
+  })
+
+  test('When /proc/1/cgroup is unreadable on Linux, then container detection is skipped', () => {
+    const fs = {
+      existsSync: () => false,
+      readFileSync: () => {
+        throw new Error('ENOENT')
+      },
+    }
+    assert.strictEqual(canLaunchBrowser({ env: { DISPLAY: ':0' }, platform: 'linux', fs }), true)
   })
 })
 

--- a/test/local/credential-oauth-flow.test.js
+++ b/test/local/credential-oauth-flow.test.js
@@ -288,4 +288,164 @@ describe('printConsentUrl', () => {
     assert.ok(stream.text.includes('Open this URL to consent:'))
     assert.ok(stream.text.includes('https://example.test/consent'))
   })
+
+  it('When the output stream is a TTY, then the URL inside the box is wrapped with an OSC 8 hyperlink', () => {
+    const stream = makeCaptureStream(true)
+    const url = 'https://example.test/consent'
+    printConsentUrl(url, stream)
+    assert.ok(stream.text.includes(`${ESC}]8;;${url}${ESC}\\`), 'expected OSC 8 opener with url target')
+    assert.ok(stream.text.includes(`${ESC}]8;;${ESC}\\`), 'expected OSC 8 terminator')
+  })
+})
+
+/* Fake child process for spawn injection — tracks calls and exits cleanly. */
+function makeFakeSpawn() {
+  const calls = []
+  function spawnImpl(cmd, args) {
+    calls.push({ cmd, args })
+    const listeners = {}
+    const child = {
+      on(event, cb) {
+        listeners[event] = cb
+        if (event === 'exit') {
+          setImmediate(() => cb(0))
+        }
+        return child
+      },
+      unref() {},
+    }
+    return child
+  }
+  return { spawnImpl, calls }
+}
+
+describe('defaultOpenBrowser activation', () => {
+  function withoutBrowserEnv(fn) {
+    const prev = process.env.BROWSER
+    delete process.env.BROWSER
+    try {
+      return fn()
+    } finally {
+      if (prev === undefined) {
+        delete process.env.BROWSER
+      } else {
+        process.env.BROWSER = prev
+      }
+    }
+  }
+
+  it('When the platform is darwin, then an osascript activate call targets Google Chrome', async () => {
+    await withoutBrowserEnv(async () => {
+      _resetChromeDetectionCacheForTests()
+      const { spawnImpl, calls } = makeFakeSpawn()
+      const spawnSyncImpl = () => ({ status: 0, stdout: '/Applications/Google Chrome.app' })
+      const stream = makeCaptureStream(false)
+      await defaultOpenBrowser('https://example.test/consent', {
+        spawnImpl,
+        spawnSyncImpl,
+        platform: 'darwin',
+        attentionStream: stream,
+        canLaunch: () => true,
+      })
+      const osascript = calls.find(c => c.cmd === 'osascript')
+      assert.ok(osascript, 'expected an osascript spawn for window activation')
+      assert.ok(
+        osascript.args.some(a => /tell application "Google Chrome" to activate/.test(a)),
+        `expected activate script, got ${JSON.stringify(osascript.args)}`,
+      )
+    })
+  })
+
+  it('When the platform is win32, then a PowerShell AppActivate call targets the Chrome window', async () => {
+    await withoutBrowserEnv(async () => {
+      const { spawnImpl, calls } = makeFakeSpawn()
+      const stream = makeCaptureStream(false)
+      await defaultOpenBrowser('https://example.test/consent', {
+        spawnImpl,
+        spawnSyncImpl: () => ({ status: 1 }),
+        platform: 'win32',
+        attentionStream: stream,
+        canLaunch: () => true,
+      })
+      const ps = calls.find(c => c.cmd === 'powershell')
+      assert.ok(ps, 'expected a powershell spawn for AppActivate')
+      assert.ok(
+        ps.args.some(a => /AppActivate\('Chrome'\)/.test(a)),
+        `expected AppActivate('Chrome'), got ${JSON.stringify(ps.args)}`,
+      )
+    })
+  })
+
+  it('When the platform is linux and wmctrl is on PATH, then a wmctrl -a chrome call fires', async () => {
+    await withoutBrowserEnv(async () => {
+      const { spawnImpl, calls } = makeFakeSpawn()
+      const spawnSyncImpl = (cmd, args) => {
+        if (cmd === 'sh' && args?.[1]?.includes('command -v wmctrl')) {
+          return { status: 0 }
+        }
+        return { status: 1 }
+      }
+      const stream = makeCaptureStream(false)
+      await defaultOpenBrowser('https://example.test/consent', {
+        spawnImpl,
+        spawnSyncImpl,
+        platform: 'linux',
+        attentionStream: stream,
+        canLaunch: () => true,
+      })
+      const wmctrl = calls.find(c => c.cmd === 'wmctrl')
+      assert.ok(wmctrl, 'expected a wmctrl spawn for window activation')
+      assert.deepEqual(wmctrl.args, ['-a', 'chrome'])
+    })
+  })
+
+  it('When the platform is linux and wmctrl is missing, then no wmctrl spawn fires', async () => {
+    await withoutBrowserEnv(async () => {
+      const { spawnImpl, calls } = makeFakeSpawn()
+      const spawnSyncImpl = () => ({ status: 1 })
+      const stream = makeCaptureStream(false)
+      await defaultOpenBrowser('https://example.test/consent', {
+        spawnImpl,
+        spawnSyncImpl,
+        platform: 'linux',
+        attentionStream: stream,
+        canLaunch: () => true,
+      })
+      assert.equal(
+        calls.find(c => c.cmd === 'wmctrl'),
+        undefined,
+      )
+    })
+  })
+
+  it('When stderr is a TTY, then a BEL and OSC 9 attention hint are written after the launch', async () => {
+    await withoutBrowserEnv(async () => {
+      const { spawnImpl } = makeFakeSpawn()
+      const stream = makeCaptureStream(true)
+      await defaultOpenBrowser('https://example.test/consent', {
+        spawnImpl,
+        spawnSyncImpl: () => ({ status: 1 }),
+        platform: 'linux',
+        attentionStream: stream,
+        canLaunch: () => true,
+      })
+      assert.ok(stream.text.includes('\x07'), 'expected BEL character on TTY')
+      assert.ok(stream.text.includes('\x1b]9;'), 'expected OSC 9 notification sequence on TTY')
+    })
+  })
+
+  it('When stderr is not a TTY, then no BEL or OSC 9 sequence is written', async () => {
+    await withoutBrowserEnv(async () => {
+      const { spawnImpl } = makeFakeSpawn()
+      const stream = makeCaptureStream(false)
+      await defaultOpenBrowser('https://example.test/consent', {
+        spawnImpl,
+        spawnSyncImpl: () => ({ status: 1 }),
+        platform: 'linux',
+        attentionStream: stream,
+        canLaunch: () => true,
+      })
+      assert.equal(stream.text, '')
+    })
+  })
 })

--- a/test/local/credential-oauth-flow.test.js
+++ b/test/local/credential-oauth-flow.test.js
@@ -19,7 +19,12 @@ import assert from 'node:assert/strict'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import os from 'node:os'
-import { oauthFlowCredential } from '../../lib/util/credential/oauth_flow.js'
+import {
+  oauthFlowCredential,
+  defaultOpenBrowser,
+  printConsentUrl,
+  _resetChromeDetectionCacheForTests,
+} from '../../lib/util/credential/oauth_flow.js'
 
 async function tmpCachePath(name) {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'cep-mcp-oauth-test-'))
@@ -225,5 +230,62 @@ describe('oauthFlowCredential runLoginFlow', () => {
 
     const stat = await fs.stat(cachePath)
     assert.equal(stat.mode & 0o777, 0o600, `expected cache file mode 0600, got ${(stat.mode & 0o777).toString(8)}`)
+  })
+})
+
+describe('defaultOpenBrowser', () => {
+  /* eslint-disable require-atomic-updates */
+  it('When SSH_CONNECTION is set, then defaultOpenBrowser returns false without spawning', async () => {
+    const prev = process.env.SSH_CONNECTION
+    process.env.SSH_CONNECTION = '10.0.0.1 22 10.0.0.2 22'
+    _resetChromeDetectionCacheForTests()
+    try {
+      const result = await defaultOpenBrowser('https://example.test/consent')
+      assert.equal(result, false)
+    } finally {
+      if (prev === undefined) {
+        delete process.env.SSH_CONNECTION
+      } else {
+        process.env.SSH_CONNECTION = prev
+      }
+    }
+  })
+  /* eslint-enable require-atomic-updates */
+})
+
+/* Captures a write stream's stderr-style output for assertions. */
+function makeCaptureStream(isTTY) {
+  const chunks = []
+  return {
+    isTTY,
+    write(s) {
+      chunks.push(s)
+      return true
+    },
+    get text() {
+      return chunks.join('')
+    },
+  }
+}
+
+describe('printConsentUrl', () => {
+  const ESC = String.fromCharCode(0x1b)
+
+  it('When the output stream is a TTY, then the URL is wrapped in an ANSI-coloured box', () => {
+    const stream = makeCaptureStream(true)
+    printConsentUrl('https://example.test/consent', stream)
+    assert.ok(stream.text.includes(`${ESC}[1;36m`), 'expected bright-cyan ANSI sequence')
+    assert.ok(stream.text.includes('╔'), 'expected box top corner')
+    assert.ok(stream.text.includes('╚'), 'expected box bottom corner')
+    assert.ok(stream.text.includes('https://example.test/consent'))
+  })
+
+  it('When the output stream is not a TTY, then the plain URL block is written without ANSI', () => {
+    const stream = makeCaptureStream(false)
+    printConsentUrl('https://example.test/consent', stream)
+    assert.ok(!stream.text.includes(`${ESC}[`), 'expected no ANSI escape sequences')
+    assert.ok(!stream.text.includes('╔'), 'expected no box drawing characters')
+    assert.ok(stream.text.includes('Open this URL to consent:'))
+    assert.ok(stream.text.includes('https://example.test/consent'))
   })
 })

--- a/test/local/credential-oauth-flow.test.js
+++ b/test/local/credential-oauth-flow.test.js
@@ -19,12 +19,7 @@ import assert from 'node:assert/strict'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import os from 'node:os'
-import {
-  oauthFlowCredential,
-  defaultOpenBrowser,
-  printConsentUrl,
-  _resetChromeDetectionCacheForTests,
-} from '../../lib/util/credential/oauth_flow.js'
+import { oauthFlowCredential, defaultOpenBrowser, printConsentUrl } from '../../lib/util/credential/oauth_flow.js'
 
 async function tmpCachePath(name) {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'cep-mcp-oauth-test-'))
@@ -233,24 +228,109 @@ describe('oauthFlowCredential runLoginFlow', () => {
   })
 })
 
+/* Fake child process for openImpl injection — tracks calls and exits cleanly. */
+function makeFakeOpen() {
+  const calls = []
+  async function openImpl(url, opts) {
+    calls.push({ url, opts })
+    const listeners = {}
+    const child = {
+      on(event, cb) {
+        listeners[event] = cb
+        if (event === 'exit') {
+          setImmediate(() => cb(0))
+        }
+        return child
+      },
+      unref() {},
+    }
+    return child
+  }
+  return { openImpl, calls }
+}
+
 describe('defaultOpenBrowser', () => {
+  it('When canLaunchBrowser returns false, then defaultOpenBrowser returns false without invoking open', async () => {
+    const { openImpl, calls } = makeFakeOpen()
+    const result = await defaultOpenBrowser('https://example.test/consent', {
+      openImpl,
+      canLaunch: () => false,
+    })
+    assert.equal(result, false)
+    assert.equal(calls.length, 0)
+  })
+
+  it('When canLaunchBrowser returns true, then defaultOpenBrowser calls open with the URL and resolves true', async () => {
+    const { openImpl, calls } = makeFakeOpen()
+    const stream = makeCaptureStream(false)
+    const result = await defaultOpenBrowser('https://example.test/consent', {
+      openImpl,
+      canLaunch: () => true,
+      attentionStream: stream,
+    })
+    assert.equal(result, true)
+    assert.equal(calls.length, 1)
+    assert.equal(calls[0].url, 'https://example.test/consent')
+  })
+
   /* eslint-disable require-atomic-updates */
-  it('When SSH_CONNECTION is set, then defaultOpenBrowser returns false without spawning', async () => {
-    const prev = process.env.SSH_CONNECTION
-    process.env.SSH_CONNECTION = '10.0.0.1 22 10.0.0.2 22'
-    _resetChromeDetectionCacheForTests()
+  it('When $BROWSER is set, then defaultOpenBrowser passes it through as the open app name', async () => {
+    const prev = process.env.BROWSER
+    process.env.BROWSER = 'firefox'
     try {
-      const result = await defaultOpenBrowser('https://example.test/consent')
-      assert.equal(result, false)
+      const { openImpl, calls } = makeFakeOpen()
+      const stream = makeCaptureStream(false)
+      await defaultOpenBrowser('https://example.test/consent', {
+        openImpl,
+        canLaunch: () => true,
+        attentionStream: stream,
+      })
+      assert.equal(calls.length, 1)
+      assert.deepEqual(calls[0].opts, { app: { name: 'firefox' } })
     } finally {
       if (prev === undefined) {
-        delete process.env.SSH_CONNECTION
+        delete process.env.BROWSER
       } else {
-        process.env.SSH_CONNECTION = prev
+        process.env.BROWSER = prev
       }
     }
   })
   /* eslint-enable require-atomic-updates */
+
+  it('When open throws synchronously or rejects, then defaultOpenBrowser resolves false', async () => {
+    async function openImpl() {
+      throw new Error('spawn failed')
+    }
+    const stream = makeCaptureStream(false)
+    const result = await defaultOpenBrowser('https://example.test/consent', {
+      openImpl,
+      canLaunch: () => true,
+      attentionStream: stream,
+    })
+    assert.equal(result, false)
+  })
+
+  it('When stderr is a TTY, then a BEL is written after the launch', async () => {
+    const { openImpl } = makeFakeOpen()
+    const stream = makeCaptureStream(true)
+    await defaultOpenBrowser('https://example.test/consent', {
+      openImpl,
+      canLaunch: () => true,
+      attentionStream: stream,
+    })
+    assert.ok(stream.text.includes('\x07'), 'expected BEL character on TTY')
+  })
+
+  it('When stderr is not a TTY, then no BEL is written', async () => {
+    const { openImpl } = makeFakeOpen()
+    const stream = makeCaptureStream(false)
+    await defaultOpenBrowser('https://example.test/consent', {
+      openImpl,
+      canLaunch: () => true,
+      attentionStream: stream,
+    })
+    assert.equal(stream.text, '')
+  })
 })
 
 /* Captures a write stream's stderr-style output for assertions. */
@@ -295,157 +375,5 @@ describe('printConsentUrl', () => {
     printConsentUrl(url, stream)
     assert.ok(stream.text.includes(`${ESC}]8;;${url}${ESC}\\`), 'expected OSC 8 opener with url target')
     assert.ok(stream.text.includes(`${ESC}]8;;${ESC}\\`), 'expected OSC 8 terminator')
-  })
-})
-
-/* Fake child process for spawn injection — tracks calls and exits cleanly. */
-function makeFakeSpawn() {
-  const calls = []
-  function spawnImpl(cmd, args) {
-    calls.push({ cmd, args })
-    const listeners = {}
-    const child = {
-      on(event, cb) {
-        listeners[event] = cb
-        if (event === 'exit') {
-          setImmediate(() => cb(0))
-        }
-        return child
-      },
-      unref() {},
-    }
-    return child
-  }
-  return { spawnImpl, calls }
-}
-
-describe('defaultOpenBrowser activation', () => {
-  function withoutBrowserEnv(fn) {
-    const prev = process.env.BROWSER
-    delete process.env.BROWSER
-    try {
-      return fn()
-    } finally {
-      if (prev === undefined) {
-        delete process.env.BROWSER
-      } else {
-        process.env.BROWSER = prev
-      }
-    }
-  }
-
-  it('When the platform is darwin, then an osascript activate call targets Google Chrome', async () => {
-    await withoutBrowserEnv(async () => {
-      _resetChromeDetectionCacheForTests()
-      const { spawnImpl, calls } = makeFakeSpawn()
-      const spawnSyncImpl = () => ({ status: 0, stdout: '/Applications/Google Chrome.app' })
-      const stream = makeCaptureStream(false)
-      await defaultOpenBrowser('https://example.test/consent', {
-        spawnImpl,
-        spawnSyncImpl,
-        platform: 'darwin',
-        attentionStream: stream,
-        canLaunch: () => true,
-      })
-      const osascript = calls.find(c => c.cmd === 'osascript')
-      assert.ok(osascript, 'expected an osascript spawn for window activation')
-      assert.ok(
-        osascript.args.some(a => /tell application "Google Chrome" to activate/.test(a)),
-        `expected activate script, got ${JSON.stringify(osascript.args)}`,
-      )
-    })
-  })
-
-  it('When the platform is win32, then a PowerShell AppActivate call targets the Chrome window', async () => {
-    await withoutBrowserEnv(async () => {
-      const { spawnImpl, calls } = makeFakeSpawn()
-      const stream = makeCaptureStream(false)
-      await defaultOpenBrowser('https://example.test/consent', {
-        spawnImpl,
-        spawnSyncImpl: () => ({ status: 1 }),
-        platform: 'win32',
-        attentionStream: stream,
-        canLaunch: () => true,
-      })
-      const ps = calls.find(c => c.cmd === 'powershell')
-      assert.ok(ps, 'expected a powershell spawn for AppActivate')
-      assert.ok(
-        ps.args.some(a => /AppActivate\('Chrome'\)/.test(a)),
-        `expected AppActivate('Chrome'), got ${JSON.stringify(ps.args)}`,
-      )
-    })
-  })
-
-  it('When the platform is linux and wmctrl is on PATH, then a wmctrl -a chrome call fires', async () => {
-    await withoutBrowserEnv(async () => {
-      const { spawnImpl, calls } = makeFakeSpawn()
-      const spawnSyncImpl = (cmd, args) => {
-        if (cmd === 'sh' && args?.[1]?.includes('command -v wmctrl')) {
-          return { status: 0 }
-        }
-        return { status: 1 }
-      }
-      const stream = makeCaptureStream(false)
-      await defaultOpenBrowser('https://example.test/consent', {
-        spawnImpl,
-        spawnSyncImpl,
-        platform: 'linux',
-        attentionStream: stream,
-        canLaunch: () => true,
-      })
-      const wmctrl = calls.find(c => c.cmd === 'wmctrl')
-      assert.ok(wmctrl, 'expected a wmctrl spawn for window activation')
-      assert.deepEqual(wmctrl.args, ['-a', 'chrome'])
-    })
-  })
-
-  it('When the platform is linux and wmctrl is missing, then no wmctrl spawn fires', async () => {
-    await withoutBrowserEnv(async () => {
-      const { spawnImpl, calls } = makeFakeSpawn()
-      const spawnSyncImpl = () => ({ status: 1 })
-      const stream = makeCaptureStream(false)
-      await defaultOpenBrowser('https://example.test/consent', {
-        spawnImpl,
-        spawnSyncImpl,
-        platform: 'linux',
-        attentionStream: stream,
-        canLaunch: () => true,
-      })
-      assert.equal(
-        calls.find(c => c.cmd === 'wmctrl'),
-        undefined,
-      )
-    })
-  })
-
-  it('When stderr is a TTY, then a BEL and OSC 9 attention hint are written after the launch', async () => {
-    await withoutBrowserEnv(async () => {
-      const { spawnImpl } = makeFakeSpawn()
-      const stream = makeCaptureStream(true)
-      await defaultOpenBrowser('https://example.test/consent', {
-        spawnImpl,
-        spawnSyncImpl: () => ({ status: 1 }),
-        platform: 'linux',
-        attentionStream: stream,
-        canLaunch: () => true,
-      })
-      assert.ok(stream.text.includes('\x07'), 'expected BEL character on TTY')
-      assert.ok(stream.text.includes('\x1b]9;'), 'expected OSC 9 notification sequence on TTY')
-    })
-  })
-
-  it('When stderr is not a TTY, then no BEL or OSC 9 sequence is written', async () => {
-    await withoutBrowserEnv(async () => {
-      const { spawnImpl } = makeFakeSpawn()
-      const stream = makeCaptureStream(false)
-      await defaultOpenBrowser('https://example.test/consent', {
-        spawnImpl,
-        spawnSyncImpl: () => ({ status: 1 }),
-        platform: 'linux',
-        attentionStream: stream,
-        canLaunch: () => true,
-      })
-      assert.equal(stream.text, '')
-    })
   })
 })

--- a/test/local/credential-oauth-flow.test.js
+++ b/test/local/credential-oauth-flow.test.js
@@ -228,8 +228,8 @@ describe('oauthFlowCredential runLoginFlow', () => {
   })
 })
 
-/* Fake child process for openImpl injection — tracks calls and exits cleanly. */
-function makeFakeOpen() {
+/* Fake child process for openImpl injection — tracks calls and exits with the given code. */
+function makeFakeOpen({ exitCode = 0 } = {}) {
   const calls = []
   async function openImpl(url, opts) {
     calls.push({ url, opts })
@@ -238,7 +238,7 @@ function makeFakeOpen() {
       on(event, cb) {
         listeners[event] = cb
         if (event === 'exit') {
-          setImmediate(() => cb(0))
+          setImmediate(() => cb(exitCode))
         }
         return child
       },
@@ -310,15 +310,28 @@ describe('defaultOpenBrowser', () => {
     assert.equal(result, false)
   })
 
-  it('When stderr is a TTY, then a BEL is written after the launch', async () => {
-    const { openImpl } = makeFakeOpen()
+  it('When openBrowser exits with code 0 on TTY, then a BEL is written to stderr', async () => {
+    const { openImpl } = makeFakeOpen({ exitCode: 0 })
     const stream = makeCaptureStream(true)
-    await defaultOpenBrowser('https://example.test/consent', {
+    const result = await defaultOpenBrowser('https://example.test/consent', {
       openImpl,
       canLaunch: () => true,
       attentionStream: stream,
     })
+    assert.equal(result, true)
     assert.ok(stream.text.includes('\x07'), 'expected BEL character on TTY')
+  })
+
+  it('When openBrowser exits with code non-zero on TTY, then no BEL is written', async () => {
+    const { openImpl } = makeFakeOpen({ exitCode: 1 })
+    const stream = makeCaptureStream(true)
+    const result = await defaultOpenBrowser('https://example.test/consent', {
+      openImpl,
+      canLaunch: () => true,
+      attentionStream: stream,
+    })
+    assert.equal(result, false)
+    assert.ok(!stream.text.includes('\x07'), 'expected no BEL when launch exits non-zero')
   })
 
   it('When stderr is not a TTY, then no BEL is written', async () => {


### PR DESCRIPTION
## What this changes

`defaultOpenBrowser` now calls the `open` npm package instead of spawning `open` / `xdg-open` / `cmd start` directly. The platform-specific activation calls added in an earlier iteration (osascript on macOS, PowerShell `AppActivate` on Windows, `wmctrl` on Linux, OSC 9 desktop notification) are gone.

## Why

Forcing the browser to the foreground is not reliably solvable from the terminal side. The OS controls activation. The previous activation stack worked in the lucky cases and silently failed everywhere else, which is the worst of both worlds — fragile code that gave a false sense of completeness.

A survey of widely-used CLIs that face the same problem confirmed the boring answer: open the URL, print a clear terminal cue, accept that the user may need to click to focus the tab. None of `gh`, `gcloud`, `vercel`, `firebase`, or `npm` try to force focus; all of them rely on a prominent URL line and a brief instruction.

## What stayed

The terminal cue is still useful, so the parts of the earlier iteration that don't depend on OS activation remain:

- `printConsentUrl` renders a bright-cyan Unicode box on TTY stderr.
- The URL inside the box is wrapped in an OSC 8 hyperlink escape, so terminals that support it (iTerm2, WezTerm, kitty, Windows Terminal, VS Code, Ghostty) render it as clickable.
- A single BEL plays on TTY launch as an audible cue.
- `canLaunchBrowser` still short-circuits the launch in headless environments (SSH, no `DISPLAY`, container-via-cgroup), so the paste-back path is reached without a failed launch attempt.

## Prior art

The `open` package is used by [Vite](https://github.com/vitejs/vite), [Vercel CLI](https://github.com/vercel/vercel), [Storybook](https://github.com/storybookjs/storybook), and many others for the same cross-platform browser-launch problem. It handles platform detection, `$BROWSER` env-var honoring, and graceful failure.

## Engine bump

`open@v10` requires Node `>=20`. `engines.node` moves from `>=18.0.0` to `>=20.0.0`. Node 18 went EOL in April 2025.

## Tests

Unit tests cover the launcher-injection point, the headless short-circuit, the BEL on TTY, and the OSC 8 wrap. `npm run test:unit` and `npm run lint` both pass.

Closes #236.