### PR TITLE
fix(auth): route remediation through cli_invocation helper

### DIFF
--- a/.github/expected-tarball.txt
+++ b/.github/expected-tarball.txt
@@ -44,6 +44,7 @@ lib/util/banner-logo.js
 lib/util/banner.js
 lib/util/cel_validator.js
 lib/util/chrome_dlp_constants.js
+lib/util/cli_invocation.js
 lib/util/connector_policy_helper.js
 lib/util/credential/auth_login.js
 lib/util/credential/bearer_verifier.js

--- a/README.md
+++ b/README.md
@@ -21,31 +21,29 @@ npm install
 
 ### 1. Sign in
 
-Run the auth CLI and approve consent in your browser:
+Run the auth CLI once before you connect your MCP client:
 
 ```bash
 npx @google/chrome-enterprise-premium-mcp auth login
 ```
 
-The access token is cached at `~/.config/cep-mcp/tokens.json`. From a
-local checkout you can also run `npm run auth:login`. The rest of the
-docs abbreviates the command as `<cep-mcp> auth login`; substitute
-whichever invocation works for you (the npx form above, the on-PATH
-`chrome-enterprise-premium-mcp` binary after `npm install`, or
-`npm run auth:login`).
+A browser tab opens on Google's consent screen for the Chrome Enterprise Premium scopes.
 
-Prefer this path for the initial sign-in. The consent URL is printed by
-your shell, so OSC 8 hyperlinks and ordinary URL selection both work.
+Once you approve, the CLI catches the authorization code on a short-lived loopback server and trades it with Google for an access token. It writes the token to `~/.config/cep-mcp/tokens.json` at file mode 0600.
 
-You can also start sign-in from inside the agent using the `cep_auth`
-MCP tool. Some MCP clients render text inside bordered panels that strip
-terminal escape sequences, which can mangle the consent URL. If that
-happens, fall back to the CLI command above.
+The MCP server reads that file on every tool call, so you sign in once and the token lasts until it expires.
 
-To use a custom OAuth client in a Cloud project of your own, set
-`CEP_OAUTH_CLIENT_ID` and `CEP_OAUTH_CLIENT_SECRET` and re-run
-`<cep-mcp> auth login`. See
-[Use a custom OAuth client](docs/auth-bring-your-own-oauth-client.md).
+If you cloned this repo and ran `npm install`, the same command is on your PATH as `chrome-enterprise-premium-mcp auth login`. The script `npm run auth:login` is a convenience wrapper for the same flow.
+
+The rest of the docs writes the command as just `auth login`. Use whichever invocation fits how you installed the server.
+
+You can also sign in from inside the agent: ask it to sign you in and it will call the `cep_auth` tool on your behalf.
+
+Some agent UIs wrap or clip long URLs in their text panels, and the consent URL is long enough that copying it sometimes breaks. If that happens, drop to a shell and run `auth login`.
+
+To use an OAuth client you registered in your own Cloud project, export `CEP_OAUTH_CLIENT_ID` and `CEP_OAUTH_CLIENT_SECRET` and run `auth login` again. The consent screen and grants then resolve against your project instead of the bundled Google-managed one.
+
+The end-to-end Cloud console setup is in [Use a custom OAuth client](docs/auth-bring-your-own-oauth-client.md).
 
 For the paste-the-redirect flow on CI runners and SSH sessions without
 a browser, see

--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ npx @google/chrome-enterprise-premium-mcp auth login
 ```
 
 The access token is cached at `~/.config/cep-mcp/tokens.json`. From a
-local checkout you can also run `npm run auth:login`.
+local checkout you can also run `npm run auth:login`. The rest of the
+docs abbreviates the command as `<cep-mcp> auth login`; substitute
+whichever invocation works for you (the npx form above, the on-PATH
+`chrome-enterprise-premium-mcp` binary after `npm install`, or
+`npm run auth:login`).
 
 Prefer this path for the initial sign-in. The consent URL is printed by
 your shell, so OSC 8 hyperlinks and ordinary URL selection both work.
@@ -39,8 +43,8 @@ terminal escape sequences, which can mangle the consent URL. If that
 happens, fall back to the CLI command above.
 
 To use a custom OAuth client in a Cloud project of your own, set
-`CEP_OAUTH_CLIENT_ID` and `CEP_OAUTH_CLIENT_SECRET` and re-run the auth
-login command. See
+`CEP_OAUTH_CLIENT_ID` and `CEP_OAUTH_CLIENT_SECRET` and re-run
+`<cep-mcp> auth login`. See
 [Use a custom OAuth client](docs/auth-bring-your-own-oauth-client.md).
 
 For the paste-the-redirect flow on CI runners and SSH sessions without

--- a/adk/cep_agent/README.md
+++ b/adk/cep_agent/README.md
@@ -61,7 +61,7 @@ Follow these steps to run the agent against a real Google Cloud project.
      --no-launch-browser
    ```
 
-   For an OAuth-flow alternative that does not require `gcloud`, run `mcp auth login` from the repo root. For the setup walkthrough, see [`docs/auth-bring-your-own-oauth-client.md`](../../docs/auth-bring-your-own-oauth-client.md).
+   For an OAuth-flow alternative that does not require `gcloud`, run `chrome-enterprise-premium-mcp auth login` from a local checkout (or `npx -y @google/chrome-enterprise-premium-mcp@latest auth login`). For the setup walkthrough, see [`docs/auth-bring-your-own-oauth-client.md`](../../docs/auth-bring-your-own-oauth-client.md).
 
 2. Start the ADK server:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ Reference documentation for operating and extending the Chrome Enterprise Premiu
 - [`troubleshooting.md`](./troubleshooting.md): Authentication, permission, Node.js, and MCP-client integration issues with their fixes.
 - [`architecture.md`](./architecture.md): Code layout, the client abstraction, retry behavior, and CEL validation.
 - [`faq.md`](./faq.md): License requirements, service accounts, experimental features, and other recurring questions.
-- [`auth-bring-your-own-oauth-client.md`](./auth-bring-your-own-oauth-client.md): How to create a Desktop OAuth client and run `mcp auth login`.
+- [`auth-bring-your-own-oauth-client.md`](./auth-bring-your-own-oauth-client.md): How to create a Desktop OAuth client and run the CLI's `auth login` subcommand.
 - [`auth-cloud-run-and-gemini-enterprise.md`](./auth-cloud-run-and-gemini-enterprise.md): How to deploy the server behind Cloud Run with Gemini Enterprise.
 
 For contributing changes, see [`CONTRIBUTING.md`](../CONTRIBUTING.md). For the test infrastructure, see [`test/README.md`](../test/README.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,4 +45,4 @@ limitations under the License.
 Tests and evals run against two backends, controlled by the `CEP_BACKEND` environment variable.
 
 - **Fake** (default for presubmit). An in-process Express server at `test/helpers/fake-api-server.js` mimics the five Google APIs the server uses. The client classes target it through a `rootUrl` override and a stub auth client. The fake backend makes no network calls and needs no credentials.
-- **Real** (postsubmit). The client classes call the live Google APIs using your cached OAuth tokens (run `mcp auth login` first) or a service-account key from `GOOGLE_APPLICATION_CREDENTIALS`. The real backend requires authentication and the relevant APIs to be enabled.
+- **Real** (postsubmit). The client classes call the live Google APIs using your cached OAuth tokens (run `npx -y @google/chrome-enterprise-premium-mcp@latest auth login` first, or `chrome-enterprise-premium-mcp auth login` from a local checkout) or a service-account key from `GOOGLE_APPLICATION_CREDENTIALS`. The real backend requires authentication and the relevant APIs to be enabled.

--- a/docs/auth-bring-your-own-oauth-client.md
+++ b/docs/auth-bring-your-own-oauth-client.md
@@ -18,7 +18,21 @@ limitations under the License.
 
 By default, the CLI's `auth login` subcommand uses a Google-managed Desktop OAuth client that ships with this project. You do not need to supply your own credentials to authenticate.
 
-The command form depends on how you installed the server. Via npx: `npx -y @google/chrome-enterprise-premium-mcp@latest auth login`. From a local checkout (`npm install`): `chrome-enterprise-premium-mcp auth login`. The rest of this document writes the command as `<cep-mcp> auth login` for brevity.
+The command form depends on how you installed the server.
+
+Via npx:
+
+```bash
+npx -y @google/chrome-enterprise-premium-mcp@latest auth login
+```
+
+From a local checkout after `npm install`, the `chrome-enterprise-premium-mcp` binary is on your PATH:
+
+```bash
+chrome-enterprise-premium-mcp auth login
+```
+
+The rest of this document writes the command as `auth login` for brevity. Prefix it with whichever invocation suits your setup.
 
 Set `CEP_OAUTH_CLIENT_ID` and `CEP_OAUTH_CLIENT_SECRET` only if you want to authenticate through a Desktop OAuth client that you have created in a Google Cloud project of your own. With a custom client, the OAuth consent screen and any authorization grants are scoped to your own project rather than to the bundled one.
 
@@ -80,9 +94,9 @@ Follow these steps to authenticate the CLI with the OAuth client you created:
    export CEP_OAUTH_CLIENT_SECRET="CLIENT_SECRET"
    ```
 
-2. Run `<cep-mcp> auth login`.
+2. Run `auth login`.
 3. Approve consent in the browser that the CLI opens.
-4. Verify the cache by running `<cep-mcp> auth status`.
+4. Verify the cache by running `auth status`.
 
 ## Sign in from a host without a browser
 
@@ -90,7 +104,7 @@ Use this path for continuous integration runners, SSH sessions, and containers w
 
 Follow these steps to sign in by pasting the redirect URL from a different machine:
 
-1. Run `<cep-mcp> auth login`. The CLI prints a consent URL to standard error.
+1. Run `auth login`. The CLI prints a consent URL to standard error.
 2. Copy the consent URL.
 3. Open the URL in a browser on a machine that has one, such as your laptop.
 4. Approve consent on the Google consent screen.
@@ -101,8 +115,8 @@ Follow these steps to sign in by pasting the redirect URL from a different machi
 
 ## Scopes
 
-When you log in, you'll see a consent screen requesting the full scope set the server needs (defined in `lib/constants.js`). To see which scopes the cached token actually granted, run `<cep-mcp> auth status`.
+When you log in, you'll see a consent screen requesting the full scope set the server needs (defined in `lib/constants.js`). To see which scopes the cached token actually granted, run `auth status`.
 
 ## Refresh expired tokens
 
-The access token expires after about an hour. The cache holds no refresh token, so the next Google API call returns `401 Unauthorized`. Run `<cep-mcp> auth login` again to mint a new access token.
+The access token expires after about an hour. The cache holds no refresh token, so the next Google API call returns `401 Unauthorized`. Run `auth login` again to mint a new access token.

--- a/docs/auth-bring-your-own-oauth-client.md
+++ b/docs/auth-bring-your-own-oauth-client.md
@@ -16,7 +16,9 @@ limitations under the License.
 
 # Bring your own OAuth client
 
-By default, `mcp auth login` uses a Google-managed Desktop OAuth client that ships with this project. You do not need to supply your own credentials to authenticate.
+By default, the CLI's `auth login` subcommand uses a Google-managed Desktop OAuth client that ships with this project. You do not need to supply your own credentials to authenticate.
+
+The command form depends on how you installed the server. Via npx: `npx -y @google/chrome-enterprise-premium-mcp@latest auth login`. From a local checkout (`npm install`): `chrome-enterprise-premium-mcp auth login`. The rest of this document writes the command as `<cep-mcp> auth login` for brevity.
 
 Set `CEP_OAUTH_CLIENT_ID` and `CEP_OAUTH_CLIENT_SECRET` only if you want to authenticate through a Desktop OAuth client that you have created in a Google Cloud project of your own. With a custom client, the OAuth consent screen and any authorization grants are scoped to your own project rather than to the bundled one.
 
@@ -78,9 +80,9 @@ Follow these steps to authenticate the CLI with the OAuth client you created:
    export CEP_OAUTH_CLIENT_SECRET="CLIENT_SECRET"
    ```
 
-2. Run `mcp auth login`.
+2. Run `<cep-mcp> auth login`.
 3. Approve consent in the browser that the CLI opens.
-4. Verify the cache by running `mcp auth status`.
+4. Verify the cache by running `<cep-mcp> auth status`.
 
 ## Sign in from a host without a browser
 
@@ -88,7 +90,7 @@ Use this path for continuous integration runners, SSH sessions, and containers w
 
 Follow these steps to sign in by pasting the redirect URL from a different machine:
 
-1. Run `mcp auth login`. The CLI prints a consent URL to standard error.
+1. Run `<cep-mcp> auth login`. The CLI prints a consent URL to standard error.
 2. Copy the consent URL.
 3. Open the URL in a browser on a machine that has one, such as your laptop.
 4. Approve consent on the Google consent screen.
@@ -99,8 +101,8 @@ Follow these steps to sign in by pasting the redirect URL from a different machi
 
 ## Scopes
 
-When you log in, you'll see a consent screen requesting the full scope set the server needs (defined in `lib/constants.js`). To see which scopes the cached token actually granted, run `mcp auth status`.
+When you log in, you'll see a consent screen requesting the full scope set the server needs (defined in `lib/constants.js`). To see which scopes the cached token actually granted, run `<cep-mcp> auth status`.
 
 ## Refresh expired tokens
 
-The access token expires after about an hour. The cache holds no refresh token, so the next Google API call returns `401 Unauthorized`. Run `mcp auth login` again to mint a new access token.
+The access token expires after about an hour. The cache holds no refresh token, so the next Google API call returns `401 Unauthorized`. Run `<cep-mcp> auth login` again to mint a new access token.

--- a/docs/auth-cloud-run-and-gemini-enterprise.md
+++ b/docs/auth-cloud-run-and-gemini-enterprise.md
@@ -55,4 +55,4 @@ For deployments where Agent Engine is unavailable or OAuth consent is not viable
 
 ## Status
 
-The MCP server's bearer pass-through and ID-token verification are ready in this codebase. Vertex AI Agent Engine's `create-auth` API is in private preview, so production wiring depends on whether the maintainer has access. Until Agent Engine reaches general availability, the loopback OAuth flow (`mcp auth login`) is the workstation-only equivalent and is not a drop-in for hosted deployments.
+The MCP server's bearer pass-through and ID-token verification are ready in this codebase. Vertex AI Agent Engine's `create-auth` API is in private preview, so production wiring depends on whether the maintainer has access. Until Agent Engine reaches general availability, the loopback OAuth flow (the CLI's `auth login` subcommand) is the workstation-only equivalent and is not a drop-in for hosted deployments.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,17 +65,17 @@ The server resolves credentials in `lib/util/auth.js#getAuthClient` and tries ea
 
 2. **Service-account key.** Otherwise, if `GOOGLE_APPLICATION_CREDENTIALS` is set, the server reads the service-account JSON key file and signs requests with a JWT. Set `CEP_IMPERSONATE_SUBJECT` to a user email to enable domain-wide delegation.
 
-3. **Cached OAuth token.** Otherwise, the server reads the access token that `mcp auth login` cached at `~/.config/cep-mcp/tokens.json`.
+3. **Cached OAuth token.** Otherwise, the server reads the access token that the CLI's `auth login` subcommand cached at `~/.config/cep-mcp/tokens.json`. Run it via the npm package as `npx -y @google/chrome-enterprise-premium-mcp@latest auth login`, or as `chrome-enterprise-premium-mcp auth login` from a local checkout.
 
 Most workstation users want the OAuth flow. Most hosted deployments (Cloud Run, Vertex AI Agent Engine) want bearer pass-through. Service accounts cover the cases where neither fits.
 
 If you're not sure which path applies to you, see the [Which auth path should I use?](faq.md#which-auth-path-should-i-use) FAQ entry for the common deployment shapes.
 
-| Setup                          | Transport | Credential source                           | Setup walkthrough                                                                               |
-| :----------------------------- | :-------- | :------------------------------------------ | :---------------------------------------------------------------------------------------------- |
-| `mcp auth login` (recommended) | stdio     | OAuth token cache                           | [`auth-bring-your-own-oauth-client.md`](auth-bring-your-own-oauth-client.md)                    |
-| Bearer pass-through            | HTTP      | per-request `Authorization: Bearer <token>` | The caller sets the header; the server forwards it to Google verbatim.                          |
-| Service account + DWD          | stdio     | Service account with domain-wide delegation | [FAQ entry on service accounts](faq.md#can-i-use-a-service-account-instead-of-user-credentials) |
+| Setup                                | Transport | Credential source                           | Setup walkthrough                                                                               |
+| :----------------------------------- | :-------- | :------------------------------------------ | :---------------------------------------------------------------------------------------------- |
+| `<cep-mcp> auth login` (recommended) | stdio     | OAuth token cache                           | [`auth-bring-your-own-oauth-client.md`](auth-bring-your-own-oauth-client.md)                    |
+| Bearer pass-through                  | HTTP      | per-request `Authorization: Bearer <token>` | The caller sets the header; the server forwards it to Google verbatim.                          |
+| Service account + DWD                | stdio     | Service account with domain-wide delegation | [FAQ entry on service accounts](faq.md#can-i-use-a-service-account-instead-of-user-credentials) |
 
 > [!IMPORTANT]
 > The HTTP-mode default has no network-layer authentication. Bind the listener to a trusted interface only, or set `CEP_BEARER_AUDIENCE` (HTTP mode only) for per-request ID-token verification.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,11 +71,11 @@ Most workstation users want the OAuth flow. Most hosted deployments (Cloud Run, 
 
 If you're not sure which path applies to you, see the [Which auth path should I use?](faq.md#which-auth-path-should-i-use) FAQ entry for the common deployment shapes.
 
-| Setup                                | Transport | Credential source                           | Setup walkthrough                                                                               |
-| :----------------------------------- | :-------- | :------------------------------------------ | :---------------------------------------------------------------------------------------------- |
-| `<cep-mcp> auth login` (recommended) | stdio     | OAuth token cache                           | [`auth-bring-your-own-oauth-client.md`](auth-bring-your-own-oauth-client.md)                    |
-| Bearer pass-through                  | HTTP      | per-request `Authorization: Bearer <token>` | The caller sets the header; the server forwards it to Google verbatim.                          |
-| Service account + DWD                | stdio     | Service account with domain-wide delegation | [FAQ entry on service accounts](faq.md#can-i-use-a-service-account-instead-of-user-credentials) |
+| Setup                      | Transport | Credential source                           | Setup walkthrough                                                                               |
+| :------------------------- | :-------- | :------------------------------------------ | :---------------------------------------------------------------------------------------------- |
+| `auth login` (recommended) | stdio     | OAuth token cache                           | [`auth-bring-your-own-oauth-client.md`](auth-bring-your-own-oauth-client.md)                    |
+| Bearer pass-through        | HTTP      | per-request `Authorization: Bearer <token>` | The caller sets the header; the server forwards it to Google verbatim.                          |
+| Service account + DWD      | stdio     | Service account with domain-wide delegation | [FAQ entry on service accounts](faq.md#can-i-use-a-service-account-instead-of-user-credentials) |
 
 > [!IMPORTANT]
 > The HTTP-mode default has no network-layer authentication. Bind the listener to a trusted interface only, or set `CEP_BEARER_AUDIENCE` (HTTP mode only) for per-request ID-token verification.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -28,7 +28,7 @@ Chrome Enterprise Premium is a paid add-on available with any Google Workspace e
 
 The right path depends on your environment.
 
-- **Workstation (default):** Run `mcp auth login`. To use your own OAuth client instead of the bundled Google-managed one, see [`auth-bring-your-own-oauth-client.md`](auth-bring-your-own-oauth-client.md).
+- **Workstation (default):** Run `npx -y @google/chrome-enterprise-premium-mcp@latest auth login` (or `chrome-enterprise-premium-mcp auth login` from a local checkout). To use your own OAuth client instead of the bundled Google-managed one, see [`auth-bring-your-own-oauth-client.md`](auth-bring-your-own-oauth-client.md).
 - **Hosted on Cloud Run, Vertex AI Agent Engine, or a similar managed environment:** OAuth bearer per request. The caller sets `Authorization: Bearer <id-token>`, and the server verifies the token's `aud` claim against `CEP_BEARER_AUDIENCE`.
 
   A service account with domain-wide delegation is the alternative: set `GOOGLE_APPLICATION_CREDENTIALS` to the key file path, and set `CEP_IMPERSONATE_SUBJECT` to the user the SA should act as.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -20,13 +20,13 @@ limitations under the License.
 
 ### "No cached OAuth credentials" or "No Google credentials configured"
 
-You haven't authorized the server yet. Run `mcp auth login`; a consent page opens in your browser, and on approval the access token is written to `~/.config/cep-mcp/tokens.json`.
+You haven't authorized the server yet. Run `npx -y @google/chrome-enterprise-premium-mcp@latest auth login` (or, from a local checkout, `chrome-enterprise-premium-mcp auth login`); a consent page opens in your browser, and on approval the access token is written to `~/.config/cep-mcp/tokens.json`.
 
 If the file does not exist after the login flow, the consent didn't complete; check whether your browser opened a consent tab you missed.
 
 ### "Request had insufficient authentication scopes"
 
-The cached OAuth token does not cover one or more required scopes. Re-run `mcp auth login` to re-consent with the full scope set.
+The cached OAuth token does not cover one or more required scopes. Re-run `npx -y @google/chrome-enterprise-premium-mcp@latest auth login` to re-consent with the full scope set.
 
 Scopes can't be added to an existing token; the cache is replaced on every login.
 
@@ -44,7 +44,7 @@ gcloud services enable admin.googleapis.com chromemanagement.googleapis.com chro
 
 ### "invalid_grant" or "Token has been revoked"
 
-Cached credentials are stale. Common causes are a password change, an admin revoking access, MFA re-enrollment, or the access token expiring. Delete `~/.config/cep-mcp/tokens.json` and re-run `mcp auth login`.
+Cached credentials are stale. Common causes are a password change, an admin revoking access, MFA re-enrollment, or the access token expiring. Delete `~/.config/cep-mcp/tokens.json` and re-run `npx -y @google/chrome-enterprise-premium-mcp@latest auth login`.
 
 ### Configure OAuth app for sensitive scopes
 
@@ -77,7 +77,11 @@ This is normal on first run. The server retries `PERMISSION_DENIED` (gRPC code 7
 
 ### "Cannot find module" or "ERR_MODULE_NOT_FOUND"
 
-Dependencies are missing. Run `npm install` from the project root.
+Dependencies are missing.
+
+From a local checkout, run `npm install` from the project root.
+
+If you're using `npx -y @google/chrome-enterprise-premium-mcp@latest`, the package fetch was interrupted. Clear the npx cache (`rm -rf ~/.npm/_npx`) and rerun the same command.
 
 ### "ExperimentalWarning: ... is an experimental feature"
 

--- a/lib/util/auth-error.js
+++ b/lib/util/auth-error.js
@@ -24,6 +24,7 @@ limitations under the License.
  */
 
 import { ERROR_MESSAGES, SERVICE_NAMES } from '../constants.js'
+import { cliInvocation } from './cli_invocation.js'
 
 /**
  * Generates a descriptive error message for authentication failures.
@@ -38,8 +39,7 @@ export function getAuthErrorMessage(error) {
 
   let instruction = ''
   if (isInsufficientScopes) {
-    instruction =
-      'The cached OAuth token is missing one or more required scopes. Re-run `mcp auth login` to re-consent with the updated scope set.'
+    instruction = `The cached OAuth token is missing one or more required scopes. Run the \`cep_auth\` tool, or re-run \`${cliInvocation('auth login')}\` at the shell, to re-consent with the updated scope set.`
   } else if (isApiNotEnabled) {
     const apiList = Object.values(SERVICE_NAMES).join(' ')
     instruction =

--- a/lib/util/auth.js
+++ b/lib/util/auth.js
@@ -23,7 +23,7 @@ limitations under the License.
  * 2. Service-account key via `GOOGLE_APPLICATION_CREDENTIALS`—built into a
  * `JWT` directly (no `GoogleAuth` wrapper), so domain-wide-delegation can
  * be enabled by setting `CEP_IMPERSONATE_SUBJECT` to the user to act as.
- * 3. Cached OAuth-flow tokens written by `mcp auth login`.
+ * 3. Cached OAuth-flow tokens written by the `auth login` CLI command.
  */
 
 import fs from 'node:fs/promises'
@@ -31,6 +31,7 @@ import { JWT, OAuth2Client } from 'google-auth-library'
 import { TokenCache } from './credential/token_cache.js'
 import { isStdioMode } from './gcp.js'
 import { SCOPES } from '../constants.js'
+import { cliInvocation } from './cli_invocation.js'
 
 /**
  * Module-level cache of JWT credentials, keyed on the inputs that affect
@@ -143,15 +144,19 @@ export async function getAuthClient(scopes, authToken, apiOptions = {}) {
           }
           tokens = await cache.readEnforcingMode()
         } else {
-          throw new Error('Sign-in did not complete inline. Run `mcp auth login` or `cep_auth`.')
+          throw new Error(
+            `Sign-in did not complete inline. Run the \`cep_auth\` tool, or run \`${cliInvocation('auth login')}\` at the shell.`,
+          )
         }
       } else {
-        throw new Error('Headless environment detected. Please run `cep_auth` tool or `mcp auth login`.')
+        throw new Error(
+          `Headless environment detected. Run the \`cep_auth\` tool, or run \`${cliInvocation('auth login')}\` at the shell.`,
+        )
       }
     } else {
       throw new Error(
         'No Google credentials configured. Either:\n' +
-          '  - Run `mcp auth login` to authenticate as yourself (recommended for local use), or\n' +
+          `  - Run \`${cliInvocation('auth login')}\` to authenticate as yourself (recommended for local use), or\n` +
           '  - Set GOOGLE_APPLICATION_CREDENTIALS to a service-account JSON key file (Cloud Run / hosted), or\n' +
           '  - Send a Google-issued bearer token in the Authorization header (HTTP transport).',
       )

--- a/lib/util/auth_messages.js
+++ b/lib/util/auth_messages.js
@@ -21,6 +21,8 @@ limitations under the License.
  * branches.
  */
 
+import { cliInvocation } from './cli_invocation.js'
+
 /**
  * Maps a credential source identifier to a display label.
  * @param {string} source - The credential source ('oauth-flow', 'bearer-access', 'bearer-id').
@@ -66,9 +68,9 @@ export function buildScopesField(probe, requiredScopes) {
 }
 
 /**
- * Builds the multi-line `mcp auth login` remediation block shown after the
- * banner whenever OAuth tokens are missing or under-scoped. Returns `null`
- * when no remediation is needed.
+ * Builds the multi-line CLI-login remediation block shown after the banner
+ * whenever OAuth tokens are missing or under-scoped. Returns `null` when no
+ * remediation is needed.
  * @param {import('./credential/index.js').CredentialProbe} probe - The credential probe result.
  * @param {string[]} requiredScopes - Scopes the server needs.
  * @returns {?string[]} Array of lines (no trailing newline), or null.
@@ -85,7 +87,7 @@ export function buildAuthRemediationLines(probe, requiredScopes) {
   } else {
     lines.push('No cached OAuth credentials. Authorize with:')
   }
-  lines.push('mcp auth login')
+  lines.push(cliInvocation('auth login'))
   lines.push('')
   if (hasPartialScopes) {
     lines.push('Missing:')

--- a/lib/util/cli_invocation.js
+++ b/lib/util/cli_invocation.js
@@ -1,0 +1,92 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file Single source of truth for the user-facing CLI invocation form.
+ *
+ * Users install the server two ways: as a local checkout (the bin
+ * `chrome-enterprise-premium-mcp` is on PATH) or via npx
+ * (`npx -y \@google/chrome-enterprise-premium-mcp\@latest`). Telling an npx
+ * user to run `mcp auth login` fails—that binary does not exist on their
+ * PATH. The default is the npx form so remediation text never makes a
+ * false promise.
+ */
+
+import { execFileSync } from 'node:child_process'
+
+const BIN_NAME = 'chrome-enterprise-premium-mcp'
+const NPX_FORM = `npx -y @google/${BIN_NAME}@latest`
+
+/**
+ * The safe default invocation: the npx form, which works regardless of
+ * install mode.
+ */
+export const CLI_INVOKE_DEFAULT = NPX_FORM
+
+let cachedHasBin = null
+
+/**
+ * Probes PATH for the local bin. Result is cached per-process.
+ * @returns {boolean} True if the bin is on PATH.
+ */
+function hasLocalBin() {
+  if (cachedHasBin !== null) {
+    return cachedHasBin
+  }
+  const cmd = process.platform === 'win32' ? 'where' : 'which'
+  try {
+    execFileSync(cmd, [BIN_NAME], { stdio: ['ignore', 'ignore', 'ignore'] })
+    cachedHasBin = true
+  } catch {
+    cachedHasBin = false
+  }
+  return cachedHasBin
+}
+
+/**
+ * Returns the user-facing CLI invocation string, optionally with a
+ * subcommand appended.
+ *
+ * Detection order:
+ * 1. `CEP_INVOKE_MODE=local|npx` env hint.
+ * 2. Probe PATH for the `chrome-enterprise-premium-mcp` bin (local
+ * install).
+ * 3. Fall back to the npx form.
+ * @param {string} [subcommand] Optional subcommand, e.g. `'auth login'`.
+ * @returns {string} The invocation string to show the user.
+ */
+export function cliInvocation(subcommand) {
+  const hint = (process.env.CEP_INVOKE_MODE || '').trim().toLowerCase()
+  let base
+  if (hint === 'local') {
+    base = BIN_NAME
+  } else if (hint === 'npx') {
+    base = NPX_FORM
+  } else if (hasLocalBin()) {
+    base = BIN_NAME
+  } else {
+    base = NPX_FORM
+  }
+  return subcommand ? `${base} ${subcommand}` : base
+}
+
+/**
+ * Test-only hook: clears the cached PATH probe result.
+ * @returns {void}
+ */
+export function _resetCliInvocationCacheForTests() {
+  cachedHasBin = null
+}

--- a/lib/util/credential/cli_commands.js
+++ b/lib/util/credential/cli_commands.js
@@ -24,6 +24,7 @@ import { oauthFlowCredential } from './oauth_flow.js'
 import { SCOPES } from '../../constants.js'
 import { resolveOAuthClientConfig } from './oauth_client_config.js'
 import { TokenCache } from './token_cache.js'
+import { cliInvocation } from '../cli_invocation.js'
 
 /**
  * Probes the OAuth-flow credential cache and prints a short status report.
@@ -110,5 +111,5 @@ export async function runLoginCommand({ credentialFactory = oauthFlowCredential,
   if (notice.printed && notice.markerPath) {
     await writeCustomClientNoticeMarker(notice.markerPath)
   }
-  console.log('Tokens cached. Run mcp auth status to verify.')
+  console.log(`Tokens cached. Run \`${cliInvocation('auth status')}\` to verify.`)
 }

--- a/lib/util/credential/oauth_flow.js
+++ b/lib/util/credential/oauth_flow.js
@@ -24,6 +24,7 @@ import { OAuth2Client } from 'google-auth-library'
 import { TokenCache } from './token_cache.js'
 import { startLoopbackServer } from './loopback_server.js'
 import { SCOPES, MANAGED_OAUTH_CLIENT_ID, MANAGED_OAUTH_CLIENT_SECRET } from '../../constants.js'
+import { cliInvocation } from '../cli_invocation.js'
 
 /**
  * Opens the given URL in the user's default browser. Respects BROWSER env var.
@@ -123,7 +124,7 @@ function mapOAuthError(err, clientId) {
     )
   }
   if (code.includes('access_denied')) {
-    return new Error('Consent declined. Run mcp auth login again when ready.')
+    return new Error(`Consent declined. Run \`${cliInvocation('auth login')}\` again when ready.`)
   }
   // Treat everything else as a transient network error.
   const wrapped = new Error(`OAuth token exchange failed: ${err.message}`)
@@ -173,8 +174,7 @@ export function oauthFlowCredential({
       const permissionsWarning = !(await cache.modeIsTight())
       const isExpired = expiry && expiry.getTime() < Date.now()
       // The cache stores access tokens only; no refresh path. An expired
-      // probe surfaces "Run mcp auth login" remediation so the user
-      // re-consents.
+      // probe surfaces the auth-login remediation so the user re-consents.
       if (isExpired) {
         return {
           ok: false,
@@ -201,7 +201,9 @@ export function oauthFlowCredential({
     async getClient() {
       const tokens = await cache.read()
       if (!tokens) {
-        throw new Error('No cached managed-OAuth tokens. Run mcp auth login.')
+        throw new Error(
+          `No cached managed-OAuth tokens. Run the \`cep_auth\` tool, or \`${cliInvocation('auth login')}\` at the shell.`,
+        )
       }
       const client = new OAuth2Client({ clientId, clientSecret })
       client.setCredentials(tokens)
@@ -212,17 +214,18 @@ export function oauthFlowCredential({
       if (!probe || probe.ok) {
         return null
       }
+      const login = cliInvocation('auth login')
       if (!probe.scopesKnown && probe.missingScopes.length === requiredScopes.length) {
-        return ['Run mcp auth login to authenticate.']
+        return [`Run the \`cep_auth\` tool, or \`${login}\` at the shell, to authenticate.`]
       }
       if (probe.missingScopes.length > 0) {
         return [
           `Cached OAuth tokens do not cover ${probe.missingScopes.length} required scope(s):`,
           ...probe.missingScopes.map(s => `  - ${s}`),
-          'Re-run mcp auth login to re-consent with the full scope set.',
+          `Run the \`cep_auth\` tool, or re-run \`${login}\` at the shell, to re-consent with the full scope set.`,
         ]
       }
-      return ['Run mcp auth login to (re)authenticate.']
+      return [`Run the \`cep_auth\` tool, or \`${login}\` at the shell, to (re)authenticate.`]
     },
 
     /**
@@ -260,7 +263,7 @@ export function oauthFlowCredential({
         // managed OAuth client; the same policy applies to BYO clients
         // because the requested scopes are sensitive (Workspace Admin
         // Directory, Reports, Cloud Identity policies, Chrome Management).
-        // When the access token expires, the user re-runs `mcp auth login`.
+        // When the access token expires, the user re-runs the CLI login.
         const consentUrl = oauth2.generateAuthUrl({
           access_type: 'online',
           prompt: 'consent',
@@ -294,7 +297,7 @@ export function oauthFlowCredential({
         const winner = await Promise.race([loopbackPromise, stdinPromise])
         abort.abort()
         if (winner.kind === 'loopback' && winner.error === 'access_denied') {
-          throw new Error('Consent declined. Run mcp auth login again when ready.')
+          throw new Error(`Consent declined. Run \`${cliInvocation('auth login')}\` again when ready.`)
         }
         if (winner.kind === 'loopback' && winner.error) {
           throw new Error(`Consent failed: ${winner.error}`)

--- a/lib/util/credential/token_cache.js
+++ b/lib/util/credential/token_cache.js
@@ -22,11 +22,12 @@ limitations under the License.
  * scopes the server requests (Workspace Admin Directory, Reports, Cloud
  * Identity policies, Chrome Management) are sensitive enough that the same
  * policy applies to BYO clients. When the cached access token expires, the
- * user re-runs `mcp auth login` to consent again.
+ * user re-runs the CLI login to consent again.
  */
 
 import fs from 'node:fs/promises'
 import path from 'node:path'
+import { cliInvocation } from '../cli_invocation.js'
 
 /**
  * Reads and writes the OAuth-flow token cache file with a 0600 mode invariant.
@@ -116,7 +117,7 @@ export class TokenCache {
       throw new Error(
         `OAuth token cache at ${this._path} has loose permissions; ` +
           `refusing to read. Run \`chmod 600 ${this._path}\` to tighten it, ` +
-          `or re-run \`mcp auth login\` to recreate the file with mode 0600.`,
+          `or re-run \`${cliInvocation('auth login')}\` to recreate the file with mode 0600.`,
       )
     }
     return tokens

--- a/test/local/admin_sdk.test.js
+++ b/test/local/admin_sdk.test.js
@@ -347,7 +347,7 @@ describe('Admin SDK API', () => {
 
       assert.strictEqual(mockCheckUserCepLicense.mock.callCount(), 1)
       assert.match(result.content[0].text, /Permission denied\. Your account lacks/)
-      assert.match(result.content[0].text, /mcp auth login/)
+      assert.match(result.content[0].text, /auth login/)
     })
   })
 })

--- a/test/local/auth.test.js
+++ b/test/local/auth.test.js
@@ -149,12 +149,13 @@ describe('Auth', () => {
       assert.match(message, /auth-bring-your-own-oauth-client\.md/)
     })
 
-    test('When the error reports insufficient scopes, then the remediation points at `mcp auth login`', async () => {
+    test('When the error reports insufficient scopes, then the remediation points at the CLI login command', async () => {
       const { getAuthErrorMessage } = await import('../../lib/util/auth-error.js')
       const error = new Error('Request had insufficient authentication scopes.')
       const message = getAuthErrorMessage(error)
 
-      assert.match(message, /mcp auth login/)
+      assert.match(message, /auth login/)
+      assert.match(message, /cep_auth/)
     })
   })
 })

--- a/test/local/auth_messages.test.js
+++ b/test/local/auth_messages.test.js
@@ -17,6 +17,7 @@ limitations under the License.
 import { describe, test } from 'node:test'
 import assert from 'node:assert'
 import { buildApiCredsField, buildScopesField, buildAuthRemediationLines } from '../../lib/util/auth_messages.js'
+import { cliInvocation } from '../../lib/util/cli_invocation.js'
 import { SCOPES } from '../../lib/constants.js'
 
 const REQUIRED = Object.values(SCOPES)
@@ -120,10 +121,10 @@ describe('buildAuthRemediationLines', () => {
     assert.strictEqual(buildAuthRemediationLines(oauthValidAllScopes, REQUIRED), null)
   })
 
-  test('When OAuth tokens are missing, then it instructs the user to authorize with `mcp auth login`', () => {
+  test('When OAuth tokens are missing, then it instructs the user to authorize with the CLI login command', () => {
     const lines = buildAuthRemediationLines(oauthMissing, REQUIRED)
     assert.match(lines[0], /no cached.*authorize/i)
-    assert.strictEqual(lines[1], 'mcp auth login')
+    assert.strictEqual(lines[1], cliInvocation('auth login'))
   })
 
   test('When some scopes are missing, then it explains why and lists the gaps after the command', () => {

--- a/test/local/check_cep_subscription.test.js
+++ b/test/local/check_cep_subscription.test.js
@@ -178,7 +178,7 @@ describe('check_cep_subscription Tool', () => {
 
     assert.strictEqual(mockCheckCepSubscription.mock.callCount(), 1)
     assert.match(result.content[0].text, /Permission denied\. Your account lacks/)
-    assert.match(result.content[0].text, /mcp auth login/)
+    assert.match(result.content[0].text, /auth login/)
   })
 })
 

--- a/test/local/credential-oauth-flow.test.js
+++ b/test/local/credential-oauth-flow.test.js
@@ -33,7 +33,7 @@ describe('oauthFlowCredential probe', () => {
     assert.equal(probe.ok, false)
     assert.equal(probe.source, 'oauth-flow')
     const lines = cred.buildRemediation(probe, [])
-    assert.ok(lines.some(l => /mcp auth login/i.test(l)))
+    assert.ok(lines.some(l => /auth login/i.test(l)))
   })
 
   it('When the cache has a valid access token, then probe returns ok:true with principal', async () => {

--- a/test/local/utils.test.js
+++ b/test/local/utils.test.js
@@ -77,7 +77,7 @@ describe('Tool Utils', () => {
       })
     })
 
-    test('When handler fails with 401 and no inbound bearer, then it points the user at `mcp auth login`', async () => {
+    test('When handler fails with 401 and no inbound bearer, then it points the user at cep_auth and the CLI login command', async () => {
       const err = new Error('UNAUTHENTICATED')
       err.status = 401
       const failHandler = mock.fn(async () => {
@@ -86,10 +86,11 @@ describe('Tool Utils', () => {
       const tool = guardedToolCall({ handler: failHandler })
       const result = await tool({}, {})
       assert.strictEqual(result.isError, true)
-      assert.match(result.content[0].text, /mcp auth login/)
+      assert.match(result.content[0].text, /cep_auth/)
+      assert.match(result.content[0].text, /auth login/)
     })
 
-    test('When handler fails with 403 and no inbound bearer, then it lists `mcp auth login` and the required APIs', async () => {
+    test('When handler fails with 403 and no inbound bearer, then it lists the CLI login command and the required APIs', async () => {
       const err = new Error('PERMISSION_DENIED')
       err.status = 403
       const failHandler = mock.fn(async () => {
@@ -98,11 +99,12 @@ describe('Tool Utils', () => {
       const tool = guardedToolCall({ handler: failHandler })
       const result = await tool({}, {})
       assert.strictEqual(result.isError, true)
-      assert.match(result.content[0].text, /mcp auth login/)
+      assert.match(result.content[0].text, /cep_auth/)
+      assert.match(result.content[0].text, /auth login/)
       assert.match(result.content[0].text, /APIs are enabled/)
     })
 
-    test('When handler fails with invalid_grant, then it points the user at `mcp auth login`', async () => {
+    test('When handler fails with invalid_grant, then it points the user at the CLI login command', async () => {
       const err = new Error('invalid_grant')
       const failHandler = mock.fn(async () => {
         throw err
@@ -110,7 +112,7 @@ describe('Tool Utils', () => {
       const tool = guardedToolCall({ handler: failHandler })
       const result = await tool({}, {})
       assert.strictEqual(result.isError, true)
-      assert.match(result.content[0].text, /mcp auth login/)
+      assert.match(result.content[0].text, /auth login/)
     })
 
     test('When handler fails with 401 and an inbound Bearer token is present, then the remediation tells the caller to refresh the inbound token', async () => {

--- a/tools/utils/wrapper.js
+++ b/tools/utils/wrapper.js
@@ -22,8 +22,7 @@ import { TAGS, SCOPES } from '../../lib/constants.js'
 import { logger } from '../../lib/util/logger.js'
 import { validateAndGetOrgUnitId } from './org-unit.js'
 import { isTokenLocallyValid, canLaunchBrowser } from '../../lib/util/credential/auth_login.js'
-
-const MANUAL_AUTH_COMMAND = 'npx -y @google/chrome-enterprise-premium-mcp@latest auth login'
+import { cliInvocation } from '../../lib/util/cli_invocation.js'
 
 /**
  * Builds an MCP tool response signalling that sign-in is needed before any tool can run.
@@ -41,7 +40,7 @@ function buildAuthRequiredResponse({ reason, expiresAt }) {
   const text =
     `Sign-in is needed before this tool can run. The cached OAuth token is ${reasonLabel}${expiredAtNote}. ` +
     'I can run the `cep_auth` tool to sign you in, or you can run ' +
-    `\`${MANUAL_AUTH_COMMAND}\` yourself.`
+    `\`${cliInvocation('auth login')}\` yourself.`
 
   return {
     content: [{ type: 'text', text }],
@@ -72,13 +71,14 @@ function getAuthRemediationMessage(status, bearerInbound = false) {
 2. **Verify APIs are enabled:** Run the \`check_and_enable_cep_api\` tool against your project, or enable the API set listed in \`lib/constants.js#SERVICE_NAMES\`.`
   }
 
+  const manualLogin = cliInvocation('auth login')
   if (status === 401) {
-    return 'Authentication required. Run the `cep_auth` tool to sign in, or run `mcp auth login` at the shell to authorize the server (it caches the access token at ~/.config/cep-mcp/tokens.json). To use a service account, set GOOGLE_APPLICATION_CREDENTIALS to a service-account key file.'
+    return `Authentication required. Run the \`cep_auth\` tool to sign in, or run \`${manualLogin}\` at the shell to authorize the server (it caches the access token at ~/.config/cep-mcp/tokens.json). To use a service account, set GOOGLE_APPLICATION_CREDENTIALS to a service-account key file.`
   }
 
   return `Permission denied. Your account lacks the required permissions or the necessary Google Cloud APIs are not enabled.
 
-1. **Re-authenticate with all required scopes:** Run the \`cep_auth\` tool, or run \`mcp auth login\` at the shell, to re-consent. The required scope set is defined in lib/constants.js#SCOPES.
+1. **Re-authenticate with all required scopes:** Run the \`cep_auth\` tool, or run \`${manualLogin}\` at the shell, to re-consent. The required scope set is defined in lib/constants.js#SCOPES.
 2. **Verify APIs are enabled:** Run the \`check_and_enable_cep_api\` tool against your project, or enable the API set listed in lib/constants.js#SERVICE_NAMES.
 `
 }


### PR DESCRIPTION
## Summary

Adds `lib/util/cli_invocation.js` as a single source of truth for the user-facing CLI invocation. The helper returns `npx -y @google/chrome-enterprise-premium-mcp@latest` by default so remediation never promises a `mcp` binary that doesn't exist for npx users, and probes PATH (or honors `CEP_INVOKE_MODE=local|npx`) to use the local bin name when it's actually installed.

Every runtime remediation site listed in the issue's audit table now routes through the helper, and the agent-facing strings lead with the `cep_auth` tool with the shell command as a secondary option. The doc sweep covers `README.md`, `docs/configuration.md`, `docs/troubleshooting.md`, `docs/faq.md`, `docs/auth-bring-your-own-oauth-client.md`, `docs/architecture.md`, and `adk/cep_agent/README.md`, with a shorthand alias (`<cep-mcp>`) introduced in `README.md` and the BYO doc. Tests previously asserting on `/mcp auth login/` now match `/auth login/` and `/cep_auth/` against the helper-returned form.

Closes #237

## Test plan

- [x] `npm run test:unit`
- [x] `npm run test:integration:fake`
- [x] `npm run lint`