### PR TITLE
fix(auth): OSC 8 hyperlink + own-line consent URL

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -6,10 +6,7 @@
   "mcpServers": {
     "chrome-enterprise-premium": {
       "command": "npx",
-      "args": [
-        "-y",
-        "@google/chrome-enterprise-premium-mcp@^1.4.0"
-      ]
+      "args": ["-y", "@google/chrome-enterprise-premium-mcp@^1.4.0"]
     }
   }
 }

--- a/test/local/auth-tool.test.js
+++ b/test/local/auth-tool.test.js
@@ -84,6 +84,17 @@ describe('cep_auth Tool', () => {
     assert.ok(result.structuredContent.agentHint?.length > 0)
     assert.match(result.content[0].text, /Open this URL/)
     assert.match(result.content[0].text, /accounts\.google\.com/)
+
+    const lines = result.content[0].text.split('\n')
+    const urlLineIndex = lines.findIndex(l => l.includes('https://accounts.google.com/o/oauth2/v2/auth?state=ABC'))
+    assert.ok(urlLineIndex > 0, 'authUrl should appear in the text block')
+    assert.strictEqual(lines[urlLineIndex - 1], '', 'authUrl should have a blank line above it')
+    assert.strictEqual(lines[urlLineIndex + 1], '', 'authUrl should have a blank line below it')
+
+    const ESC = '\x1b'
+    const url = 'https://accounts.google.com/o/oauth2/v2/auth?state=ABC'
+    const expected = `${ESC}]8;;${url}${ESC}\\${url}${ESC}]8;;${ESC}\\`
+    assert.strictEqual(lines[urlLineIndex], expected, 'authUrl line should be wrapped in OSC 8 hyperlink escapes')
   })
 
   test('When cep_auth is invoked with a valid redirectUrl, then it calls completeToolAuth and returns status=completed', async () => {

--- a/tools/definitions/auth.js
+++ b/tools/definitions/auth.js
@@ -36,6 +36,21 @@ const AGENT_HINT =
   'ask the user to paste that full URL back. Then call cep_auth again with the pasted URL as ' +
   'the redirectUrl argument.'
 
+/* OSC 8 hyperlink: ESC ] 8 ; ; URI ST text ESC ] 8 ; ; ST, where ST is ESC \. */
+const OSC = '\x1b]8;;'
+const ST = '\x1b\x5c'
+
+/**
+ * Wraps a URL in OSC 8 hyperlink escapes. Modern terminals render the visible
+ * text as a clickable link to the same URL; others show the URL bytes plus
+ * a few stray escape chars but the URL itself remains selectable.
+ * @param {string} url The URL to render as a hyperlink.
+ * @returns {string} The OSC 8 wrapped URL.
+ */
+function osc8(url) {
+  return `${OSC}${url}${ST}${url}${OSC}${ST}`
+}
+
 /**
  * Registers the authentication tools with the MCP server (alias for registerAuthTools).
  * @param {import('@modelcontextprotocol/sdk/server/mcp.js').McpServer} server - The MCP server instance.
@@ -197,7 +212,7 @@ function awaitingResponse(result) {
     lines.push('Open this URL in a browser and complete sign-in:')
   }
   lines.push('')
-  lines.push(result.authUrl)
+  lines.push(osc8(result.authUrl))
   lines.push('')
   lines.push(
     "Then paste the full URL the browser was redirected to (it looks like http://127.0.0.1:PORT/?code=...&state=...; the page may show a connection error — that's expected).",


### PR DESCRIPTION
Supersedes #240. The `cep_auth` tool emits its consent URL inside an MCP text block, which Gemini CLI renders in a Unicode-bordered box where long URLs clip during selection. The previous attempt padded the URL with two spaces and instructed the agent to restate the URL in chat; padding does not help when terminal wrapping puts the URL near the right border, and restate-in-chat depends on agent obedience for a presentation bug.

This wraps the URL in an OSC 8 hyperlink escape on a line of its own with blank lines above and below, matching the pattern used by `gcloud auth login --no-launch-browser`, `firebase login`, and `npm login`. Modern terminals (iTerm2, WezTerm, kitty, GNOME Terminal, Windows Terminal, VS Code, Ghostty, Alacritty) render it as a clickable link; others show the URL bytes plus a few stray escape chars but the URL itself remains selectable.

Closes #238