### PR TITLE
chore: format gemini-extension.json

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -6,10 +6,7 @@
   "mcpServers": {
     "chrome-enterprise-premium": {
       "command": "npx",
-      "args": [
-        "-y",
-        "@google/chrome-enterprise-premium-mcp@^1.4.0"
-      ]
+      "args": ["-y", "@google/chrome-enterprise-premium-mcp@^1.4.0"]
     }
   }
 }


### PR DESCRIPTION
Unblocks the Kokoro presubmit check, which runs \`prettier --check .\` across the whole tree and currently fails on \`main\` because \`gemini-extension.json\`'s \`args\` array is split across three lines while prettier wants it inlined. Bringing the file back in line with prettier defaults.

\`lint-staged\` only formats staged files, so unrelated changes don't catch drift in files the contributor didn't touch — that's how this slipped through. A follow-up issue tracks the root cause: the file is rewritten by tooling (release-please version bumps; possibly an args-version sync script) without a subsequent prettier pass.