### PR TITLE
chore(test): remove unused fetched URL tracker

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -6,10 +6,7 @@
   "mcpServers": {
     "chrome-enterprise-premium": {
       "command": "npx",
-      "args": [
-        "-y",
-        "@google/chrome-enterprise-premium-mcp@^1.4.0"
-      ]
+      "args": ["-y", "@google/chrome-enterprise-premium-mcp@^1.4.0"]
     }
   }
 }

--- a/test/local/knowledge_search.test.js
+++ b/test/local/knowledge_search.test.js
@@ -20,7 +20,6 @@ import esmock from 'esmock'
 
 describe('Knowledge Tools Real Database Integration', () => {
   const handlers = {}
-  const fetched = []
 
   // Stub axios so get_document never reaches Helpcenter — that hop is slow,
   // racy, and dominates the unit-suite budget. The HTML we return is the
@@ -36,8 +35,7 @@ describe('Knowledge Tools Real Database Integration', () => {
     const { registerKnowledgeTools } = await esmock('../../tools/definitions/knowledge.js', {
       axios: {
         default: {
-          get: async url => {
-            fetched.push(url)
+          get: async () => {
             return { data: stubHtml }
           },
         },


### PR DESCRIPTION
## Summary

- `fetched` is declared in `test/local/knowledge_search.test.js` and pushed to inside the axios stub, but no assertion reads it. Dead state.

## Test plan

- [ ] `npm test` for the knowledge_search suite
