### PR TITLE
test: cover createSseHandler null-principal path

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -6,10 +6,7 @@
   "mcpServers": {
     "chrome-enterprise-premium": {
       "command": "npx",
-      "args": [
-        "-y",
-        "@google/chrome-enterprise-premium-mcp@^1.4.0"
-      ]
+      "args": ["-y", "@google/chrome-enterprise-premium-mcp@^1.4.0"]
     }
   }
 }

--- a/test/unit/mcp-server-state-isolation.test.js
+++ b/test/unit/mcp-server-state-isolation.test.js
@@ -126,4 +126,16 @@ describe('HTTP per-request session state isolation', () => {
 
     assert.strictEqual(captured[0].principal, principal)
   })
+
+  test('When createSseHandler receives a request with no req.verifiedPrincipal, then it passes null as the principal', async () => {
+    const { fn: recorder, captured } = makeRecorder()
+    const sseTransports = {}
+    const handler = createSseHandler({}, sseTransports, recorder)
+    const fakeReq = { on: () => {} }
+    const fakeRes = { on: () => {}, headersSent: false }
+
+    await handler(fakeReq, fakeRes)
+
+    assert.strictEqual(captured[0].principal, null)
+  })
 })


### PR DESCRIPTION
## Summary

- `createMcpPostHandler` has paired tests for `req.verifiedPrincipal` present and absent.
- `createSseHandler` has only the present case. Added the absent case for parity.

## Test plan

- [ ] `npm run test:unit` — new test passes
