### PR TITLE
chore(test): use lastIndexOf for version range extraction

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -6,10 +6,7 @@
   "mcpServers": {
     "chrome-enterprise-premium": {
       "command": "npx",
-      "args": [
-        "-y",
-        "@google/chrome-enterprise-premium-mcp@^1.4.0"
-      ]
+      "args": ["-y", "@google/chrome-enterprise-premium-mcp@^1.4.0"]
     }
   }
 }

--- a/test/local/extension_version.test.js
+++ b/test/local/extension_version.test.js
@@ -42,7 +42,9 @@ test('gemini-extension.json package version matches package.json version', () =>
   const packageArg = args.find(arg => arg.startsWith('@google/chrome-enterprise-premium-mcp@'))
   assert.ok(packageArg, 'Could not find @google/chrome-enterprise-premium-mcp dependency in args')
 
-  const rangeString = packageArg.split('@').pop()
+  const lastAtIndex = packageArg.lastIndexOf('@')
+  assert.ok(lastAtIndex > 0, 'Could not find version delimiter in argument')
+  const rangeString = packageArg.slice(lastAtIndex + 1)
   assert.ok(rangeString, 'Could not extract version range from argument')
 
   assert.ok(rangeString.startsWith('^'), 'Version range must start with ^ for semantic versioning')


### PR DESCRIPTION
## Summary

- The current expression `packageArg.split('@').pop()` works on `@scope/name@^1.4.0` because `.pop()` returns the segment after the last `@`.
- `lastIndexOf('@')` is clearer about intent and adds a positive-index assertion before the slice.

## Test plan

- [ ] `node --test test/local/extension_version.test.js` — version-match test still passes
