### PR TITLE
feat(auth): dynamic environment-aware agent hints and user instructions

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,5 @@ results_final.json
 .gemini/
 .opencode/
 *.patch
+.venv/
+.stryker-tmp/

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -41,7 +41,17 @@ const copyrightHeader = [
 
 export default [
   {
-    ignores: ['**/dist', '**/node_modules', 'results/**', '.worktrees/**', '.claude/**', '.gemini/**', '.opencode/**'],
+    ignores: [
+      '**/dist',
+      '**/node_modules',
+      'results/**',
+      '.worktrees/**',
+      '.claude/**',
+      '.gemini/**',
+      '.opencode/**',
+      '**/.venv/**',
+      '**/.stryker-tmp/**',
+    ],
   },
   js.configs.recommended,
   nodePlugin.configs['flat/recommended'],

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -28,37 +28,84 @@ export const SERVICE_NAMES = {
   SERVICE_MANAGEMENT: 'servicemanagement.googleapis.com',
 }
 
-export const SCOPES = {
-  OPENID: 'openid',
-  EMAIL: 'https://www.googleapis.com/auth/userinfo.email',
-  CHROME_MANAGEMENT_POLICY: 'https://www.googleapis.com/auth/chrome.management.policy',
-  CHROME_MANAGEMENT_REPORTS_READONLY: 'https://www.googleapis.com/auth/chrome.management.reports.readonly',
-  CHROME_MANAGEMENT_PROFILES_READONLY: 'https://www.googleapis.com/auth/chrome.management.profiles.readonly',
-  ADMIN_REPORTS_AUDIT_READONLY: 'https://www.googleapis.com/auth/admin.reports.audit.readonly',
-  ADMIN_DIRECTORY_ORGUNIT_READONLY: 'https://www.googleapis.com/auth/admin.directory.orgunit.readonly',
-  ADMIN_DIRECTORY_CUSTOMER_READONLY: 'https://www.googleapis.com/auth/admin.directory.customer.readonly',
-  LICENSING: 'https://www.googleapis.com/auth/apps.licensing',
-  CLOUD_IDENTITY_POLICIES: 'https://www.googleapis.com/auth/cloud-identity.policies',
-  SERVICE_USAGE: 'https://www.googleapis.com/auth/service.management',
-}
+/**
+ * Authoritative configuration for all OAuth scopes used by the project.
+ * This is the SINGLE SOURCE OF TRUTH for scope URLs, names, and categories.
+ * Keyed by internal ID for use in code (e.g., OAUTH_SCOPE_CONFIG.EMAIL).
+ */
+export const OAUTH_SCOPE_CONFIG = Object.freeze({
+  OPENID: {
+    url: 'openid',
+    name: 'OpenID Connect',
+    category: 'Identity',
+  },
+  EMAIL: {
+    url: 'https://www.googleapis.com/auth/userinfo.email',
+    name: 'User Email',
+    category: 'Identity',
+  },
+  CHROME_MANAGEMENT_POLICY: {
+    url: 'https://www.googleapis.com/auth/chrome.management.policy',
+    name: 'Chrome Policy',
+    category: 'Chrome browser management',
+  },
+  CHROME_MANAGEMENT_REPORTS_READONLY: {
+    url: 'https://www.googleapis.com/auth/chrome.management.reports.readonly',
+    name: 'Chrome Reports',
+    category: 'Chrome browser management',
+  },
+  CHROME_MANAGEMENT_PROFILES_READONLY: {
+    url: 'https://www.googleapis.com/auth/chrome.management.profiles.readonly',
+    name: 'Chrome Profiles',
+    category: 'Chrome browser management',
+  },
+  ADMIN_REPORTS_AUDIT_READONLY: {
+    url: 'https://www.googleapis.com/auth/admin.reports.audit.readonly',
+    name: 'Admin Audit Reports',
+    category: 'Admin SDK reports',
+  },
+  ADMIN_DIRECTORY_ORGUNIT_READONLY: {
+    url: 'https://www.googleapis.com/auth/admin.directory.orgunit.readonly',
+    name: 'Admin Org Units',
+    category: 'Admin SDK reports',
+  },
+  ADMIN_DIRECTORY_CUSTOMER_READONLY: {
+    url: 'https://www.googleapis.com/auth/admin.directory.customer.readonly',
+    name: 'Admin Customer Info',
+    category: 'Admin SDK reports',
+  },
+  LICENSING: {
+    url: 'https://www.googleapis.com/auth/apps.licensing',
+    name: 'App Licensing',
+    category: 'Licensing',
+  },
+  CLOUD_IDENTITY_POLICIES: {
+    url: 'https://www.googleapis.com/auth/cloud-identity.policies',
+    name: 'Cloud Identity Policies',
+    category: 'Cloud Identity (DLP)',
+  },
+  SERVICE_USAGE: {
+    url: 'https://www.googleapis.com/auth/service.management',
+    name: 'Service Management',
+    category: 'Service Usage',
+  },
+})
 
 /**
- * Metadata registry for OAuth scopes. Maps raw URLs to human-readable names and categories.
- * This is the SINGLE SOURCE OF TRUTH for scope documentation and audit reporting.
+ * Legacy SCOPES object used throughout the codebase. Derived from OAUTH_SCOPE_CONFIG.
+ * Keyed by ID (e.g. SCOPES.EMAIL), value is the URL string.
  */
-export const OAUTH_SCOPE_REGISTRY = Object.freeze({
-  [SCOPES.OPENID]: { name: 'OpenID Connect', category: 'Identity' },
-  [SCOPES.EMAIL]: { name: 'User Email', category: 'Identity' },
-  [SCOPES.CHROME_MANAGEMENT_POLICY]: { name: 'Chrome Policy', category: 'Chrome browser management' },
-  [SCOPES.CHROME_MANAGEMENT_REPORTS_READONLY]: { name: 'Chrome Reports', category: 'Chrome browser management' },
-  [SCOPES.CHROME_MANAGEMENT_PROFILES_READONLY]: { name: 'Chrome Profiles', category: 'Chrome browser management' },
-  [SCOPES.ADMIN_REPORTS_AUDIT_READONLY]: { name: 'Admin Audit Reports', category: 'Admin SDK reports' },
-  [SCOPES.ADMIN_DIRECTORY_ORGUNIT_READONLY]: { name: 'Admin Org Units', category: 'Admin SDK reports' },
-  [SCOPES.ADMIN_DIRECTORY_CUSTOMER_READONLY]: { name: 'Admin Customer Info', category: 'Admin SDK reports' },
-  [SCOPES.LICENSING]: { name: 'App Licensing', category: 'Licensing' },
-  [SCOPES.CLOUD_IDENTITY_POLICIES]: { name: 'Cloud Identity Policies', category: 'Cloud Identity (DLP)' },
-  [SCOPES.SERVICE_USAGE]: { name: 'Service Usage/Management', category: 'Service Usage' },
-})
+export const SCOPES = Object.freeze(
+  Object.fromEntries(Object.entries(OAUTH_SCOPE_CONFIG).map(([key, meta]) => [key, meta.url])),
+)
+
+/**
+ * Metadata registry for OAuth scopes. Derived from OAUTH_SCOPE_CONFIG.
+ * Keyed by raw URL for runtime lookups (e.g. from token scopes).
+ */
+export const OAUTH_SCOPE_REGISTRY = Object.freeze(
+  Object.fromEntries(Object.values(OAUTH_SCOPE_CONFIG).map(meta => [meta.url, meta])),
+)
 
 /**
  * Returns a sorted list of unique human-readable categories for the given scope URLs.

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -43,6 +43,40 @@ export const SCOPES = {
 }
 
 /**
+ * Metadata registry for OAuth scopes. Maps raw URLs to human-readable names and categories.
+ * This is the SINGLE SOURCE OF TRUTH for scope documentation and audit reporting.
+ */
+export const OAUTH_SCOPE_REGISTRY = Object.freeze({
+  [SCOPES.OPENID]: { name: 'OpenID Connect', category: 'Identity' },
+  [SCOPES.EMAIL]: { name: 'User Email', category: 'Identity' },
+  [SCOPES.CHROME_MANAGEMENT_POLICY]: { name: 'Chrome Policy', category: 'Chrome browser management' },
+  [SCOPES.CHROME_MANAGEMENT_REPORTS_READONLY]: { name: 'Chrome Reports', category: 'Chrome browser management' },
+  [SCOPES.CHROME_MANAGEMENT_PROFILES_READONLY]: { name: 'Chrome Profiles', category: 'Chrome browser management' },
+  [SCOPES.ADMIN_REPORTS_AUDIT_READONLY]: { name: 'Admin Audit Reports', category: 'Admin SDK reports' },
+  [SCOPES.ADMIN_DIRECTORY_ORGUNIT_READONLY]: { name: 'Admin Org Units', category: 'Admin SDK reports' },
+  [SCOPES.ADMIN_DIRECTORY_CUSTOMER_READONLY]: { name: 'Admin Customer Info', category: 'Admin SDK reports' },
+  [SCOPES.LICENSING]: { name: 'App Licensing', category: 'Licensing' },
+  [SCOPES.CLOUD_IDENTITY_POLICIES]: { name: 'Cloud Identity Policies', category: 'Cloud Identity (DLP)' },
+  [SCOPES.SERVICE_USAGE]: { name: 'Service Usage/Management', category: 'Service Usage' },
+})
+
+/**
+ * Returns a sorted list of unique human-readable categories for the given scope URLs.
+ * @param {string[]} scopes List of raw scope URLs.
+ * @returns {string[]} List of unique category names.
+ */
+export function getUniqueScopeCategories(scopes) {
+  const categories = new Set()
+  for (const url of scopes) {
+    const meta = OAUTH_SCOPE_REGISTRY[url]
+    if (meta?.category) {
+      categories.add(meta.category)
+    }
+  }
+  return [...categories].sort()
+}
+
+/**
  * Bundled OAuth client for `mcp auth login`. Google Cloud Desktop
  * (installed-app) OAuth client in project `cep-mcp-server-prod-190085`.
  *

--- a/test/local/auth-tool.test.js
+++ b/test/local/auth-tool.test.js
@@ -110,7 +110,7 @@ describe('cep_auth Tool', () => {
       assert.strictEqual(result.structuredContent.nextAction, 'paste-redirect-url')
       assert.strictEqual(result.structuredContent.authUrl, 'https://accounts.google.com/o/oauth2/v2/auth?state=ABC')
       assert.ok(result.structuredContent.agentHint?.length > 0)
-      assert.match(result.content[0].text, /Open this URL/)
+      assert.match(result.content[0].text, /Open the URL below/)
       assert.match(result.content[0].text, /accounts\.google\.com/)
 
       const lines = result.content[0].text.split('\n')
@@ -149,7 +149,7 @@ describe('cep_auth Tool', () => {
       assert.strictEqual(result.structuredContent.nextAction, 'paste-redirect-url')
       assert.strictEqual(result.structuredContent.authUrl, 'https://accounts.google.com/o/oauth2/v2/auth?state=ABC')
       assert.ok(result.structuredContent.agentHint?.length > 0)
-      assert.match(result.content[0].text, /Open this URL/)
+      assert.match(result.content[0].text, /Open the URL below/)
       assert.match(result.content[0].text, /accounts\.google\.com/)
 
       const text = result.content[0].text

--- a/test/local/tool-registration.test.js
+++ b/test/local/tool-registration.test.js
@@ -22,6 +22,7 @@ import assert from 'node:assert/strict'
 import { describe, test, mock, beforeEach } from 'node:test'
 import { registerTools } from '../../tools/index.js'
 import { FLAGS } from '../../lib/util/feature_flags.js'
+import { SCOPES, OAUTH_SCOPE_REGISTRY } from '../../lib/constants.js'
 
 const CORE_TOOLS = [
   'cep_auth',
@@ -156,5 +157,45 @@ describe('SEB Tool Registration', () => {
     assert.strictEqual(mockAdminSdkClient.listOrgUnits.mock.callCount(), 1)
     const callArgs = mockAdminSdkClient.listOrgUnits.mock.calls[0].arguments
     assert.deepStrictEqual(callArgs[0], { customerId: 'C_SHARED_123' })
+  })
+
+  describe('Scope Registry Integrity', () => {
+    test('Every scope URL in the SCOPES constant must have an entry in OAUTH_SCOPE_REGISTRY', () => {
+      for (const [id, url] of Object.entries(SCOPES)) {
+        assert.ok(
+          OAUTH_SCOPE_REGISTRY[url],
+          `Scope "${id}" with URL "${url}" is missing from OAUTH_SCOPE_REGISTRY in lib/constants.js`,
+        )
+        assert.ok(OAUTH_SCOPE_REGISTRY[url].name, `Scope "${url}" in registry is missing a human-readable "name"`)
+        assert.ok(OAUTH_SCOPE_REGISTRY[url].category, `Scope "${url}" in registry is missing a functional "category"`)
+      }
+    })
+
+    test('Every tool registered in the codebase must use scopes that exist in the Registry', () => {
+      const server = {
+        registerTool: mock.fn(),
+      }
+
+      // Register ALL tools (including experiments) to audit their scopes
+      registerTools(server, {
+        featureFlags: { isEnabled: () => true },
+      })
+
+      const registeredTools = server.registerTool.mock.calls
+
+      for (const call of registeredTools) {
+        const toolName = call.arguments[0]
+        const handler = call.arguments[2]
+        const requestedScopes = handler._scopes || Object.values(SCOPES)
+
+        for (const url of requestedScopes) {
+          assert.ok(
+            OAUTH_SCOPE_REGISTRY[url],
+            `Tool "${toolName}" requests scope "${url}" which is NOT found in the Registry. ` +
+              `Update OAUTH_SCOPE_CONFIG in lib/constants.js.`,
+          )
+        }
+      }
+    })
   })
 })

--- a/tools/definitions/auth.js
+++ b/tools/definitions/auth.js
@@ -33,11 +33,19 @@ import { guardedToolCall, formatToolResponse } from '../utils/wrapper.js'
 const TOOL_NAME = 'cep_auth'
 const NPX_CLI = 'npx @google/chrome-enterprise-premium-mcp auth login'
 
-const AGENT_HINT =
-  'Show the user the authUrl and ask them to open it in a browser. After the browser is ' +
-  'redirected to a 127.0.0.1 URL (the page may show "connection refused" — that is expected), ' +
-  'ask the user to paste that full URL back. Then call cep_auth again with the pasted URL as ' +
-  'the redirectUrl argument.'
+const AGENT_HINT_WORKSTATION =
+  'A browser tab opened automatically. The user needs to sign in with their Google account ' +
+  'in that tab and can close it once they see the "Signed in" success page. No further ' +
+  'action is needed from you unless the user asks for help.'
+
+const AGENT_HINT_HEADLESS =
+  'The browser could not open automatically. Provide the user with these instructions: ' +
+  '1. Open the authUrl in your local browser. ' +
+  '2. Sign in with your Google account. ' +
+  '3. After signing in, your browser will redirect to a 127.0.0.1 address and show a ' +
+  '"Connection Refused" error—tell the user this is expected. ' +
+  '4. Copy that entire new address from the address bar and paste it back here. ' +
+  'Once the user pastes the URL, call cep_auth again with that string as the redirectUrl argument.'
 
 /**
  * Builds the user-facing fallback line suggesting the CLI sign-in command.
@@ -301,16 +309,20 @@ function successResponse(result) {
  */
 function awaitingResponse(result) {
   const lines = []
+  const agentHint = result.browserOpened ? AGENT_HINT_WORKSTATION : AGENT_HINT_HEADLESS
+
   if (result.browserOpened) {
     lines.push('A browser tab should have opened for sign-in.')
     lines.push(
-      "Once the browser is redirected to a 127.0.0.1 URL (the page may show a connection error — that's fine), paste that full URL back so the sign-in can complete.",
+      'Once you sign in and see the "Signed in" success message, you can close that tab and return here to continue.',
     )
     lines.push('')
-    lines.push('If the browser did not open, the consent URL is:')
+    lines.push('If the browser did not open, you can complete sign-in manually:')
   } else {
-    lines.push('Open this URL in a browser and complete sign-in:')
+    lines.push('I cannot open a browser in this environment. Please complete sign-in manually:')
   }
+
+  lines.push('1. Open the URL below in your local browser:')
   lines.push('')
   if (supportsHyperlinks()) {
     lines.push(`🔗 ${osc8(result.authUrl, 'Click here to open the Google Sign-in page in your browser')}`)
@@ -321,8 +333,9 @@ function awaitingResponse(result) {
   lines.push(result.authUrl)
   lines.push('')
   lines.push(
-    "Then paste the full URL the browser was redirected to (it looks like http://127.0.0.1:PORT/?code=...&state=...; the page may show a connection error — that's expected).",
+    '2. Sign in with your Google account. After signing in, your browser will redirect to a 127.0.0.1 address and show a "Connection Refused" error—this is expected.',
   )
+  lines.push("3. Copy that entire new address from your browser's address bar and paste it back here.")
   lines.push('')
   lines.push(cliFallbackLine(resolveOAuthClientConfig().source))
   const expiresAt = result.expiresAt instanceof Date ? result.expiresAt.toISOString() : undefined
@@ -336,7 +349,7 @@ function awaitingResponse(result) {
       browserOpened: result.browserOpened,
       expiresAt,
       source: result.source,
-      agentHint: AGENT_HINT,
+      agentHint,
     },
   }
 }

--- a/tools/definitions/auth.js
+++ b/tools/definitions/auth.js
@@ -22,13 +22,12 @@ limitations under the License.
  */
 
 import { z } from 'zod'
-import { TAGS } from '../../lib/constants.js'
 import { logger } from '../../lib/util/logger.js'
 import { startToolAuth, completeToolAuth } from '../../lib/util/credential/auth_login.js'
 import { TokenCache } from '../../lib/util/credential/token_cache.js'
 import { oauthFlowCredential } from '../../lib/util/credential/oauth_flow.js'
 import { resolveOAuthClientConfig } from '../../lib/util/credential/oauth_client_config.js'
-import { SCOPES, getUniqueScopeCategories } from '../../lib/constants.js'
+import { TAGS, SCOPES, OAUTH_SCOPE_REGISTRY, getUniqueScopeCategories } from '../../lib/constants.js'
 import { guardedToolCall, formatToolResponse } from '../utils/wrapper.js'
 
 const TOOL_NAME = 'cep_auth'
@@ -116,6 +115,24 @@ function supportsHyperlinks() {
  */
 function osc8(url, label = url) {
   return `${OSC}${url}${ST}${label}${OSC}${ST}`
+}
+
+/**
+ * Formats the OAuth probe result into a human-friendly summary string.
+ * @param {object} probe The result from oauthFlowCredential().probe().
+ * @returns {string} Human-readable summary.
+ */
+function formatAuthStatusSummary(probe) {
+  if (!probe.ok) {
+    return probe.scopesKnown && probe.missingScopes.length > 0
+      ? 'OAuth credentials missing or incomplete permissions.'
+      : 'OAuth credentials not configured.'
+  }
+
+  const granted = probe.grantedScopes || Object.keys(OAUTH_SCOPE_REGISTRY)
+  const categories = getUniqueScopeCategories(granted)
+
+  return `OAuth credentials valid and active. Authorized for: ${categories.join(', ')}.`
 }
 
 /**
@@ -212,9 +229,17 @@ export function registerAuthTools(server, options, sessionState) {
           const requiredScopes = Object.values(SCOPES)
           const cred = oauthFlowCredential({ requiredScopes })
           const probe = await cred.probe()
+
+          // Enhance the probe data with friendly names for the user/agent
+          const statusReport = {
+            ...probe,
+            granted: (probe.grantedScopes || []).map(url => OAUTH_SCOPE_REGISTRY[url]?.name || url),
+            missing: (probe.missingScopes || []).map(url => OAUTH_SCOPE_REGISTRY[url]?.name || url),
+          }
+
           return formatToolResponse({
-            summary: probe.ok ? 'OAuth credentials valid and active.' : 'OAuth credentials missing or incomplete.',
-            data: { status: probe },
+            summary: formatAuthStatusSummary(probe),
+            data: { status: statusReport },
             structuredContent: { status: probe },
           })
         },

--- a/tools/definitions/auth.js
+++ b/tools/definitions/auth.js
@@ -28,7 +28,7 @@ import { startToolAuth, completeToolAuth } from '../../lib/util/credential/auth_
 import { TokenCache } from '../../lib/util/credential/token_cache.js'
 import { oauthFlowCredential } from '../../lib/util/credential/oauth_flow.js'
 import { resolveOAuthClientConfig } from '../../lib/util/credential/oauth_client_config.js'
-import { SCOPES } from '../../lib/constants.js'
+import { SCOPES, getUniqueScopeCategories } from '../../lib/constants.js'
 import { guardedToolCall, formatToolResponse } from '../utils/wrapper.js'
 
 const TOOL_NAME = 'cep_auth'
@@ -135,13 +135,15 @@ export const registerAuthTool = registerAuthTools
 export function registerAuthTools(server, options, sessionState) {
   logger.debug(`${TAGS.MCP} Registering auth tools...`)
 
+  const scopeSummary = getUniqueScopeCategories(Object.values(SCOPES)).join(', ')
+
   server.registerTool(
     TOOL_NAME,
     {
       description:
         'Sign in to Google for the Chrome Enterprise Premium (CEP) MCP server. ' +
         'Use this tool ONLY for the CEP MCP server. The Google Workspace MCP server has its own separate auth tool—do not use this one for that. ' +
-        'Requests the CEP scope set: Chrome browser management, Chrome policy, Cloud Identity (DLP), Admin SDK reports, and Service Usage. ' +
+        `Requests the CEP scope set: ${scopeSummary}. ` +
         'Call with no arguments to start the sign-in. ' +
         'If the response sets `nextAction` to `paste-redirect-url`, ask the user to paste the URL the browser was redirected to, then call `cep_auth` again with that string as the `redirectUrl` argument.',
       inputSchema: {

--- a/tools/utils/wrapper.js
+++ b/tools/utils/wrapper.js
@@ -165,7 +165,7 @@ export function guardedToolCall(
   options = {},
   sessionState = { customerId: null, cachedRootOrgUnitId: null },
 ) {
-  return async (params, context) => {
+  const wrapped = async (params, context) => {
     const authToken = getAuthToken(context?.requestInfo)
     if (!authToken) {
       const validity = await isTokenLocallyValid({ scopes })
@@ -291,4 +291,7 @@ export function guardedToolCall(
       }
     }
   }
+
+  wrapped._scopes = scopes
+  return wrapped
 }


### PR DESCRIPTION
## Summary
This PR implements dynamic, context-sensitive instructions for both users and AI agents during the OAuth sign-in flow. It distinguishes between workstation (local) and headless (SSH/remote) environments to reduce user friction.

## Motivation
Previously, the server provided a single set of 'paste-back' instructions regardless of the environment. This confused local workstation users (where the browser opened automatically) and failed to provide clear guidance for remote users on how to handle the '127.0.0.1 Connection Refused' redirect.

## Main Changes
- **Dynamic Hints:** Refactored `cep_auth` to select between `AGENT_HINT_WORKSTATION` and `AGENT_HINT_HEADLESS` based on the `browserOpened` flag.
- **Improved User Guidance:** Updated the `awaitingResponse` text to provide a technically accurate, step-by-step guide for manual sign-in in headless environments.
- **Agent Knowledge:** Added explicit instructions for the agent on how to guide the user in the workstation case (sign in and close tab).

## Non-Trivial Design Decisions
### 1. Tool-Driven Branching
**Decision:** The branching logic lives in the tool definition (`auth.js`) rather than the core auth logic.
**Motivation:** This keeps the instructions close to the presentation layer (MCP tool response) while allowing the core logic to remain purely functional.

### 2. Matching Agent and User Text
**Decision:** The instructions provided to the agent in the `agentHint` field mirror the steps shown to the user in the `content` field.
**Motivation:** This ensures the agent and user are always 'on the same page' when troubleshooting or following the sign-in flow.

## Verification
- **Unit Tests:** `test/local/auth-tool.test.js` passes 100% with updated assertions.
- **Manual Verification:** Confirmed that the output text correctly reflects the intended scenarios.