### PR TITLE
fix(auth): prevent mangled consent URLs by conditionally wrapping in OSC 8

### DIFF
--- a/test/local/auth-tool.test.js
+++ b/test/local/auth-tool.test.js
@@ -64,37 +64,79 @@ describe('cep_auth Tool', () => {
     assert.strictEqual(completeToolAuth.mock.callCount(), 0)
   })
 
-  test('When cep_auth is invoked and the wait window expires, then it returns status=awaiting with the consent URL and paste-redirect-url next action', async () => {
-    const startToolAuth = mock.fn(async () => ({
-      status: 'awaiting',
-      authUrl: 'https://accounts.google.com/o/oauth2/v2/auth?state=ABC',
-      browserAttempted: false,
-      browserOpened: false,
-      expiresAt: new Date(Date.now() + 300_000),
-      source: 'managed',
-    }))
-    const completeToolAuth = mock.fn()
-    await register({ startToolAuth, completeToolAuth })
+  test('When cep_auth is invoked and the wait window expires with terminal hyperlink support, then it returns status=awaiting with OSC 8 hyperlink and plain URL', async () => {
+    process.env.FORCE_HYPERLINK = '1'
+    try {
+      const startToolAuth = mock.fn(async () => ({
+        status: 'awaiting',
+        authUrl: 'https://accounts.google.com/o/oauth2/v2/auth?state=ABC',
+        browserAttempted: false,
+        browserOpened: false,
+        expiresAt: new Date(Date.now() + 300_000),
+        source: 'managed',
+      }))
+      const completeToolAuth = mock.fn()
+      await register({ startToolAuth, completeToolAuth })
 
-    const result = await handler({}, {})
+      const result = await handler({}, {})
 
-    assert.strictEqual(result.structuredContent.status, 'awaiting')
-    assert.strictEqual(result.structuredContent.nextAction, 'paste-redirect-url')
-    assert.strictEqual(result.structuredContent.authUrl, 'https://accounts.google.com/o/oauth2/v2/auth?state=ABC')
-    assert.ok(result.structuredContent.agentHint?.length > 0)
-    assert.match(result.content[0].text, /Open this URL/)
-    assert.match(result.content[0].text, /accounts\.google\.com/)
+      assert.strictEqual(result.structuredContent.status, 'awaiting')
+      assert.strictEqual(result.structuredContent.nextAction, 'paste-redirect-url')
+      assert.strictEqual(result.structuredContent.authUrl, 'https://accounts.google.com/o/oauth2/v2/auth?state=ABC')
+      assert.ok(result.structuredContent.agentHint?.length > 0)
+      assert.match(result.content[0].text, /Open this URL/)
+      assert.match(result.content[0].text, /accounts\.google\.com/)
 
-    const lines = result.content[0].text.split('\n')
-    const urlLineIndex = lines.findIndex(l => l.includes('https://accounts.google.com/o/oauth2/v2/auth?state=ABC'))
-    assert.ok(urlLineIndex > 0, 'authUrl should appear in the text block')
-    assert.strictEqual(lines[urlLineIndex - 1], '', 'authUrl should have a blank line above it')
-    assert.strictEqual(lines[urlLineIndex + 1], '', 'authUrl should have a blank line below it')
+      const lines = result.content[0].text.split('\n')
+      const plainUrlIndex = lines.findIndex(l => l === 'https://accounts.google.com/o/oauth2/v2/auth?state=ABC')
+      assert.ok(plainUrlIndex > 0, 'plainUrl should appear in the text block')
+      assert.strictEqual(lines[plainUrlIndex - 1], '', 'plainUrl should have a blank line above it')
+      assert.strictEqual(lines[plainUrlIndex + 1], '', 'plainUrl should have a blank line below it')
 
-    const ESC = '\x1b'
-    const url = 'https://accounts.google.com/o/oauth2/v2/auth?state=ABC'
-    const expected = `${ESC}]8;;${url}${ESC}\\${url}${ESC}]8;;${ESC}\\`
-    assert.strictEqual(lines[urlLineIndex], expected, 'authUrl line should be wrapped in OSC 8 hyperlink escapes')
+      const ESC = '\x1b'
+      const url = 'https://accounts.google.com/o/oauth2/v2/auth?state=ABC'
+      const expectedLabel = 'Click here to open the Google Sign-in page in your browser'
+      const expectedLink = `🔗 ${ESC}]8;;${url}${ESC}\\${expectedLabel}${ESC}]8;;${ESC}\\`
+      assert.ok(lines.includes(expectedLink), 'Should contain the OSC 8 formatted hyperlink')
+    } finally {
+      delete process.env.FORCE_HYPERLINK
+    }
+  })
+
+  test('When cep_auth is invoked and the wait window expires without terminal hyperlink support, then it returns status=awaiting with plain URL and no OSC 8 sequences', async () => {
+    process.env.FORCE_HYPERLINK = '0'
+    try {
+      const startToolAuth = mock.fn(async () => ({
+        status: 'awaiting',
+        authUrl: 'https://accounts.google.com/o/oauth2/v2/auth?state=ABC',
+        browserAttempted: false,
+        browserOpened: false,
+        expiresAt: new Date(Date.now() + 300_000),
+        source: 'managed',
+      }))
+      const completeToolAuth = mock.fn()
+      await register({ startToolAuth, completeToolAuth })
+
+      const result = await handler({}, {})
+
+      assert.strictEqual(result.structuredContent.status, 'awaiting')
+      assert.strictEqual(result.structuredContent.nextAction, 'paste-redirect-url')
+      assert.strictEqual(result.structuredContent.authUrl, 'https://accounts.google.com/o/oauth2/v2/auth?state=ABC')
+      assert.ok(result.structuredContent.agentHint?.length > 0)
+      assert.match(result.content[0].text, /Open this URL/)
+      assert.match(result.content[0].text, /accounts\.google\.com/)
+
+      const text = result.content[0].text
+      assert.ok(!text.includes('\x1b]8;;'), 'Should not contain any OSC 8 hyperlink escapes')
+
+      const lines = text.split('\n')
+      const plainUrlIndex = lines.findIndex(l => l === 'https://accounts.google.com/o/oauth2/v2/auth?state=ABC')
+      assert.ok(plainUrlIndex > 0, 'plainUrl should appear in the text block')
+      assert.strictEqual(lines[plainUrlIndex - 1], '', 'plainUrl should have a blank line above it')
+      assert.strictEqual(lines[plainUrlIndex + 1], '', 'plainUrl should have a blank line below it')
+    } finally {
+      delete process.env.FORCE_HYPERLINK
+    }
   })
 
   test('When cep_auth is invoked with a valid redirectUrl, then it calls completeToolAuth and returns status=completed', async () => {

--- a/tools/definitions/auth.js
+++ b/tools/definitions/auth.js
@@ -43,14 +43,54 @@ const OSC = '\x1b]8;;'
 const ST = '\x1b\x5c'
 
 /**
+ * Detects if the current terminal environment is likely to support OSC 8 hyperlinks.
+ * Checks environment variables FORCE_HYPERLINK, DOMTERM, VTE_VERSION, TERM_PROGRAM,
+ * TERM, and NO_COLOR.
+ * @returns {boolean} True if the terminal likely supports hyperlinks.
+ */
+function supportsHyperlinks() {
+  if (process.env.FORCE_HYPERLINK === '1') {
+    return true
+  }
+  if (process.env.FORCE_HYPERLINK === '0') {
+    return false
+  }
+  if (process.env.NO_COLOR) {
+    return false
+  }
+
+  const env = process.env
+  if (env.DOMTERM) {
+    return true
+  }
+  if (env.TERM_PROGRAM) {
+    const program = env.TERM_PROGRAM.toLowerCase()
+    if (['hyper', 'iterm.app', 'wezterm', 'vscode'].includes(program)) {
+      return true
+    }
+  }
+  if (env.TERM === 'xterm-kitty') {
+    return true
+  }
+  if (env.VTE_VERSION) {
+    const version = parseInt(env.VTE_VERSION, 10)
+    if (version >= 4902) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
  * Wraps a URL in OSC 8 hyperlink escapes. Modern terminals render the visible
  * text as a clickable link to the same URL; others show the URL bytes plus
  * a few stray escape chars but the URL itself remains selectable.
  * @param {string} url The URL to render as a hyperlink.
+ * @param {string} [label] The visible text label. Defaults to the URL itself.
  * @returns {string} The OSC 8 wrapped URL.
  */
-function osc8(url) {
-  return `${OSC}${url}${ST}${url}${OSC}${ST}`
+function osc8(url, label = url) {
+  return `${OSC}${url}${ST}${label}${OSC}${ST}`
 }
 
 /**
@@ -220,7 +260,13 @@ function awaitingResponse(result) {
     lines.push('Open this URL in a browser and complete sign-in:')
   }
   lines.push('')
-  lines.push(osc8(result.authUrl))
+  if (supportsHyperlinks()) {
+    lines.push(`🔗 ${osc8(result.authUrl, 'Click here to open the Google Sign-in page in your browser')}`)
+    lines.push('')
+    lines.push('Or copy and paste this URL if the link above does not work:')
+    lines.push('')
+  }
+  lines.push(result.authUrl)
   lines.push('')
   lines.push(
     "Then paste the full URL the browser was redirected to (it looks like http://127.0.0.1:PORT/?code=...&state=...; the page may show a connection error — that's expected).",


### PR DESCRIPTION
Prevent mangled consent URLs and duplicate escape characters in terminals/panels that do not support OSC 8 hyperlinks.

### Description
This PR conditionally formats the Google OAuth consent URL printed by the `cep_auth` tool. It resolves issue b/514456098.

When the terminal environment supports OSC 8 hyperlinks:
- Displays a short, wrap-resilient hyperlink (`🔗 Click here to open the Google Sign-in page in your browser`) that avoids layout wrapping and vertical borders (`│`) mangling the URL.
- Also prints the clean plain URL as a backup.

When the terminal/client does not support OSC 8 hyperlinks:
- Prints **only** the plain, clean URL.
- Completely removes all raw escape characters and duplicate URLs, significantly simplifying manual copy-pasting and cleanup.

### Changes
- Added the `supportsHyperlinks()` helper in `tools/definitions/auth.js` to check standard environment signals.
- Updated `osc8()` helper to support custom labels.
- Refactored `awaitingResponse()` to conditionally output short hyperlinks or plain fallbacks.
- Added comprehensive unit tests in `test/local/auth-tool.test.js` covering both supported and unsupported hyperlink environments.