### PR TITLE
promote npx auth CLI as the primary sign-in path; surface it from cep_auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,26 @@ npm install
 
 ### 1. Sign in
 
-Run `mcp auth login` and approve consent in the browser. The CLI caches
-the access token at `~/.config/cep-mcp/tokens.json`.
+Run the auth CLI and approve consent in your browser:
 
-If a tool call runs and the cached token has expired, the agent will
-offer to sign you in. It does this by calling the `cep_auth` tool, which
-opens a browser tab for consent and stores the new token in the same
-place.
+```bash
+npx @google/chrome-enterprise-premium-mcp auth login
+```
+
+The access token is cached at `~/.config/cep-mcp/tokens.json`. From a
+local checkout you can also run `npm run auth:login`.
+
+Prefer this path for the initial sign-in. The consent URL is printed by
+your shell, so OSC 8 hyperlinks and ordinary URL selection both work.
+
+You can also start sign-in from inside the agent using the `cep_auth`
+MCP tool. Some MCP clients render text inside bordered panels that strip
+terminal escape sequences, which can mangle the consent URL. If that
+happens, fall back to the CLI command above.
 
 To use a custom OAuth client in a Cloud project of your own, set
-`CEP_OAUTH_CLIENT_ID` and `CEP_OAUTH_CLIENT_SECRET` and re-run
-`mcp auth login`. See
+`CEP_OAUTH_CLIENT_ID` and `CEP_OAUTH_CLIENT_SECRET` and re-run the auth
+login command. See
 [Use a custom OAuth client](docs/auth-bring-your-own-oauth-client.md).
 
 For the paste-the-redirect flow on CI runners and SSH sessions without

--- a/test/local/auth-tool.test.js
+++ b/test/local/auth-tool.test.js
@@ -27,6 +27,32 @@ async function loadToolWithMocks({ startToolAuth, completeToolAuth }) {
   })
 }
 
+/* Snapshot the given env-var keys, set the new values (undefined deletes), run fn, then restore. */
+async function withClientEnv(vars, fn) {
+  const snapshot = {}
+  for (const key of Object.keys(vars)) {
+    snapshot[key] = process.env[key]
+    const value = vars[key]
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+  try {
+    await fn()
+  } finally {
+    for (const key of Object.keys(snapshot)) {
+      const original = snapshot[key]
+      if (original === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = original
+      }
+    }
+  }
+}
+
 describe('cep_auth Tool', () => {
   let server
   let handler
@@ -141,5 +167,49 @@ describe('cep_auth Tool', () => {
     assert.strictEqual(result.structuredContent.code, 'BEARER_INBOUND')
     assert.strictEqual(startToolAuth.mock.callCount(), 0)
     assert.strictEqual(completeToolAuth.mock.callCount(), 0)
+  })
+
+  test('When cep_auth awaits with the managed OAuth client, then the response suggests the bare npx CLI as fallback', async () => {
+    await withClientEnv({ CEP_OAUTH_CLIENT_ID: undefined, CEP_OAUTH_CLIENT_SECRET: undefined }, async () => {
+      const startToolAuth = mock.fn(async () => ({
+        status: 'awaiting',
+        authUrl: 'https://accounts.google.com/o/oauth2/v2/auth?state=ABC',
+        browserAttempted: false,
+        browserOpened: false,
+        expiresAt: new Date(Date.now() + 300_000),
+        source: 'managed',
+      }))
+      const completeToolAuth = mock.fn()
+      await register({ startToolAuth, completeToolAuth })
+
+      const result = await handler({}, {})
+
+      assert.match(
+        result.content[0].text,
+        /you can also run `npx @google\/chrome-enterprise-premium-mcp auth login` in your shell/,
+      )
+    })
+  })
+
+  test('When cep_auth awaits with a custom OAuth client, then the response tells the user to export the env vars before running the CLI', async () => {
+    await withClientEnv({ CEP_OAUTH_CLIENT_ID: 'custom-id', CEP_OAUTH_CLIENT_SECRET: 'custom-secret' }, async () => {
+      const startToolAuth = mock.fn(async () => ({
+        status: 'awaiting',
+        authUrl: 'https://accounts.google.com/o/oauth2/v2/auth?state=ABC',
+        browserAttempted: false,
+        browserOpened: false,
+        expiresAt: new Date(Date.now() + 300_000),
+        source: 'custom',
+      }))
+      const completeToolAuth = mock.fn()
+      await register({ startToolAuth, completeToolAuth })
+
+      const result = await handler({}, {})
+
+      assert.match(
+        result.content[0].text,
+        /export CEP_OAUTH_CLIENT_ID and CEP_OAUTH_CLIENT_SECRET in your shell and run `npx @google\/chrome-enterprise-premium-mcp auth login`/,
+      )
+    })
   })
 })

--- a/tools/definitions/auth.js
+++ b/tools/definitions/auth.js
@@ -27,16 +27,41 @@ import { logger } from '../../lib/util/logger.js'
 import { startToolAuth, completeToolAuth } from '../../lib/util/credential/auth_login.js'
 import { TokenCache } from '../../lib/util/credential/token_cache.js'
 import { oauthFlowCredential } from '../../lib/util/credential/oauth_flow.js'
+import { resolveOAuthClientConfig } from '../../lib/util/credential/oauth_client_config.js'
 import { SCOPES } from '../../lib/constants.js'
 import { guardedToolCall, formatToolResponse } from '../utils/wrapper.js'
 
 const TOOL_NAME = 'cep_auth'
+const NPX_CLI = 'npx @google/chrome-enterprise-premium-mcp auth login'
 
 const AGENT_HINT =
   'Show the user the authUrl and ask them to open it in a browser. After the browser is ' +
   'redirected to a 127.0.0.1 URL (the page may show "connection refused" — that is expected), ' +
   'ask the user to paste that full URL back. Then call cep_auth again with the pasted URL as ' +
   'the redirectUrl argument.'
+
+/**
+ * Builds the user-facing fallback line suggesting the CLI sign-in command.
+ * For the managed OAuth client, the bare npx command is enough. For a custom
+ * OAuth client, the env vars must also be exported in the shell, otherwise
+ * the CLI would silently sign in under the bundled managed client.
+ * @param {'managed'|'custom'} source The resolved OAuth client source.
+ * @returns {string} A single line of user-facing prose.
+ */
+function cliFallbackLine(source) {
+  if (source === 'custom') {
+    return (
+      "If the URL above is hard to copy or doesn't render cleanly in your client, " +
+      `export CEP_OAUTH_CLIENT_ID and CEP_OAUTH_CLIENT_SECRET in your shell and run \`${NPX_CLI}\`. ` +
+      'Running that caches a token this server reads on every call.'
+    )
+  }
+  return (
+    "If the URL above is hard to copy or doesn't render cleanly in your client, " +
+    `you can also run \`${NPX_CLI}\` in your shell. ` +
+    'Running that caches a token this server reads on every call.'
+  )
+}
 
 /* OSC 8 hyperlink: ESC ] 8 ; ; URI ST text ESC ] 8 ; ; ST, where ST is ESC \. */
 const OSC = '\x1b]8;;'
@@ -225,6 +250,8 @@ function awaitingResponse(result) {
   lines.push(
     "Then paste the full URL the browser was redirected to (it looks like http://127.0.0.1:PORT/?code=...&state=...; the page may show a connection error — that's expected).",
   )
+  lines.push('')
+  lines.push(cliFallbackLine(resolveOAuthClientConfig().source))
   const expiresAt = result.expiresAt instanceof Date ? result.expiresAt.toISOString() : undefined
   return {
     content: [{ type: 'text', text: lines.join('\n') }],


### PR DESCRIPTION
## Summary

Two related changes that route users to the CLI sign-in when the in-agent consent URL is unreliable.

- README sign-in section: show the explicit `npx @google/chrome-enterprise-premium-mcp auth login` command, frame it as the recommended first-time sign-in path, note the `cep_auth` rendering caveat.
- `cep_auth` awaiting response: append a line pointing at the same CLI command, so users who hit the broken render in their MCP client see the escape hatch in the very response that is broken.

The CLI line is conditional on the resolved OAuth client source. For the bundled managed client, the bare `npx ... auth login` works. For a custom client (`CEP_OAUTH_CLIENT_ID` / `CEP_OAUTH_CLIENT_SECRET` set on the server), the user must also export those env vars in their shell, otherwise the CLI would silently sign in under the bundled managed client and cache a token under the wrong identity.

## Context

Follow-up from #244 / #258. The `cep_auth` tool returns the consent URL inside an MCP text block. Some clients (Gemini CLI's panel renderer in the reported case) display the text block inside a Unicode-bordered panel where OSC 8 escape sequences are not processed, so the URL renders as raw escape bytes or gets clipped at the border.

#244 wrapped the URL in OSC 8 escapes on the assumption that the terminal would render them. The client-side panel sits in front of the terminal and strips the escapes, so the assumption did not hold.

#258 conditionally emits OSC 8 only when `process.env` signals a hyperlink-capable terminal. That fixes the reported case in practice because MCP child processes typically do not inherit `TERM_PROGRAM` etc., so the heuristic falls back to plain URL. The detection is a heuristic, though, and can misfire when env vars do propagate to the child but the client panel still strips escapes.

The CLI sidesteps the question. The user runs it in their shell, the URL is printed straight to the terminal, and a token is cached at `~/.config/cep-mcp/tokens.json` for the server to read on every call. No client-side rendering is in the loop.

#258 is still worth landing as the polite fallback when `cep_auth` does get invoked. This PR makes the CLI the recommended path, and makes sure users who do hit `cep_auth` see how to recover from a bad render.

## Files

- `README.md` — sign-in section rewritten
- `tools/definitions/auth.js` — adds `cliFallbackLine(source)` and appends it to the awaiting response; uses `resolveOAuthClientConfig().source` to choose between managed and custom variants
- `test/local/auth-tool.test.js` — adds `withClientEnv` helper plus two BDD tests covering the managed and custom variants

## Test plan

- [x] Unit suite (`npm run test:unit`) — 454 passing
- [x] ESLint clean on the touched files
- [x] Prettier clean on the touched files
- [ ] After #258 merges, rebase to confirm no functional conflict (the diffs touch different regions of `awaitingResponse`)