### PR TITLE
chore(auth): say "return to the agent" on loopback success page

### DIFF
--- a/lib/util/credential/loopback_server.js
+++ b/lib/util/credential/loopback_server.js
@@ -91,7 +91,7 @@ function renderSuccessPage() {
     `<style>${PAGE_STYLE}</style></head><body>` +
     '<div class="card"><div class="icon ok">✓</div>' +
     '<h1>Signed in</h1>' +
-    '<p>Chrome Enterprise Premium MCP has your credentials. You can close this window and return to your terminal.</p>' +
+    '<p>Chrome Enterprise Premium MCP has your credentials. You can close this window and return to the agent.</p>' +
     '</div></body></html>'
   )
 }


### PR DESCRIPTION
## Summary

The post-consent loopback landing page told users to "return to your terminal". Most uses of this server are via an AI agent (Gemini CLI, Claude Desktop, etc.), not a bare terminal. Changed to "return to the agent".

Addresses Dylan's review comment on the loopback HTML PR.

## Test plan

- [x] `node --test test/local/loopback-server.test.js` — passes (no test asserts the prose)