### PR TITLE
fix(auth): dim plain URL fallback inside TUI container

### DIFF
--- a/test/local/auth-tool.test.js
+++ b/test/local/auth-tool.test.js
@@ -88,7 +88,7 @@ describe('cep_auth Tool', () => {
       assert.match(result.content[0].text, /accounts\.google\.com/)
 
       const lines = result.content[0].text.split('\n')
-      const plainUrlIndex = lines.findIndex(l => l.includes('https://accounts.google.com/o/oauth2/v2/auth?state=ABC'))
+      const plainUrlIndex = lines.findIndex(l => l.includes('accounts.google.com/o/oauth2/v2/auth?state=ABC'))
       assert.ok(plainUrlIndex > 0, 'plainUrl should appear in the text block')
       assert.strictEqual(lines[plainUrlIndex - 1], '', 'plainUrl should have a blank line above it')
       assert.strictEqual(lines[plainUrlIndex + 1], '', 'plainUrl should have a blank line below it')
@@ -130,7 +130,7 @@ describe('cep_auth Tool', () => {
       assert.ok(!text.includes('\x1b]8;;'), 'Should not contain any OSC 8 hyperlink escapes')
 
       const lines = text.split('\n')
-      const plainUrlIndex = lines.findIndex(l => l.includes('https://accounts.google.com/o/oauth2/v2/auth?state=ABC'))
+      const plainUrlIndex = lines.findIndex(l => l.includes('accounts.google.com/o/oauth2/v2/auth?state=ABC'))
       assert.ok(plainUrlIndex > 0, 'plainUrl should appear in the text block')
       assert.strictEqual(lines[plainUrlIndex - 1], '', 'plainUrl should have a blank line above it')
       assert.strictEqual(lines[plainUrlIndex + 1], '', 'plainUrl should have a blank line below it')

--- a/test/local/auth-tool.test.js
+++ b/test/local/auth-tool.test.js
@@ -84,7 +84,7 @@ describe('cep_auth Tool', () => {
       assert.strictEqual(result.structuredContent.nextAction, 'paste-redirect-url')
       assert.strictEqual(result.structuredContent.authUrl, 'https://accounts.google.com/o/oauth2/v2/auth?state=ABC')
       assert.ok(result.structuredContent.agentHint?.length > 0)
-      assert.match(result.content[0].text, /Open this URL/)
+      assert.match(result.content[0].text, /fallback URL/)
       assert.match(result.content[0].text, /accounts\.google\.com/)
 
       const lines = result.content[0].text.split('\n')
@@ -123,7 +123,7 @@ describe('cep_auth Tool', () => {
       assert.strictEqual(result.structuredContent.nextAction, 'paste-redirect-url')
       assert.strictEqual(result.structuredContent.authUrl, 'https://accounts.google.com/o/oauth2/v2/auth?state=ABC')
       assert.ok(result.structuredContent.agentHint?.length > 0)
-      assert.match(result.content[0].text, /Open this URL/)
+      assert.match(result.content[0].text, /fallback URL/)
       assert.match(result.content[0].text, /accounts\.google\.com/)
 
       const text = result.content[0].text

--- a/test/local/auth-tool.test.js
+++ b/test/local/auth-tool.test.js
@@ -88,7 +88,7 @@ describe('cep_auth Tool', () => {
       assert.match(result.content[0].text, /accounts\.google\.com/)
 
       const lines = result.content[0].text.split('\n')
-      const plainUrlIndex = lines.findIndex(l => l === 'https://accounts.google.com/o/oauth2/v2/auth?state=ABC')
+      const plainUrlIndex = lines.findIndex(l => l.includes('https://accounts.google.com/o/oauth2/v2/auth?state=ABC'))
       assert.ok(plainUrlIndex > 0, 'plainUrl should appear in the text block')
       assert.strictEqual(lines[plainUrlIndex - 1], '', 'plainUrl should have a blank line above it')
       assert.strictEqual(lines[plainUrlIndex + 1], '', 'plainUrl should have a blank line below it')
@@ -130,7 +130,7 @@ describe('cep_auth Tool', () => {
       assert.ok(!text.includes('\x1b]8;;'), 'Should not contain any OSC 8 hyperlink escapes')
 
       const lines = text.split('\n')
-      const plainUrlIndex = lines.findIndex(l => l === 'https://accounts.google.com/o/oauth2/v2/auth?state=ABC')
+      const plainUrlIndex = lines.findIndex(l => l.includes('https://accounts.google.com/o/oauth2/v2/auth?state=ABC'))
       assert.ok(plainUrlIndex > 0, 'plainUrl should appear in the text block')
       assert.strictEqual(lines[plainUrlIndex - 1], '', 'plainUrl should have a blank line above it')
       assert.strictEqual(lines[plainUrlIndex + 1], '', 'plainUrl should have a blank line below it')

--- a/tools/definitions/auth.js
+++ b/tools/definitions/auth.js
@@ -279,7 +279,8 @@ function awaitingResponse(result) {
     lines.push('Or copy and paste this URL if the link above does not work:')
     lines.push('')
   }
-  lines.push(dim(result.authUrl))
+  const fallbackUrl = result.authUrl.replace(/^https?:\/\//, '')
+  lines.push(dim(fallbackUrl))
   lines.push('')
   lines.push(
     "Then paste the full URL the browser was redirected to (it looks like http://127.0.0.1:PORT/?code=...&state=...; the page may show a connection error — that's expected).",

--- a/tools/definitions/auth.js
+++ b/tools/definitions/auth.js
@@ -94,6 +94,19 @@ function osc8(url, label = url) {
 }
 
 /**
+ * Mutes/dims a string for terminal output using ANSI dim escape codes, unless
+ * NO_COLOR is active.
+ * @param {string} s The text to dim.
+ * @returns {string} The dimmed text.
+ */
+function dim(s) {
+  if (process.env.NO_COLOR) {
+    return s
+  }
+  return `\x1b[2m${s}\x1b[0m`
+}
+
+/**
  * Registers the authentication tools with the MCP server (alias for registerAuthTools).
  * @param {import('@modelcontextprotocol/sdk/server/mcp.js').McpServer} server - The MCP server instance.
  * @param {object} options - Configuration options for the tools.
@@ -266,7 +279,7 @@ function awaitingResponse(result) {
     lines.push('Or copy and paste this URL if the link above does not work:')
     lines.push('')
   }
-  lines.push(result.authUrl)
+  lines.push(dim(result.authUrl))
   lines.push('')
   lines.push(
     "Then paste the full URL the browser was redirected to (it looks like http://127.0.0.1:PORT/?code=...&state=...; the page may show a connection error — that's expected).",

--- a/tools/definitions/auth.js
+++ b/tools/definitions/auth.js
@@ -94,19 +94,6 @@ function osc8(url, label = url) {
 }
 
 /**
- * Mutes/dims and strikes out a string for terminal output using ANSI escape codes,
- * unless NO_COLOR is active.
- * @param {string} s The text to dim.
- * @returns {string} The dimmed and struck-out text.
- */
-function dim(s) {
-  if (process.env.NO_COLOR) {
-    return s
-  }
-  return `\x1b[2;9m${s}\x1b[0m`
-}
-
-/**
  * Registers the authentication tools with the MCP server (alias for registerAuthTools).
  * @param {import('@modelcontextprotocol/sdk/server/mcp.js').McpServer} server - The MCP server instance.
  * @param {object} options - Configuration options for the tools.
@@ -280,7 +267,7 @@ function awaitingResponse(result) {
     lines.push('')
   }
   const fallbackUrl = result.authUrl.replace(/^https?:\/\//, '')
-  lines.push(dim(fallbackUrl))
+  lines.push(fallbackUrl)
   lines.push('')
   lines.push(
     "Then paste the full URL the browser was redirected to (it looks like http://127.0.0.1:PORT/?code=...&state=...; the page may show a connection error — that's expected).",

--- a/tools/definitions/auth.js
+++ b/tools/definitions/auth.js
@@ -94,16 +94,16 @@ function osc8(url, label = url) {
 }
 
 /**
- * Mutes/dims a string for terminal output using ANSI dim escape codes, unless
- * NO_COLOR is active.
+ * Mutes/dims and strikes out a string for terminal output using ANSI escape codes,
+ * unless NO_COLOR is active.
  * @param {string} s The text to dim.
- * @returns {string} The dimmed text.
+ * @returns {string} The dimmed and struck-out text.
  */
 function dim(s) {
   if (process.env.NO_COLOR) {
     return s
   }
-  return `\x1b[2m${s}\x1b[0m`
+  return `\x1b[2;9m${s}\x1b[0m`
 }
 
 /**
@@ -268,9 +268,9 @@ function awaitingResponse(result) {
       "Once the browser is redirected to a 127.0.0.1 URL (the page may show a connection error — that's fine), paste that full URL back so the sign-in can complete.",
     )
     lines.push('')
-    lines.push('If the browser did not open, the consent URL is:')
+    lines.push('If the browser did not open, the fallback URL (copy-paste only) is:')
   } else {
-    lines.push('Open this URL in a browser and complete sign-in:')
+    lines.push('Copy and paste this fallback URL into a browser and complete sign-in:')
   }
   lines.push('')
   if (supportsHyperlinks()) {


### PR DESCRIPTION
Strip protocol prefix from plain fallback consent URL to deactivate terminal native hyperlink parsing.

### Description
This PR strips the `https://` or `http://` protocol prefix from the plain fallback consent URL printed inside the boxed TUI panel.

This deactivates native terminal/CLI link parsing for this line (meaning it will not be clickable or highlighted), preventing accidental clicks on wrapped or mangled URL fragments inside boxed TUI containers. The fallback URL remains fully copy-pasteable (browsers automatically resolve protocol-less URLs), and the primary "Sign in to Chrome Enterprise Premium" markdown link printed below remains standard and fully highlighted.

Instruction texts have also been updated to explicitly mention "fallback URL" and "copy-paste only".

### Changes
- Stripped the `https?://` prefix from `result.authUrl` when printing the fallback URL in `awaitingResponse()`.
- Updated surrounding instruction texts to guide users toward copy-pasting.
- Updated assertions in `test/local/auth-tool.test.js` to resiliently search for the protocol-less URL using `.includes()`.
