### PR TITLE
feat(ci): send email on weekday agent evals regressions

### DIFF
--- a/.github/workflows/agent-evals.yml
+++ b/.github/workflows/agent-evals.yml
@@ -161,6 +161,35 @@ jobs:
               --body-file "$BODY_FILE"
           fi
 
+      - name: Check if today is a weekday
+        id: weekday
+        if: always()
+        run: |
+          DAY_OF_WEEK=$(date +%u)
+          if [ "$DAY_OF_WEEK" -le 5 ]; then
+            echo "is_weekday=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_weekday=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Send email on weekday regression
+        if: steps.diff.outputs.exit_code == '1' && steps.weekday.outputs.is_weekday == 'true'
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          username: ${{ secrets.NOTIFICATION_SMTP_USERNAME }}
+          password: ${{ secrets.NOTIFICATION_SMTP_PASSWORD }}
+          subject: '⚠️ Agent Evals Regression Detected'
+          to: ${{ secrets.NOTIFICATION_EMAILS }}
+          from: Agent Evals GHA Runner
+          body: |
+            The daily Agent Evals cron detected a pass-rate regression beyond the 5% threshold.
+
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            Download `results/eval-latest.json` from the run's artifacts for the full per-case detail.
+
       - name: Fail on regression or catastrophic failure
         if: steps.diff.outputs.exit_code == '1' || steps.infra.outputs.exit_code == '1'
         run: exit 1

--- a/.github/workflows/agent-evals.yml
+++ b/.github/workflows/agent-evals.yml
@@ -172,8 +172,20 @@ jobs:
             echo "is_weekday=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Check if notification secrets are configured
+        id: secrets_check
+        if: always()
+        env:
+          SMTP_USER: ${{ secrets.NOTIFICATION_SMTP_USERNAME }}
+        run: |
+          if [ -n "$SMTP_USER" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Send email on weekday regression
-        if: steps.diff.outputs.exit_code == '1' && steps.weekday.outputs.is_weekday == 'true'
+        if: steps.diff.outputs.exit_code == '1' && steps.weekday.outputs.is_weekday == 'true' && steps.secrets_check.outputs.configured == 'true'
         uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com


### PR DESCRIPTION
Configure the Agent Evals workflow (agent-evals.yml) to send email notifications on weekday (Monday to Friday) pass-rate regressions under the baseline.

### Implementation Details
- Checks if the current execution day is a weekday (1-5) using `date +%u`.
- Checks if SMTP secrets are configured (`secrets.NOTIFICATION_SMTP_USERNAME` is non-empty). If they aren't provisioned yet, the notification step is gracefully skipped.
- Sends email using `dawidd6/action-send-mail@v3` when `diff` exit code is `1` on weekdays.

### Prerequisites (Required Actions Secrets)
To enable weekday regression email notifications, the following repository secrets must be configured in GitHub (**Settings > Secrets and variables > Actions**):
1. **`NOTIFICATION_SMTP_USERNAME`**: The sender SMTP email/username (e.g., Gmail address or service account email).
2. **`NOTIFICATION_SMTP_PASSWORD`**: The sender SMTP password or app-specific password.
3. **`NOTIFICATION_EMAILS`**: Comma-separated list of recipient email addresses (e.g., `member1@google.com, member2@google.com`).

*Note: If these secrets are not provisioned yet, the workflow run will skip the email step gracefully without failing the run.*

Refs: b/515120442, b/493244463