### PR TITLE
fix: distinguish 1P auth project and target project for API enablement

### DIFF
--- a/lib/util/auth-error.js
+++ b/lib/util/auth-error.js
@@ -23,7 +23,7 @@ limitations under the License.
  * uses. Returns OAuth-flow-flavored remediation.
  */
 
-import { ERROR_MESSAGES, SERVICE_NAMES } from '../constants.js'
+import { ERROR_MESSAGES, SERVICE_NAMES, MANAGED_OAUTH_CLIENT_ID } from '../constants.js'
 
 /**
  * Generates a descriptive error message for authentication failures.
@@ -42,13 +42,26 @@ export function getAuthErrorMessage(error) {
       'The cached OAuth token is missing one or more required scopes. Re-run `mcp auth login` to re-consent with the updated scope set.'
   } else if (isApiNotEnabled) {
     const apiList = Object.values(SERVICE_NAMES).join(' ')
-    instruction =
-      'A required API is not enabled in the Google Cloud project that owns your OAuth client.\n\n' +
-      'Enable the required APIs in that project:\n' +
-      `  gcloud services enable ${apiList} --project=YOUR_PROJECT_ID\n\n` +
-      'Or call the check_and_enable_cep_api tool against your project. ' +
-      'For the full BYO OAuth-client walkthrough, see:\n' +
-      '  https://github.com/google/chrome-enterprise-premium-mcp/blob/main/docs/auth-bring-your-own-oauth-client.md'
+    const authProjectNumber = MANAGED_OAUTH_CLIENT_ID.split('-')[0]
+    const mentionsDefaultAuthProject = errorMessage.includes(authProjectNumber)
+
+    if (mentionsDefaultAuthProject) {
+      instruction =
+        `A required API is disabled for the default Google-managed 1P OAuth project (${authProjectNumber}).\n\n` +
+        'For first-party (1P) authentication, APIs must be enabled on the default project rather than your own project. ' +
+        'Because you do not have permissions to modify the default 1P project, please reach out to a Chrome Enterprise Premium team member ' +
+        `to enable the missing API on project ${authProjectNumber}.\n\n` +
+        'Alternatively, if you are using a custom OAuth client (BYO) or a service account, ensure that you have enabled ' +
+        'the required Workspace APIs in your own Google Cloud project (e.g., via the check_and_enable_cep_api tool).'
+    } else {
+      instruction =
+        'A required API is not enabled in the Google Cloud project that owns your OAuth client.\n\n' +
+        'Enable the required APIs in that project:\n' +
+        `  gcloud services enable ${apiList} --project=YOUR_PROJECT_ID\n\n` +
+        'Or call the check_and_enable_cep_api tool against your project. ' +
+        'For the full BYO OAuth-client walkthrough, see:\n' +
+        '  https://github.com/google/chrome-enterprise-premium-mcp/blob/main/docs/auth-bring-your-own-oauth-client.md'
+    }
   }
 
   if (instruction) {

--- a/prompts/system-prompt.md
+++ b/prompts/system-prompt.md
@@ -16,6 +16,8 @@ You are the Official Chrome Enterprise Premium (CEP) Technical Agent. Your missi
 
 6. **Verify, don't assume.** You verify the actual environment state with your diagnostic tools rather than making assumptions about timing, propagation, or configuration. For example, even if a user mentions that rules were "just" configured, you still check the logs to confirm if any telemetry has arrived, as this grounding leads to more precise advice.
 
+7. **Distinguish Auth Project vs Target Project:** Project `947770278602` is the default Google-managed 1P OAuth project used strictly for authentication. For first-party (1P) authentication, customers do NOT need to enable APIs on their personal/target GCP project. The APIs are enabled on `947770278602` itself. If any GCP API errors mention project `947770278602` having disabled APIs, explain to the user that `947770278602` is the default 1P project, they do not have permissions to enable APIs on it, and they must reach out to a Chrome Enterprise Premium team member to enable that API on `947770278602`. If they are using a custom OAuth client (BYO) or service account, they must enable APIs on their own project using the `check_and_enable_cep_api` tool.
+
 ## Knowledge Base Traversal
 
 When reading documentation, you will see inline cross-references formatted as `[Topic](filename.md)`.

--- a/test/local/auth.test.js
+++ b/test/local/auth.test.js
@@ -149,6 +149,19 @@ describe('Auth', () => {
       assert.match(message, /auth-bring-your-own-oauth-client\.md/)
     })
 
+    test('When the error reports SERVICE_DISABLED for the default managed OAuth project, then it instructs to reach out to a Chrome Enterprise Premium team member', async () => {
+      const { getAuthErrorMessage } = await import('../../lib/util/auth-error.js')
+      const error = new Error(
+        'Admin SDK API has not been used in project 947770278602 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/admin.googleapis.com/overview?project=947770278602 then retry.',
+      )
+      const message = getAuthErrorMessage(error)
+
+      assert.match(message, /default Google-managed 1P OAuth project/)
+      assert.match(message, /reach out to a Chrome Enterprise Premium team member/)
+      assert.match(message, /enable the missing API on project 947770278602/)
+      assert.match(message, /check_and_enable_cep_api/)
+    })
+
     test('When the error reports insufficient scopes, then the remediation points at `mcp auth login`', async () => {
       const { getAuthErrorMessage } = await import('../../lib/util/auth-error.js')
       const error = new Error('Request had insufficient authentication scopes.')


### PR DESCRIPTION
Distinguishes default 1P OAuth project 947770278602 from customer target projects.

Closes b/515133413.