### PR TITLE
fix: block dangerous URI schemes in custom message href (CWE-79)

### DIFF
--- a/lib/util/cel_validator.js
+++ b/lib/util/cel_validator.js
@@ -310,6 +310,18 @@ export function validateActionParameters(action, params = {}, triggers = []) {
         errors.push(ACTION_PARAMETER_CONSTRAINTS.CUSTOM_MESSAGE_SUPPORT)
         break
       }
+
+      // Prevent XSS via dangerous URI schemes in href
+      const hrefMatch = tag.match(/href\s*=\s*(?:(['"])(.*?)\1|([^\s>]+))/i)
+      if (hrefMatch) {
+        const hrefValue = (hrefMatch[2] || hrefMatch[3] || '').trim().toLowerCase()
+        // Strip control characters that might obfuscate the scheme
+        const sanitizedHref = hrefValue.replace(/[\x00-\x1F\x7F]/g, '') // eslint-disable-line no-control-regex
+        if (/^(javascript|data|vbscript|file):/i.test(sanitizedHref)) {
+          errors.push(ACTION_PARAMETER_CONSTRAINTS.CUSTOM_MESSAGE_SUPPORT)
+          break
+        }
+      }
     }
   }
 


### PR DESCRIPTION
This PR addresses a Stored XSS Filter Bypass in `lib/util/cel_validator.js` which leads to a Stored XSS vulnerability on the end-user's Chrome Enterprise browser.

### Vulnerability Details:
The `create_chrome_dlp_rule` tool allows users to specify a `customMessage`. To prevent XSS, the `validateActionParameters` function attempts to sanitize the input by allowing only `<a>` tags with `href` and `target` attributes. However, it fails to validate the **value** of the `href` attribute itself. 

An attacker can pass a message like: `<a href="javascript:alert(1)">Click to resolve</a>`. This perfectly bypasses the regex checks.

### Fix:
I have patched the vulnerability by extracting the `href` value and checking it against dangerous URI schemes (like `javascript:`, `data:`, `vbscript:`, `file:`).
