### PR TITLE
fix(auth): route sign-in fallback through cli_invocation helper

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -6,10 +6,7 @@
   "mcpServers": {
     "chrome-enterprise-premium": {
       "command": "npx",
-      "args": [
-        "-y",
-        "@google/chrome-enterprise-premium-mcp@^1.4.0"
-      ]
+      "args": ["-y", "@google/chrome-enterprise-premium-mcp@^1.4.0"]
     }
   }
 }

--- a/test/local/auth-tool.test.js
+++ b/test/local/auth-tool.test.js
@@ -17,6 +17,7 @@ limitations under the License.
 import assert from 'node:assert/strict'
 import { describe, test, mock, beforeEach } from 'node:test'
 import esmock from 'esmock'
+import { cliInvocation } from '../../lib/util/cli_invocation.js'
 
 async function loadToolWithMocks({ startToolAuth, completeToolAuth }) {
   return esmock('../../tools/definitions/auth.js', {
@@ -226,9 +227,10 @@ describe('cep_auth Tool', () => {
 
       const result = await handler({}, {})
 
-      assert.match(
-        result.content[0].text,
-        /you can also run `npx @google\/chrome-enterprise-premium-mcp auth login` in your shell/,
+      const manualLogin = cliInvocation('auth login')
+      assert.ok(
+        result.content[0].text.includes(`you can also run \`${manualLogin}\` in your shell`),
+        `Expected output to contain: "you can also run \`${manualLogin}\` in your shell"`,
       )
     })
   })
@@ -248,9 +250,12 @@ describe('cep_auth Tool', () => {
 
       const result = await handler({}, {})
 
-      assert.match(
-        result.content[0].text,
-        /export CEP_OAUTH_CLIENT_ID and CEP_OAUTH_CLIENT_SECRET in your shell and run `npx @google\/chrome-enterprise-premium-mcp auth login`/,
+      const manualLogin = cliInvocation('auth login')
+      assert.ok(
+        result.content[0].text.includes(
+          `export CEP_OAUTH_CLIENT_ID and CEP_OAUTH_CLIENT_SECRET in your shell and run \`${manualLogin}\``,
+        ),
+        `Expected output to contain env exports and running: "${manualLogin}"`,
       )
     })
   })

--- a/tools/definitions/auth.js
+++ b/tools/definitions/auth.js
@@ -30,9 +30,9 @@ import { oauthFlowCredential } from '../../lib/util/credential/oauth_flow.js'
 import { resolveOAuthClientConfig } from '../../lib/util/credential/oauth_client_config.js'
 import { SCOPES } from '../../lib/constants.js'
 import { guardedToolCall, formatToolResponse } from '../utils/wrapper.js'
+import { cliInvocation } from '../../lib/util/cli_invocation.js'
 
 const TOOL_NAME = 'cep_auth'
-const NPX_CLI = 'npx @google/chrome-enterprise-premium-mcp auth login'
 
 const AGENT_HINT =
   'Show the user the authUrl and ask them to open it in a browser. After the browser is ' +
@@ -49,16 +49,17 @@ const AGENT_HINT =
  * @returns {string} A single line of user-facing prose.
  */
 function cliFallbackLine(source) {
+  const loginCmd = cliInvocation('auth login')
   if (source === 'custom') {
     return (
       "If the URL above is hard to copy or doesn't render cleanly in your client, " +
-      `export CEP_OAUTH_CLIENT_ID and CEP_OAUTH_CLIENT_SECRET in your shell and run \`${NPX_CLI}\`. ` +
+      `export CEP_OAUTH_CLIENT_ID and CEP_OAUTH_CLIENT_SECRET in your shell and run \`${loginCmd}\`. ` +
       'Running that caches a token this server reads on every call.'
     )
   }
   return (
     "If the URL above is hard to copy or doesn't render cleanly in your client, " +
-    `you can also run \`${NPX_CLI}\` in your shell. ` +
+    `you can also run \`${loginCmd}\` in your shell. ` +
     'Running that caches a token this server reads on every call.'
   )
 }


### PR DESCRIPTION
#### 1. MOTIVATION
When users connect to the CEP MCP server, the primary authentication method is inline and agent-guided via the `cep_auth` tool. However, if this inline flow is difficult or unsupported by their specific developer chat client/IDE, the tool provides a **fallback terminal command** so they can authorize manually in their system shell (which caches the credentials at `~/.config/cep-mcp/tokens.json` for the server to read).

Currently, this fallback instruction in `tools/definitions/auth.js` was hardcoded to suggest `npx @google/chrome-enterprise-premium-mcp auth login`. While this worked for standard NPX package users, it bypassed the unified `cliInvocation` helper. As a result, it failed to dynamically adapt for users running a local development checkout and missed the smoother `-y` and `@latest` flags.

#### 2. MAIN CHANGES
- **Auth Tool Fallback:** Refactored the fallback line in `tools/definitions/auth.js` to import and use the dynamic `cliInvocation` helper instead of a hardcoded string.
- **Test Suites Robustness:** Updated `test/local/auth-tool.test.js` to assert against `cliInvocation('auth login')` dynamically rather than hardcoding regex matches. This ensures the unit tests remain completely correct on any environment, including ones with local binaries on the path.
- **Formatting:** Ran the Prettier formatter on changed files to maintain strict style compliance.