### PR TITLE
fix: support /apps prefix for fake licensing user endpoint

### DIFF
--- a/test/helpers/fake-api-server.js
+++ b/test/helpers/fake-api-server.js
@@ -364,26 +364,32 @@ export function createFakeApp() {
   )
 
   // Licensing: Get User License
-  app.get('/licensing/v1/product/:productId/sku/:skuId/user/:userId', (req, res) => {
-    for (const customerLicenses of Object.values(state.licenses)) {
-      const skuLicenses = customerLicenses[req.params.productId]?.[req.params.skuId] || []
-      const license = skuLicenses.find(l => l.userId === req.params.userId)
-      if (license) {
-        // Return a structure matching the real Google Licensing API single response
-        return res.json({
-          kind: 'licensing#licenseAssignment',
-          etag: '"mockEtagSingle"',
-          productId: license.productId,
-          userId: license.userId,
-          selfLink: `https://licensing.googleapis.com/apps/licensing/v1/product/${license.productId}/sku/${license.skuId}/user/${license.userId}`,
-          skuId: license.skuId,
-          skuName: 'Chrome Enterprise Premium',
-          productName: 'Chrome Enterprise Premium',
-        })
+  app.get(
+    [
+      '/licensing/v1/product/:productId/sku/:skuId/user/:userId',
+      '/apps/licensing/v1/product/:productId/sku/:skuId/user/:userId',
+    ],
+    (req, res) => {
+      for (const customerLicenses of Object.values(state.licenses)) {
+        const skuLicenses = customerLicenses[req.params.productId]?.[req.params.skuId] || []
+        const license = skuLicenses.find(l => l.userId === req.params.userId)
+        if (license) {
+          // Return a structure matching the real Google Licensing API single response
+          return res.json({
+            kind: 'licensing#licenseAssignment',
+            etag: '"mockEtagSingle"',
+            productId: license.productId,
+            userId: license.userId,
+            selfLink: `https://licensing.googleapis.com/apps/licensing/v1/product/${license.productId}/sku/${license.skuId}/user/${license.userId}`,
+            skuId: license.skuId,
+            skuName: 'Chrome Enterprise Premium',
+            productName: 'Chrome Enterprise Premium',
+          })
+        }
       }
-    }
-    res.status(404).json({ error: { message: 'User license not found' } })
-  })
+      res.status(404).json({ error: { message: 'User license not found' } })
+    },
+  )
 
   // Chrome Management: Count Browser Versions
   app.get('/v1/customers/:customerId/reports\\:countChromeVersions', (req, res) => {

--- a/test/local/fake-api-server.test.js
+++ b/test/local/fake-api-server.test.js
@@ -88,14 +88,25 @@ describe('Fake API Server', () => {
       assert.strictEqual(body.items.length, 1)
     })
 
-    test('When a specific user license is requested, then it returns the license data', async () => {
+    test('When a specific user license is requested via /licensing/v1 prefix, then it returns the license data', async () => {
       const { status, body } = await get('/licensing/v1/product/101040/sku/1010400001/user/user1@example.com')
       assert.strictEqual(status, 200)
       assert.strictEqual(body.userId, 'user1@example.com')
     })
 
-    test('When an unknown user license is requested, then it returns a 404 error', async () => {
+    test('When a specific user license is requested via /apps/licensing/v1 prefix, then it returns the license data', async () => {
+      const { status, body } = await get('/apps/licensing/v1/product/101040/sku/1010400001/user/user1@example.com')
+      assert.strictEqual(status, 200)
+      assert.strictEqual(body.userId, 'user1@example.com')
+    })
+
+    test('When an unknown user license is requested via /licensing/v1 prefix, then it returns a 404 error', async () => {
       const { status } = await get('/licensing/v1/product/101040/sku/1010400001/user/unknown@example.com')
+      assert.strictEqual(status, 404)
+    })
+
+    test('When an unknown user license is requested via /apps/licensing/v1 prefix, then it returns a 404 error', async () => {
+      const { status } = await get('/apps/licensing/v1/product/101040/sku/1010400001/user/unknown@example.com')
       assert.strictEqual(status, 404)
     })
   })


### PR DESCRIPTION
Resolves the licensing evaluation failures (l01, i05) caused by 404 path mismatches on the fake API server.