### PR TITLE
docs: align knowledge summaries with actual document content

### DIFF
--- a/lib/knowledge/01-cep-overview.md
+++ b/lib/knowledge/01-cep-overview.md
@@ -1,5 +1,5 @@
 ---
-summary: 'Comprehensive introduction to Chrome Enterprise Premium. Helps with product evaluation, procurement, and delegated administration. Covers pricing, 60-day trial terms, and manual license assignment. Includes "How to": troubleshoot "Something went wrong" errors using the "Chrome DLP insight setting management" privilege, enable auto-license assignment, and configure specific Helpdesk roles. Keywords: $6/user price, Licensing, Cloud BeyondCorp Admin, license propagation, Workspace vs Cloud roles, Helpdesk permissions.'
+summary: 'Comprehensive introduction to Chrome Enterprise Premium (CEP). Helps with product evaluation and implementation. Walks through the 5-step checklist: setting up Chrome management, configuring connector policies, verifying the CEP service, setting up DLP rules, and configuring activity alerts. Covers trial terms (60 days, 5,000 users) and manual license assignment. Keywords: $6/user price, trial terms, Licensing, 5-step checklist, manual license assignment, Workspace service settings.'
 title: 'Chrome Enterprise Premium Overview and Implementation'
 articleId: 01
 url: 'https://knowledge.workspace.google.com/admin/security/protect-chrome-users-with-chrome-enterprise-premium'

--- a/lib/knowledge/09-chrome-log-events.md
+++ b/lib/knowledge/09-chrome-log-events.md
@@ -1,5 +1,5 @@
 ---
-summary: 'Chrome Reporting Connector and SIEM integration guide. Helps stream security events to Splunk and populate the Security Insights dashboard. Covers how to: enable the "Data Protection Insight Scanning" global setting, resolve empty dashboards by checking chrome://policy on clients, and verify local event generation at chrome://safe-browsing/#tab-reporting.'
+summary: 'Chrome Reporting Connector and SIEM integration guide. Helps search security event logs in the Admin Console and stream events to SIEMs like Splunk. Covers event descriptions for Threat and Data Protection events, and how to verify local event generation and policy receipt on client machines. Keywords: Chrome log events, Audit & investigation, Threat events, Data Protection events, chrome://policy, chrome://safe-browsing, Splunk integration.'
 title: 'Chrome Reporting Connector and SIEM Integration'
 articleId: 09
 url: 'https://knowledge.workspace.google.com/admin/reports/chrome-log-events'

--- a/lib/knowledge/23-insider-risk-monitoring.md
+++ b/lib/knowledge/23-insider-risk-monitoring.md
@@ -1,5 +1,5 @@
 ---
-summary: 'Insider risk and data loss monitoring guide. Helps identify unusual content transfer activity and high-volume exfiltration. Covers how to: enable risky activity reporting and monitor data movements in Chrome. Keywords: Insider risk, high-volume transfer, user activity monitoring.'
+summary: 'Insider risk and data loss monitoring guide. Covers how to turn on insider risk monitoring via the 1-click "Monitor data leaks and insider risk" flow, and how to configure the "Data protection insight scanning and report" setting. Explains how this automatically configures Chrome connectors, event logging, and DLP scanning. Keywords: Insider risk, 1-click enablement, Data protection insight scanning, Chrome security event logging, turn off monitoring.'
 title: 'Monitoring for Insider Risk and Data Loss'
 articleId: 23
 url: 'https://knowledge.workspace.google.com/admin/security/monitoring-for-insider-risk-and-data-loss'

--- a/lib/knowledge/29-admin-privilege-definitions.md
+++ b/lib/knowledge/29-admin-privilege-definitions.md
@@ -1,5 +1,5 @@
 ---
-summary: 'Reference for administrator privileges required to manage CEP features. Helps with troubleshooting "Access Denied" errors in the Admin Console. Covers privileges for "Chrome DLP insight setting management", Security Insights, DLP rules, and device management. Keywords: Chrome Security Services, Manage DLP rules, Security insights permissions.'
+summary: 'Reference for administrator privileges required to manage Google Workspace and CEP features in the Admin Console. Helps resolve "Access Denied" errors. Covers privileges for User management, Reports, Security Center, Data Loss Prevention (DLP) rule management, Chrome Management, and Data Security (Context-Aware Access). Keywords: Admin console privileges, Manage DLP rules, Security Center, Service Settings, custom roles.'
 title: 'Administrator Privilege Definitions'
 articleId: 29
 url: 'https://support.google.com/a/answer/1219251'

--- a/lib/knowledge/98-agent-knowledge-addendum.md
+++ b/lib/knowledge/98-agent-knowledge-addendum.md
@@ -1,5 +1,5 @@
 ---
-summary: 'Mandatory Technical "Golden Facts" for Chrome Enterprise Premium. Helps with troubleshooting and precise configuration. Covers Extension IDs for EV and SEB, Windows Certificate Store requirements (Current User store mandatory), and the URL filtering syntax cheat-sheet. Keywords: callobklhcbilhphinckomhgkigmfocg, ekajlcmdfcigmdbphhifahdfjbkciflj, Windows Store requirements, Sync Now, SafeBrowsingAllowlistDomains.'
+summary: 'Mandatory Technical "Golden Facts" and operational memory for Chrome Enterprise Premium. Covers Extension IDs for EV and SEB, Windows Certificate Store requirements for CBA, URL filtering syntax rules, and troubleshooting "Something went wrong" errors for Security Insights using specific privileges. Keywords: callobklhcbilhphinckomhgkigmfocg, ekajlcmdfcigmdbphhifahdfjbkciflj, Windows Store requirements, Security Insights Error, Chrome DLP insight setting management, SafeBrowsingAllowlistDomains.'
 title: 'CEP Technical Addendum (Agent Memory)'
 articleId: 98
 ---


### PR DESCRIPTION
## Motivation

This PR aligns the local knowledge base metadata summaries with the actual body content of the remote documents they index. 

During testing and diagnostics, we discovered that the JSON metadata summaries (defined in the frontmatter of `lib/knowledge/*.md` files) contained specific technical references (e.g., the `Chrome DLP insight setting management` privilege, `Data Protection Insight Scanning` global setting) that did not exist in the actual body of the retrieved documents. This mismatch was "leading agents astray" during knowledge retrieval by pointing them to the wrong source files when searching for these terms.

## Main Changes

1. **`lib/knowledge/01-cep-overview.md`**: Aligned summary to focus on the 5-step implementation checklist and trial terms. Restored the `Licensing` keyword to ensure baseline search tests continue to pass. Removed incorrect reference to troubleshooting privileges.
2. **`lib/knowledge/09-chrome-log-events.md`**: Focused summary on audit log searches, Threat/Data Protection event descriptions, and SIEM/Splunk integration. Removed incorrect reference to the `Data Protection Insight Scanning` setting.
3. **`lib/knowledge/23-insider-risk-monitoring.md`**: Updated summary to explicitly cover the 1-click *"Monitor data leaks and insider risk"* flow and the `"Data protection insight scanning and report"` setting (which are actually covered in this document).
4. **`lib/knowledge/29-admin-privilege-definitions.md`**: Removed incorrect references to non-existent privileges like `Chrome DLP insight setting management` and `Security Insights`, aligning the summary with the actual privilege list in the document.
5. **`lib/knowledge/98-agent-knowledge-addendum.md`**: Updated summary to explicitly include the `Security Insights Error` and `Chrome DLP insight setting management` privilege troubleshooting details, which are documented in this addendum.