### PR TITLE
test(evals): update deprecated model reference to gemini-3.1-flash-lite

### DIFF
--- a/test/evals/lib/agent.js
+++ b/test/evals/lib/agent.js
@@ -25,7 +25,7 @@ limitations under the License.
 import { GoogleGenerativeAI } from '@google/generative-ai'
 import { buildServerInstructions } from '../../../lib/knowledge/instructions.js'
 
-const MODEL_NAME = 'gemini-3.1-flash-lite-preview'
+const MODEL_NAME = 'gemini-3.1-flash-lite'
 const MAX_TURNS = 15
 
 /**

--- a/test/evals/lib/judge.js
+++ b/test/evals/lib/judge.js
@@ -24,7 +24,7 @@ limitations under the License.
 import { GoogleGenerativeAI } from '@google/generative-ai'
 import { isTransient } from './transient.js'
 
-const MODEL_NAME = 'gemini-3.1-flash-lite-preview'
+const MODEL_NAME = 'gemini-3.1-flash-lite'
 
 /**
  * Creates a judge instance backed by Gemini.

--- a/test/evals/run.js
+++ b/test/evals/run.js
@@ -414,10 +414,7 @@ async function main() {
       try {
         const { GoogleGenerativeAI } = await import('@google/generative-ai')
         const genAI = new GoogleGenerativeAI(apiKey)
-        const model = genAI.getGenerativeModel(
-          { model: 'gemini-3.1-flash-lite-preview' },
-          baseUrl ? { baseUrl } : undefined,
-        )
+        const model = genAI.getGenerativeModel({ model: 'gemini-3.1-flash-lite' }, baseUrl ? { baseUrl } : undefined)
 
         const failedResults = results.filter(r => r.status === Status.FAIL)
         const failureDetails = failedResults


### PR DESCRIPTION
Fixes the daily Agent Evals workflow run from failing due to deprecated preview model models/gemini-3.1-flash-lite-preview.