### PR TITLE
feat(docs): integrate Chrome Security Insights 1-click flow technical details

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,3 +9,4 @@ results_final.json
 *.patch
 .venv/
 .stryker-tmp/
+node_modules/

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -42,7 +42,6 @@ const copyrightHeader = [
 export default [
   {
     ignores: [
-
       '**/dist',
       '**/node_modules',
       '**/venv',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -42,6 +42,7 @@ const copyrightHeader = [
 export default [
   {
     ignores: [
+
       '**/dist',
       '**/node_modules',
       '**/venv',
@@ -50,6 +51,7 @@ export default [
       '**/.stryker-tmp/**',
       'results/**',
       '.worktrees/**',
+
       '.claude/**',
       '.gemini/**',
       '.opencode/**',

--- a/lib/knowledge/23-insider-risk-monitoring.md
+++ b/lib/knowledge/23-insider-risk-monitoring.md
@@ -1,5 +1,5 @@
 ---
-summary: 'Insider risk and data loss monitoring guide. Covers how to turn on insider risk monitoring via the 1-click "Monitor data leaks and insider risk" flow, and how to configure the "Data protection insight scanning and report" setting. Explains how this automatically configures Chrome connectors, event logging, and DLP scanning. Keywords: Insider risk, 1-click enablement, Data protection insight scanning, Chrome security event logging, turn off monitoring.'
+summary: 'Insider risk and data loss monitoring guide. Covers how to turn on insider risk monitoring via the 1-click "Monitor data leaks and insider risk" flow to enable Chrome Security Insights. Explains how this automatically configures Chrome connectors, event logging, and DLP scanning. Keywords: Chrome Security Insights, Insider risk, 1-click enablement, Data protection insight scanning, Chrome security event logging, turn off monitoring.'
 title: 'Monitoring for Insider Risk and Data Loss'
 articleId: 23
 url: 'https://knowledge.workspace.google.com/admin/security/monitoring-for-insider-risk-and-data-loss'

--- a/lib/knowledge/23-insider-risk-monitoring.md
+++ b/lib/knowledge/23-insider-risk-monitoring.md
@@ -1,5 +1,5 @@
 ---
-summary: 'Insider risk and data loss monitoring guide. Covers how to turn on insider risk monitoring via the 1-click "Monitor data leaks and insider risk" flow to enable Chrome Security Insights. Explains how this automatically configures Chrome connectors, event logging, and DLP scanning. Keywords: Chrome Security Insights, Insider risk, 1-click enablement, Data protection insight scanning, Chrome security event logging, turn off monitoring.'
+summary: 'Insider risk and data loss monitoring guide. Covers how to turn on insider risk monitoring via the 1-click "Monitor data leaks and insider risk" flow to enable Chrome Security Insights. Explains how this automatically configures Chrome connectors, event logging, and DLP scanning. Note that active connectors/rules do not guarantee Security Insights dashboard activation. Keywords: Chrome Security Insights, Insider risk, 1-click enablement, Data protection insight scanning, Chrome security event logging, turn off monitoring, dashboard isolation, connector vs dashboard.'
 title: 'Monitoring for Insider Risk and Data Loss'
 articleId: 23
 url: 'https://knowledge.workspace.google.com/admin/security/monitoring-for-insider-risk-and-data-loss'

--- a/lib/knowledge/98-agent-knowledge-addendum.md
+++ b/lib/knowledge/98-agent-knowledge-addendum.md
@@ -55,3 +55,15 @@ To successfully implement CBA, you **MUST** complete all three steps:
 - **Server-Side:** Use the **Investigation Tool** with the **Rule log events** data source.
 - **Client-Side:** Direct users to `chrome://policy` to verify rule receipt.
 - **SIEM:** Streaming events require the **Chrome Reporting Connector** and OU-level **Event Reporting** policy enablement.
+
+## 8. Chrome Security Insights (1-Click Flow)
+
+The "Monitor data leaks and insider risk" 1-click flow provides visibility into insider risk and data exfiltration with a single action.
+
+- **Automation:** It automatically enables **Chrome Enterprise Connectors**, **Chrome Security event logging**, and activates **50 common DLP detectors** to scan for sensitive content transfer events across Chrome.
+- **Visibility:** Provides visibility into all file transfers, sensitive data detection, and security events.
+- **Insights Reports:** Generates the following specific reports in the **Security Center** (Workspace Admin Console):
+  - **Users with high content transfer**
+  - **Domains with high content transfer**
+  - **Domain categories with high content transfer**
+  - **Most common sensitive data types**

--- a/lib/knowledge/98-agent-knowledge-addendum.md
+++ b/lib/knowledge/98-agent-knowledge-addendum.md
@@ -67,3 +67,4 @@ The "Monitor data leaks and insider risk" 1-click flow provides visibility into 
   - **Domains with high content transfer**
   - **Domain categories with high content transfer**
   - **Most common sensitive data types**
+- **Dashboard vs. Connector Isolation:** Activating connectors (like `ON_SECURITY_EVENT`) and DLP rules does **not** automatically enable the "Security Insights" dashboard, nor is it a guarantee of its state. Only the explicit activation of the Security Insights feature (such as the 1-click flow) will populate the Security Insights dashboard. Never assume "Security Insights" is active solely based on the presence of active connectors or rules.

--- a/test/evals/cases/knowledge/k37-chrome_security_insights.eval.js
+++ b/test/evals/cases/knowledge/k37-chrome_security_insights.eval.js
@@ -1,0 +1,27 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export default {
+  id: 'k37',
+  priority: 'P1',
+  tags: ['security_insights', 'dashboard', '1-click'],
+  prompt:
+    'What is Chrome Security Insights? What does the 1-click "Monitor data leaks and insider risk" flow automate, and does having active DLP rules guarantee that the Security Insights dashboard is active?',
+  goldenResponse:
+    'Chrome Security Insights is a feature that provides visibility into insider risk and data exfiltration. The 1-click "Monitor data leaks and insider risk" flow automatically enables Chrome Enterprise Connectors, Chrome Security event logging, and activates 50 common DLP detectors to scan for sensitive content transfer events. Crucially, having active DLP rules and connectors does NOT guarantee that the Security Insights dashboard is active; the dashboard itself requires explicit activation (such as via the 1-click flow) to populate, as dashboard activation is isolated from rule/connector status.',
+  judgeInstructions:
+    'The agent should explain that Chrome Security Insights provides visibility into insider risk and data exfiltration. It should note the 1-click flow automates Chrome Enterprise Connectors, Chrome Security event logging, and activates 50 common DLP detectors. Finally, it must explicitly clarify that active DLP rules/connectors do not guarantee that the Security Insights dashboard is active (dashboard activation requires explicit activation, e.g. via the 1-click flow).',
+}


### PR DESCRIPTION
MOTIVATION
The 1-click "Monitor data leaks and insider risk" flow in the Admin Console is a powerful automated feature, but its specific technical impacts—such as the activation of
50 common DLP detectors and the generation of four specific insight reports—were not documented in the local knowledge base. This caused the agent to provide generic
advice rather than precise technical details.

MAIN CHANGES
 - lib/knowledge/98-agent-knowledge-addendum.md: Added Section 8, "Chrome Security Insights (1-Click Flow)", as a "Golden Fact." This includes the specific metric (50
   detectors) and the names of the four specific reports generated (Users, Domains, Categories with high transfer, and common sensitive types).
 - lib/knowledge/23-insider-risk-monitoring.md: Updated metadata summary and keywords to include "Chrome Security Insights" to improve search discoverability for the
   agent.

NON-TRIVIAL DESIGN DECISIONS
 - Addendum Over Local KB Body: Technical specifics were added to the Addendum (Article 98) because it is automatically injected into the agent's context. This ensures I
   "know" these metrics regardless of which document I am currently reading.
 - Remote Source Preservation: Article 23 remains a remote-URL stub to maintain a single source of truth for narrative documentation, while the Addendum provides the
   high-signal "Golden Facts" often missing from general help center articles.
