### PR TITLE
fix(eval): simplify m01 judge instructions as per team consensus

### DIFF
--- a/test/evals/cases/mutation/m01-create_warn_dlp.eval.js
+++ b/test/evals/cases/mutation/m01-create_warn_dlp.eval.js
@@ -24,8 +24,7 @@ export default {
   prompt:
     'Create a DLP rule that warns users when they try to upload files containing credit card numbers. Apply it to the root organizational unit.',
   goldenResponse:
-    'Agent should identify the root OU, then create a DLP rule with warn action for file upload trigger with a content condition for credit card patterns. Should confirm the rule was created successfully. Resource IDs (policy names, OU IDs) are fine to show.',
-  judgeInstructions: `Verify the agent actually performed the action (tool was called), not just
-described how to do it. Resource IDs (policy names, OU IDs) are fine to show.
-Prefer plain-language confirmation over raw API output.`,
+    'Agent should identify the root OU, then create a DLP rule with warn action for file upload trigger with a content condition for credit card patterns. Should confirm in plain language that the rule was created successfully.',
+  judgeInstructions:
+    'Verify the agent indicated that it successfully created the DLP rule as requested. Do not penalize the agent for omitting policy resource IDs, raw API data, or OU IDs.',
 }


### PR DESCRIPTION
Updates the m01-create_warn_dlp.eval.js evaluation file to weaken the judge instructions and golden response. Following the team consensus, the criteria now simply verifies that the agent indicated successful creation of the DLP rule (since tool call execution is already verified by the expectedTools field). This prevents the judge from failing correct runs that omit sensitive policy/OU IDs.