### PR TITLE
docs: remove references to gated tools from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,15 +121,16 @@ For production environments, headless systems, or customized configurations, the
 
 For environment variables and stdio vs. HTTP transport, see
 [`docs/configuration.md`](docs/configuration.md).
+
 ## Prerequisites
 
-| Requirement              | Details                                                                                                                                                                                                                               |
-| :----------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Node.js**              | >= 20.0.0 (`node --version` to check)                                                                                                                                                                                                 |
+| Requirement              | Details                                                                                                                                                                                                                                   |
+| :----------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Node.js**              | >= 20.0.0 (`node --version` to check)                                                                                                                                                                                                     |
 | **Google Workspace**     | Any edition, plus a [Chrome Enterprise Premium](https://docs.cloud.google.com/chrome-enterprise-premium/docs/overview) license ([60-day free trial available](https://docs.cloud.google.com/chrome-enterprise-premium-mcp/docs/overview)) |
-| **Admin role**           | Google Workspace Super Admin, or a delegated admin with Chrome Management and DLP permissions                                                                                                                                         |
-| **Google Cloud project** | Linked to your Workspace domain, with required APIs enabled                                                                                                                                                                           |
-| **OAuth App Trust**      | The OAuth client must be [trusted in the Admin Console](docs/troubleshooting.md#configure-oauth-app-for-sensitive-scopes) for sensitive scopes.                                                                                       |
+| **Admin role**           | Google Workspace Super Admin, or a delegated admin with Chrome Management and DLP permissions                                                                                                                                             |
+| **Google Cloud project** | Linked to your Workspace domain, with required APIs enabled                                                                                                                                                                               |
+| **OAuth App Trust**      | The OAuth client must be [trusted in the Admin Console](docs/troubleshooting.md#configure-oauth-app-for-sensitive-scopes) for sensitive scopes.                                                                                           |
 
 > [!IMPORTANT]
 > Chrome Management and Admin SDK APIs require a Google Workspace admin
@@ -138,6 +139,7 @@ For environment variables and stdio vs. HTTP transport, see
 > delegated with Chrome Management permissions). With only Google Cloud
 > IAM permissions, calls return `403 Permission Denied` with no indication
 > that a Workspace role is missing.
+
 ## Available tools and prompts
 
 ### Prompts

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ You should see the available tools listed in the response. If they don't appear,
 > **This server is an administrator-level interface to Chrome Enterprise Premium.**
 > When you connect it to an MCP client, you can use natural-language prompts to:
 >
-> - Create, modify, and delete DLP rules and content detectors.
+> - **Create and modify DLP rules and content detectors.**
 > - Change connector policies.
 > - Force-install browser extensions onto every managed Chrome browser.
 > - Enable Google Cloud APIs on your project.
@@ -81,7 +81,7 @@ You should see the available tools listed in the response. If they don't appear,
 >
 > - Connect this server only to MCP clients you trust, on data sources you trust.
 > - Treat every document, message, and webpage you put in front of the agent as untrusted. It might contain hidden instructions.
-> - Pay extra attention to mutating tools (`create_*`, `update_*`, `delete_*`, `enable_*`); they have tenant-wide security impact.
+> - Pay extra attention to mutating tools (`create_*`, `update_*`, `enable_*`); they have tenant-wide security impact.
 > - Use a dedicated, least-privilege admin account when experimenting.
 
 ## Workspace Scopes & Permissions
@@ -121,17 +121,23 @@ For production environments, headless systems, or customized configurations, the
 
 For environment variables and stdio vs. HTTP transport, see
 [`docs/configuration.md`](docs/configuration.md).
-
 ## Prerequisites
 
-| Requirement              | Details                                                                                                                                                                                                                                   |
-| :----------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Node.js**              | >= 18.0.0 (`node --version` to check)                                                                                                                                                                                                     |
+| Requirement              | Details                                                                                                                                                                                                                               |
+| :----------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Node.js**              | >= 20.0.0 (`node --version` to check)                                                                                                                                                                                                 |
 | **Google Workspace**     | Any edition, plus a [Chrome Enterprise Premium](https://docs.cloud.google.com/chrome-enterprise-premium/docs/overview) license ([60-day free trial available](https://docs.cloud.google.com/chrome-enterprise-premium-mcp/docs/overview)) |
-| **Admin role**           | Google Workspace Super Admin, or a delegated admin with Chrome Management and DLP permissions                                                                                                                                             |
-| **Google Cloud project** | Linked to your Workspace domain, with required APIs enabled                                                                                                                                                                               |
-| **OAuth App Trust**      | The OAuth client must be [trusted in the Admin Console](docs/troubleshooting.md#configure-oauth-app-for-sensitive-scopes) for sensitive scopes.                                                                                           |
+| **Admin role**           | Google Workspace Super Admin, or a delegated admin with Chrome Management and DLP permissions                                                                                                                                         |
+| **Google Cloud project** | Linked to your Workspace domain, with required APIs enabled                                                                                                                                                                           |
+| **OAuth App Trust**      | The OAuth client must be [trusted in the Admin Console](docs/troubleshooting.md#configure-oauth-app-for-sensitive-scopes) for sensitive scopes.                                                                                       |
 
+> [!IMPORTANT]
+> Chrome Management and Admin SDK APIs require a Google Workspace admin
+> role in addition to Google Cloud IAM roles. You must hold an admin role
+> in the [Admin Console](https://admin.google.com/) (Super Admin or
+> delegated with Chrome Management permissions). With only Google Cloud
+> IAM permissions, calls return `403 Permission Denied` with no indication
+> that a Workspace role is missing.
 ## Available tools and prompts
 
 ### Prompts
@@ -150,13 +156,13 @@ The server exposes tools for reading and managing Chrome Enterprise resources:
   customer profiles
 - **Licensing:** check CEP subscription status, check per-user license
   assignment
-- **DLP:** list/create/delete DLP rules, list/create/delete detectors (regex,
+- **DLP:** list/create DLP rules, list/create detectors (regex,
   word list, URL list), create default rule sets
 - **Connectors:** get connector policy status, enable Chrome Enterprise
   connectors
 - **Extensions:** check SEB extension status, install SEB extension
 - **Security:** get Chrome activity logs, check and enable required APIs
-- **Knowledge:** search the built-in Chrome Enterprise Premium knowledge base
+- **Knowledge:** retrieve documentation from the built-in Chrome Enterprise Premium knowledge base
 
 ## Architecture
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -6,10 +6,7 @@
   "mcpServers": {
     "chrome-enterprise-premium": {
       "command": "npx",
-      "args": [
-        "-y",
-        "@google/chrome-enterprise-premium-mcp@^1.4.0"
-      ]
+      "args": ["-y", "@google/chrome-enterprise-premium-mcp@^1.4.0"]
     }
   }
 }


### PR DESCRIPTION
## Motivation
Gated/experimental tools like `delete_agent_dlp_rule` and `delete_detector` are not enabled for most end-users by default. To reduce confusion and provide a clean initial onboarding experience, these reference listings are removed from the main README capabilities section.

## Main Changes
- Updated `README.md` to remove references to gated/experimental mutating and knowledge tools.
- Corrected the Node.js prerequisite requirement in the README table from `>= 18.0.0` to `>= 20.0.0` to match `package.json`'s engines specification.