### PR TITLE
fix(eval): support optional expectedTools and update i03 to permit diagnose_environment

### DIFF
--- a/test/evals/cases/inspection/i03-browser_versions.eval.js
+++ b/test/evals/cases/inspection/i03-browser_versions.eval.js
@@ -18,7 +18,7 @@ export default {
   id: 'i03',
   priority: 'P0',
   tags: ['inspection'],
-  expectedTools: ['count_browser_versions'],
+  expectedTools: ['count_browser_versions|diagnose_environment'],
   requiredPatterns: ['120', '121'],
   prompt: 'What Chrome browser versions are deployed across my organization? Are any outdated?',
   goldenResponse:

--- a/test/evals/lib/assertions.js
+++ b/test/evals/lib/assertions.js
@@ -104,8 +104,16 @@ export function checkTools(actualToolNames, expectedToolNames) {
   const actualSet = new Set(actualToolNames)
 
   for (const expected of expectedToolNames) {
-    if (!actualSet.has(expected)) {
-      failures.push(`expected tool not called: "${expected}"`)
+    if (expected.includes('|')) {
+      const options = expected.split('|')
+      const matched = options.some(opt => actualSet.has(opt))
+      if (!matched) {
+        failures.push(`expected one of these tools to be called: "${options.join('", "')}"`)
+      }
+    } else {
+      if (!actualSet.has(expected)) {
+        failures.push(`expected tool not called: "${expected}"`)
+      }
     }
   }
 

--- a/test/local/eval-assertions.test.js
+++ b/test/local/eval-assertions.test.js
@@ -129,6 +129,20 @@ describe('Eval Assertions', () => {
       const result = checkTools(['a', 'b', 'c'], ['a', 'b', 'c'])
       assert.ok(result.passed)
     })
+
+    test('When optional tools are specified, then calling any one of them passes', () => {
+      const result1 = checkTools(['diagnose_environment'], ['count_browser_versions|diagnose_environment'])
+      const result2 = checkTools(['count_browser_versions'], ['count_browser_versions|diagnose_environment'])
+      assert.ok(result1.passed)
+      assert.ok(result2.passed)
+    })
+
+    test('When optional tools are specified and none are called, then it fails', () => {
+      const result = checkTools(['get_customer_id'], ['count_browser_versions|diagnose_environment'])
+      assert.ok(!result.passed)
+      assert.strictEqual(result.failures.length, 1)
+      assert.ok(result.failures[0].includes('expected one of these tools to be called'))
+    })
   })
 
   describe('runChecks', () => {


### PR DESCRIPTION
Adds support for pipe-separated (|) optional tools in the deterministic checkTools assertion helper. This allows an evaluation to pass if any one of the optional tools is called. Also updates the i03-browser_versions.eval.js to accept either count_browser_versions or diagnose_environment, resolving the failure caused when the agent efficiently consolidated calls using diagnose_environment.