### PR TITLE
fix: self-reference in devDependencies to resolve local npx failure

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -6,10 +6,7 @@
   "mcpServers": {
     "chrome-enterprise-premium": {
       "command": "npx",
-      "args": [
-        "-y",
-        "@google/chrome-enterprise-premium-mcp@^1.4.0"
-      ]
+      "args": ["-y", "@google/chrome-enterprise-premium-mcp@^1.4.0"]
     }
   }
 }

--- a/lib/util/cli_invocation.js
+++ b/lib/util/cli_invocation.js
@@ -48,8 +48,13 @@ function hasLocalBin() {
   }
   const cmd = process.platform === 'win32' ? 'where' : 'which'
   try {
-    execFileSync(cmd, [BIN_NAME], { stdio: ['ignore', 'ignore', 'ignore'] })
-    cachedHasBin = true
+    const stdout = execFileSync(cmd, [BIN_NAME], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] })
+    const firstPath = stdout.split(/\r?\n/)[0].trim()
+
+    // Tooling standard approach: Match exact folder boundary for 'node_modules' cross-platform
+    const isLocalDependency = /(?:^|[\\/])node_modules(?:[\\/]|$)/.test(firstPath)
+
+    cachedHasBin = firstPath.length > 0 && !isLocalDependency
   } catch {
     cachedHasBin = false
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,10 +3,12 @@
   "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
+  "dev": true,
   "packages": {
     "": {
       "name": "@google/chrome-enterprise-premium-mcp",
       "version": "1.7.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@dotenvx/dotenvx": "^1.66.0",
@@ -27,6 +29,7 @@
         "@commitlint/cli": "^21.0.1",
         "@commitlint/config-conventional": "^21.0.1",
         "@eslint/js": "^10.0.1",
+        "@google/chrome-enterprise-premium-mcp": "file:.",
         "@google/generative-ai": "^0.24.1",
         "eslint": "^10.3.0",
         "eslint-config-prettier": "^10.1.8",
@@ -535,6 +538,10 @@
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
+    },
+    "node_modules/@google/chrome-enterprise-premium-mcp": {
+      "resolved": "",
+      "link": true
     },
     "node_modules/@google/generative-ai": {
       "version": "0.24.1",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@commitlint/cli": "^21.0.1",
     "@commitlint/config-conventional": "^21.0.1",
     "@eslint/js": "^10.0.1",
+    "@google/chrome-enterprise-premium-mcp": "file:.",
     "@google/generative-ai": "^0.24.1",
     "eslint": "^10.3.0",
     "eslint-config-prettier": "^10.1.8",


### PR DESCRIPTION
# Description

## MOTIVATION
When a developer runs `npx @google/chrome-enterprise-premium-mcp auth login` inside the repository checkout directory, `npx` resolves the package locally to the current directory's `package.json` (which has matching name `@google/chrome-enterprise-premium-mcp`).
However, since the package is not a dependency of itself, the package's binary `chrome-enterprise-premium-mcp` is never linked in `node_modules/.bin`. As a result, the command fails with `sh: line 1: chrome-enterprise-premium-mcp: command not found` (exit code 127).

Furthermore, introducing this self-dependency had a subtle side-effect: when executing commands inside the workspace via npm scripts (like `npm start` or during test runs), npm temporarily prepends `node_modules/.bin` to the `PATH`. The dynamic prober `hasLocalBin()` would detect the newly linked local binary on the path, and incorrectly output the global command (`chrome-enterprise-premium-mcp auth login`), which is a "false promise" because it fails in a clean terminal shell that does not have the local `.bin` prepended.

## MAIN CHANGES
1. **Self devDependency (`package.json`)**: Added `@google/chrome-enterprise-premium-mcp: "file:."` to the package's `devDependencies`. This automatically self-installs and links `node_modules/.bin/chrome-enterprise-premium-mcp` during `npm install` in a clean, cross-platform, and standard way (following the same pattern ESLint uses).
2. **CLI Prober Path Filtering (`lib/util/cli_invocation.js`)**: Updated the dynamic prober `hasLocalBin()` to ignore binary paths resolved inside a local `node_modules` directory. This ensures that temporary test/run PATH prepends do not trick the server into printing global commands that are unavailable in a clean shell, guaranteeing that local checkout developers are correctly directed to use the local or `npx` wrappers.

## NON-TRIVIAL DESIGN DECISIONS
- **Adopted `file:.` Dependency (ESLint Pattern)**: Using `"file:."` in `devDependencies` is the standard, clean, and native npm solution to self-link packages for local testing. It delegates the symlink creation to `npm install` which is safe and platform-independent.
- **Dynamic Path Rejection in Prober**: Rather than checking only for the existence of the binary file in the `PATH`, `hasLocalBin()` now captures the resolved absolute path of the command and explicitly filters out `node_modules` folder segments via a platform-agnostic regular expression boundary check (preventing false positives from containing paths like `/node_modules-projects/` and matching standard path exclusion conventions in Webpack and Babel).
