### PR TITLE
fix: prevent local loopback server shutdown hangs by forcing Connection: close

### DIFF
--- a/lib/util/credential/loopback_server.js
+++ b/lib/util/credential/loopback_server.js
@@ -41,7 +41,10 @@ export async function startLoopbackServer() {
     const code = url.searchParams.get('code') ?? undefined
     const state = url.searchParams.get('state') ?? undefined
     const error = url.searchParams.get('error') ?? undefined
-    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+    res.writeHead(200, {
+      'Content-Type': 'text/html; charset=utf-8',
+      Connection: 'close',
+    })
     res.end(error ? renderErrorPage(error) : renderSuccessPage())
     resolveCode({ code, state, error })
   })

--- a/test/local/loopback-server.test.js
+++ b/test/local/loopback-server.test.js
@@ -96,4 +96,15 @@ describe('startLoopbackServer', () => {
       await server.stop()
     }
   })
+
+  it('When a request is received, then the response contains Connection: close header', async () => {
+    const server = await startLoopbackServer()
+    try {
+      server.waitForCode()
+      const res = await fetch(`${server.redirectUri}?code=test`)
+      assert.equal(res.headers.get('connection'), 'close')
+    } finally {
+      await server.stop()
+    }
+  })
 })


### PR DESCRIPTION
## Motivation
During local CLI authentication (`npm run auth:login` or `cep_auth` tool calls), the process would hang after the browser redirected to the local loopback server, even after displaying the "Signed in" success page. The process remained hung until the user manually closed the browser tab.

This occurred because modern web browsers use HTTP Keep-Alive by default, keeping the TCP connection open to the local loopback server. Node.js's `server.close()` hangs and waits for all active connections to close naturally before invoking its callback, holding the CLI process hostage.

## Main Changes
*   **Loopback Server Fix:** Added the standard `'Connection': 'close'` header to all loopback server HTTP responses (both success and error pages) in `lib/util/credential/loopback_server.js`. This instructs the browser to close the TCP connection immediately after it finishes downloading the HTML response.
*   **Integration Testing:** Added a new integration test case in `test/local/loopback-server.test.js` that asserts the response headers of the loopback server contain `Connection: close`.

## Design Decisions
*   **Header-Based Connection Termination:** Using the standard `'Connection': 'close'` HTTP header is a simple, robust, and backwards-compatible solution. It cleanly avoids having to track and forcefully destroy active sockets inside the Node.js server code, relying on standard protocol-level termination instead.
