### PR TITLE
refactor(auth): thread credentialsSource for context-aware remediation advice

### DIFF
--- a/lib/util/auth-error.js
+++ b/lib/util/auth-error.js
@@ -50,6 +50,9 @@ export function getAuthErrorMessage(error, source = 'cache') {
   const isInsufficientScopes = lower.includes(ERROR_MESSAGES.INSUFFICIENT_SCOPES.toLowerCase())
   const isApiNotEnabled = errorMessage.includes(ERROR_MESSAGES.API_NOT_USED_IN_PROJECT)
 
+  const authProjectNumber = MANAGED_OAUTH_CLIENT_ID.split('-')[0]
+  const mentionsDefaultAuthProject = errorMessage.includes(authProjectNumber)
+
   const status = error.status || error.code || error.response?.status
   const is401 =
     status === 401 || lower.includes('401') || lower.includes('unauthenticated') || lower.includes('invalid_grant')
@@ -60,11 +63,25 @@ export function getAuthErrorMessage(error, source = 'cache') {
   if (source === 'bearer') {
     if (resolvedStatus === 401) {
       instruction =
-        'Authentication required. The inbound Bearer token has expired or is invalid. Re-authenticate through your MCP client to refresh the token.'
+        'Authentication required. The inbound Bearer token has expired or is invalid. ' +
+        'Please re-authenticate or refresh the connection in your client application. ' +
+        "If you are using the Gemini CLI, you can run '/mcp reauth'."
+    } else if (isApiNotEnabled) {
+      if (mentionsDefaultAuthProject) {
+        instruction =
+          `A required API is disabled for the default Google-managed 1P OAuth project (${authProjectNumber}).\n\n` +
+          'For first-party (1P) authentication, APIs must be enabled on the default project rather than your own project. ' +
+          'Because you do not have permissions to modify the default 1P project, please reach out to a Chrome Enterprise Premium team member ' +
+          `to enable the missing API on project ${authProjectNumber}.`
+      } else {
+        instruction =
+          'A required API is not enabled in the Google Cloud project that owns your OAuth client.\n\n' +
+          'Please ask your Google Cloud administrator to enable the required APIs listed in lib/constants.js#SERVICE_NAMES.'
+      }
     } else {
       instruction = `Permission denied. The authenticated principal lacks the required permissions, or the necessary Google Cloud APIs are not enabled.
 
-1. **Re-authenticate:** Refresh the inbound Bearer token through your MCP client to ensure it is fresh.
+1. **Re-authenticate:** Refresh the inbound Bearer token through your client application (for example, by running '/mcp reauth' in Gemini CLI or restarting the session) to ensure it is fresh.
 2. **Verify Workspace Roles:** Ensure the Google account you signed in with has the necessary Chrome Enterprise or Workspace delegated administrator roles.
 3. **Verify APIs are enabled:** Ask your Google Cloud administrator to enable the required APIs listed in lib/constants.js#SERVICE_NAMES.`
     }
@@ -83,8 +100,6 @@ export function getAuthErrorMessage(error, source = 'cache') {
     } else if (isInsufficientScopes) {
       instruction = `The cached OAuth token is missing one or more required scopes. Run the \`cep_auth\` tool, or re-run \`${manualLogin}\` at the shell, to re-consent with the updated scope set.`
     } else if (isApiNotEnabled) {
-      const authProjectNumber = MANAGED_OAUTH_CLIENT_ID.split('-')[0]
-      const mentionsDefaultAuthProject = errorMessage.includes(authProjectNumber)
       if (mentionsDefaultAuthProject) {
         instruction =
           `A required API is disabled for the default Google-managed 1P OAuth project (${authProjectNumber}).\n\n` +

--- a/lib/util/auth-error.js
+++ b/lib/util/auth-error.js
@@ -71,8 +71,9 @@ export function getAuthErrorMessage(error, source = 'cache') {
         instruction =
           `A required API is disabled for the default Google-managed 1P OAuth project (${authProjectNumber}).\n\n` +
           'For first-party (1P) authentication, APIs must be enabled on the default project rather than your own project. ' +
-          'Because you do not have permissions to modify the default 1P project, please reach out to a Chrome Enterprise Premium team member ' +
-          `to enable the missing API on project ${authProjectNumber}.`
+          'Because you do not have permissions to modify the default 1P project, please file an issue on our GitHub repository ' +
+          `requesting to enable the missing API on project ${authProjectNumber}:\n` +
+          '  https://github.com/google/chrome-enterprise-premium-mcp/issues'
       } else {
         instruction =
           'A required API is not enabled in the Google Cloud project that owns your OAuth client.\n\n' +
@@ -104,8 +105,9 @@ export function getAuthErrorMessage(error, source = 'cache') {
         instruction =
           `A required API is disabled for the default Google-managed 1P OAuth project (${authProjectNumber}).\n\n` +
           'For first-party (1P) authentication, APIs must be enabled on the default project rather than your own project. ' +
-          'Because you do not have permissions to modify the default 1P project, please reach out to a Chrome Enterprise Premium team member ' +
-          `to enable the missing API on project ${authProjectNumber}.\n\n` +
+          'Because you do not have permissions to modify the default 1P project, please file an issue on our GitHub repository ' +
+          `requesting to enable the missing API on project ${authProjectNumber}:\n` +
+          '  https://github.com/google/chrome-enterprise-premium-mcp/issues\n\n' +
           'Alternatively, if you are using a custom OAuth client (BYO), ensure that you have enabled ' +
           'the required Workspace APIs in your own Google Cloud project (e.g., via the check_and_enable_cep_api tool).'
       } else {

--- a/lib/util/auth-error.js
+++ b/lib/util/auth-error.js
@@ -15,57 +15,123 @@ limitations under the License.
 */
 
 /**
- * @file Human-readable error messages for Google API auth failures.
+ * @file Human-readable error messages and remediation for Google API auth failures.
  *
- * Detects insufficient-scope errors and the SERVICE_DISABLED 403 ("API has
- * not been used in project ...") that fires when an OAuth client owns a
- * Google Cloud project that has not enabled the Workspace APIs this server
- * uses. Returns OAuth-flow-flavored remediation.
+ * Detects insufficient-scopes and SERVICE_DISABLED errors, and returns
+ * targeted remediation instructions depending on whether the active session
+ * used a Bearer token (Gemini CLI), Service Account ADC (Production), or the
+ * local OAuth cache (CLI login).
  */
 
 import { ERROR_MESSAGES, SERVICE_NAMES, MANAGED_OAUTH_CLIENT_ID } from '../constants.js'
 import { cliInvocation } from './cli_invocation.js'
 
 /**
- * Generates a descriptive error message for authentication failures.
- * @param {Error} error - The original error thrown during an auth-related call.
- * @returns {string} A formatted error message with OAuth-flow remediation.
+ * Resolves the active credential source based on environment and headers.
+ * @param {string|null} authToken - Inbound bearer token if present.
+ * @param {object} [env] - Environment variables; defaults to process.env.
+ * @returns {'bearer'|'adc'|'cache'} The resolved credential source.
  */
-export function getAuthErrorMessage(error) {
+export function resolveCredentialsSource(authToken, env = process.env) {
+  if (authToken) {
+    return 'bearer'
+  }
+  if (env.GOOGLE_APPLICATION_CREDENTIALS) {
+    return 'adc'
+  }
+  // If running in HTTP mode (PORT is set) and no bearer token is provided,
+  // it must be relying on GCP metadata/service account auth (ADC).
+  if (env.PORT && env.GCP_STDIO !== 'true') {
+    return 'adc'
+  }
+  return 'cache'
+}
+
+/**
+ * Generates targeted, human-readable remediation instructions for auth failures.
+ * @param {Error} error - The original error thrown during an auth-related call.
+ * @param {'bearer'|'adc'|'cache'|'provided'} [source] - The active credential source.
+ * @returns {string} A formatted error message with targeted remediation.
+ */
+export function getAuthErrorMessage(error, source = 'cache') {
   const errorMessage = error.message || ''
   const lower = errorMessage.toLowerCase()
   const isInsufficientScopes = lower.includes(ERROR_MESSAGES.INSUFFICIENT_SCOPES.toLowerCase())
   const isApiNotEnabled = errorMessage.includes(ERROR_MESSAGES.API_NOT_USED_IN_PROJECT)
 
-  let instruction = ''
-  if (isInsufficientScopes) {
-    instruction = `The cached OAuth token is missing one or more required scopes. Run the \`cep_auth\` tool, or re-run \`${cliInvocation('auth login')}\` at the shell, to re-consent with the updated scope set.`
-  } else if (isApiNotEnabled) {
-    const apiList = Object.values(SERVICE_NAMES).join(' ')
-    const authProjectNumber = MANAGED_OAUTH_CLIENT_ID.split('-')[0]
-    const mentionsDefaultAuthProject = errorMessage.includes(authProjectNumber)
+  const status = error.status || error.code || error.response?.status
+  const is401 =
+    status === 401 || lower.includes('401') || lower.includes('unauthenticated') || lower.includes('invalid_grant')
+  const resolvedStatus = is401 ? 401 : 403
 
-    if (mentionsDefaultAuthProject) {
+  let instruction = ''
+
+  if (source === 'bearer') {
+    if (resolvedStatus === 401) {
       instruction =
-        `A required API is disabled for the default Google-managed 1P OAuth project (${authProjectNumber}).\n\n` +
-        'For first-party (1P) authentication, APIs must be enabled on the default project rather than your own project. ' +
-        'Because you do not have permissions to modify the default 1P project, please reach out to a Chrome Enterprise Premium team member ' +
-        `to enable the missing API on project ${authProjectNumber}.\n\n` +
-        'Alternatively, if you are using a custom OAuth client (BYO) or a service account, ensure that you have enabled ' +
-        'the required Workspace APIs in your own Google Cloud project (e.g., via the check_and_enable_cep_api tool).'
+        'Authentication required. The inbound Bearer token has expired or is invalid. Re-authenticate through your MCP client to refresh the token.'
+    } else {
+      instruction = `Permission denied. The authenticated principal lacks the required permissions, or the necessary Google Cloud APIs are not enabled.
+
+1. **Re-authenticate:** Refresh the inbound Bearer token through your MCP client to ensure it is fresh.
+2. **Verify Workspace Roles:** Ensure the Google account you signed in with has the necessary Chrome Enterprise or Workspace delegated administrator roles.
+3. **Verify APIs are enabled:** Ask your Google Cloud administrator to enable the required APIs listed in lib/constants.js#SERVICE_NAMES.`
+    }
+  } else if (source === 'adc') {
+    if (resolvedStatus === 401) {
+      instruction =
+        'Authentication required. The Service Account credentials (ADC) are invalid or expired. Check your GOOGLE_APPLICATION_CREDENTIALS file path or GCP environment roles.'
+    } else {
+      instruction = `Permission denied. The Service Account lacks required Workspace privileges, or the necessary Google Cloud APIs are not enabled.
+
+1. **Workspace Domain-Wide Delegation:** Ensure Domain-Wide Delegation is enabled for this Service Account in the Workspace Admin Console, and that CEP_IMPERSONATE_SUBJECT is set to a valid Workspace admin email.
+2. **Verify APIs are enabled:** Ensure the required Workspace APIs are enabled in your Google Cloud project:
+   gcloud services enable ${Object.values(SERVICE_NAMES).join(' ')} --project=YOUR_PROJECT_ID`
+    }
+  } else if (source === 'provided') {
+    if (resolvedStatus === 401) {
+      instruction = 'Authentication required. The caller-provided custom AuthClient has invalid or expired credentials.'
     } else {
       instruction =
-        'A required API is not enabled in the Google Cloud project that owns your OAuth client.\n\n' +
-        'Enable the required APIs in that project:\n' +
-        `  gcloud services enable ${apiList} --project=YOUR_PROJECT_ID\n\n` +
-        'Or call the check_and_enable_cep_api tool against your project. ' +
-        'For the full BYO OAuth-client walkthrough, see:\n' +
-        '  https://github.com/google/chrome-enterprise-premium-mcp/blob/main/docs/auth-bring-your-own-oauth-client.md'
+        'Permission denied. The caller-provided custom AuthClient lacks necessary permissions or required GCP APIs are disabled.'
+    }
+  } else {
+    // Fallback/Default to 'cache' (local OAuth flow)
+    const manualLogin = cliInvocation('auth login')
+    if (resolvedStatus === 401) {
+      instruction = `Authentication required. Run the \`cep_auth\` tool to sign in, or run \`${manualLogin}\` at the shell to authorize the server (it caches the access token at ~/.config/cep-mcp/tokens.json).`
+    } else if (isInsufficientScopes) {
+      instruction = `The cached OAuth token is missing one or more required scopes. Run the \`cep_auth\` tool, or re-run \`${manualLogin}\` at the shell, to re-consent with the updated scope set.`
+    } else if (isApiNotEnabled) {
+      const authProjectNumber = MANAGED_OAUTH_CLIENT_ID.split('-')[0]
+      const mentionsDefaultAuthProject = errorMessage.includes(authProjectNumber)
+      if (mentionsDefaultAuthProject) {
+        instruction =
+          `A required API is disabled for the default Google-managed 1P OAuth project (${authProjectNumber}).\n\n` +
+          'For first-party (1P) authentication, APIs must be enabled on the default project rather than your own project. ' +
+          'Because you do not have permissions to modify the default 1P project, please reach out to a Chrome Enterprise Premium team member ' +
+          `to enable the missing API on project ${authProjectNumber}.\n\n` +
+          'Alternatively, if you are using a custom OAuth client (BYO), ensure that you have enabled ' +
+          'the required Workspace APIs in your own Google Cloud project (e.g., via the check_and_enable_cep_api tool).'
+      } else {
+        instruction =
+          'A required API is not enabled in the Google Cloud project that owns your OAuth client.\n\n' +
+          'Enable the required APIs in that project:\n' +
+          `  gcloud services enable ${Object.values(SERVICE_NAMES).join(' ')} --project=YOUR_PROJECT_ID\n\n` +
+          'Or call the check_and_enable_cep_api tool against your project. ' +
+          'For the full BYO OAuth-client walkthrough, see:\n' +
+          '  https://github.com/google/chrome-enterprise-premium-mcp/blob/main/docs/auth-bring-your-own-oauth-client.md'
+      }
+    } else {
+      instruction = `Permission denied. Your account lacks the required permissions, or the necessary Google Cloud APIs are not enabled.
+
+1. **Re-authenticate with all required scopes:** Run the \`cep_auth\` tool, or run \`${manualLogin}\` at the shell to re-consent. The required scope set is defined in lib/constants.js#SCOPES.
+2. **Verify APIs are enabled:** Run the \`check_and_enable_cep_api\` tool against your project, or enable the API set listed in lib/constants.js#SERVICE_NAMES.`
     }
   }
 
   if (instruction) {
-    return `${instruction}\n\nOriginal error message from Google Auth Library: ${errorMessage}`
+    return `${instruction}\n\nOriginal error message from Google APIs: ${errorMessage}`
   }
   return `ERROR: Authentication failed.\nOriginal error message: ${errorMessage}`
 }

--- a/lib/util/auth-error.js
+++ b/lib/util/auth-error.js
@@ -29,20 +29,11 @@ import { cliInvocation } from './cli_invocation.js'
 /**
  * Resolves the active credential source based on environment and headers.
  * @param {string|null} authToken - Inbound bearer token if present.
- * @param {object} [env] - Environment variables; defaults to process.env.
- * @returns {'bearer'|'adc'|'cache'} The resolved credential source.
+ * @returns {'bearer'|'cache'} The resolved credential source.
  */
-export function resolveCredentialsSource(authToken, env = process.env) {
+export function resolveCredentialsSource(authToken) {
   if (authToken) {
     return 'bearer'
-  }
-  if (env.GOOGLE_APPLICATION_CREDENTIALS) {
-    return 'adc'
-  }
-  // If running in HTTP mode (PORT is set) and no bearer token is provided,
-  // it must be relying on GCP metadata/service account auth (ADC).
-  if (env.PORT && env.GCP_STDIO !== 'true') {
-    return 'adc'
   }
   return 'cache'
 }
@@ -76,17 +67,6 @@ export function getAuthErrorMessage(error, source = 'cache') {
 1. **Re-authenticate:** Refresh the inbound Bearer token through your MCP client to ensure it is fresh.
 2. **Verify Workspace Roles:** Ensure the Google account you signed in with has the necessary Chrome Enterprise or Workspace delegated administrator roles.
 3. **Verify APIs are enabled:** Ask your Google Cloud administrator to enable the required APIs listed in lib/constants.js#SERVICE_NAMES.`
-    }
-  } else if (source === 'adc') {
-    if (resolvedStatus === 401) {
-      instruction =
-        'Authentication required. The Service Account credentials (ADC) are invalid or expired. Check your GOOGLE_APPLICATION_CREDENTIALS file path or GCP environment roles.'
-    } else {
-      instruction = `Permission denied. The Service Account lacks required Workspace privileges, or the necessary Google Cloud APIs are not enabled.
-
-1. **Workspace Domain-Wide Delegation:** Ensure Domain-Wide Delegation is enabled for this Service Account in the Workspace Admin Console, and that CEP_IMPERSONATE_SUBJECT is set to a valid Workspace admin email.
-2. **Verify APIs are enabled:** Ensure the required Workspace APIs are enabled in your Google Cloud project:
-   gcloud services enable ${Object.values(SERVICE_NAMES).join(' ')} --project=YOUR_PROJECT_ID`
     }
   } else if (source === 'provided') {
     if (resolvedStatus === 401) {

--- a/lib/util/helpers.js
+++ b/lib/util/helpers.js
@@ -21,7 +21,7 @@ limitations under the License.
  * - Execute API calls with retry logic.
  */
 
-import { getAuthErrorMessage } from './auth-error.js'
+import { getAuthErrorMessage, resolveCredentialsSource } from './auth-error.js'
 import { ERROR_MESSAGES } from '../constants.js'
 import { logger } from './logger.js'
 import { CHROME_ACTION_TYPES } from './chrome_dlp_constants.js'
@@ -79,7 +79,8 @@ export async function callWithRetry(fn, _description) {
       errorMessage.toLowerCase().includes(ERROR_MESSAGES.INSUFFICIENT_SCOPES.toLowerCase()) ||
       errorMessage.includes(ERROR_MESSAGES.API_NOT_USED_IN_PROJECT)
     if (isAuthError) {
-      throw new Error(getAuthErrorMessage(error))
+      const source = resolveCredentialsSource(null)
+      throw new Error(getAuthErrorMessage(error, source))
     }
     throw error
   }

--- a/test/local/auth.test.js
+++ b/test/local/auth.test.js
@@ -223,7 +223,8 @@ describe('Auth', () => {
       error.status = 401
       const msg = getAuthErrorMessage(error, 'bearer')
       assert.match(msg, /inbound Bearer token has expired/)
-      assert.match(msg, /Re-authenticate through your MCP client/)
+      assert.match(msg, /re-authenticate or refresh the connection/)
+      assert.match(msg, /Gemini CLI/)
     })
 
     test('When source is bearer and status is 403, then it returns Bearer principal lacks permissions message', async () => {
@@ -242,6 +243,26 @@ describe('Auth', () => {
       const msg = getAuthErrorMessage(error, 'provided')
       assert.match(msg, /caller-provided custom AuthClient/)
       assert.match(msg, /expired credentials/)
+    })
+
+    test('When source is bearer and status is 403 and API is disabled on default project, then it returns 1P API disabled message', async () => {
+      const { getAuthErrorMessage } = await import('../../lib/util/auth-error.js')
+      const error = new Error('API has not been used in project 947770278602')
+      error.status = 403
+      const msg = getAuthErrorMessage(error, 'bearer')
+      assert.match(msg, /default Google-managed 1P OAuth project/)
+      assert.match(msg, /reach out to a Chrome Enterprise Premium team member/)
+      assert.match(msg, /enable the missing API on project 947770278602/)
+    })
+
+    test('When source is bearer and status is 403 and API is disabled on custom project, then it returns BYO API disabled message', async () => {
+      const { getAuthErrorMessage } = await import('../../lib/util/auth-error.js')
+      const error = new Error('API has not been used in project 12345')
+      error.status = 403
+      const msg = getAuthErrorMessage(error, 'bearer')
+      assert.match(msg, /owns your OAuth client/)
+      assert.match(msg, /ask your Google Cloud administrator to enable/)
+      assert.doesNotMatch(msg, /gcloud services enable/)
     })
   })
 })

--- a/test/local/auth.test.js
+++ b/test/local/auth.test.js
@@ -203,4 +203,78 @@ describe('Auth', () => {
       assert.match(message, /cep_auth/)
     })
   })
+
+  describe('resolveCredentialsSource', () => {
+    test('When authToken is provided, then it resolves to bearer', async () => {
+      const { resolveCredentialsSource } = await import('../../lib/util/auth-error.js')
+      assert.strictEqual(resolveCredentialsSource('test-token', {}), 'bearer')
+    })
+
+    test('When GOOGLE_APPLICATION_CREDENTIALS is set in env, then it resolves to adc', async () => {
+      const { resolveCredentialsSource } = await import('../../lib/util/auth-error.js')
+      assert.strictEqual(resolveCredentialsSource(null, { GOOGLE_APPLICATION_CREDENTIALS: '/path/to/key.json' }), 'adc')
+    })
+
+    test('When PORT is set in env indicating Knative/CloudRun, then it resolves to adc', async () => {
+      const { resolveCredentialsSource } = await import('../../lib/util/auth-error.js')
+      assert.strictEqual(resolveCredentialsSource(null, { PORT: '8080' }), 'adc')
+    })
+
+    test('When PORT is set but GCP_STDIO is true indicating local debugging, then it resolves to cache', async () => {
+      const { resolveCredentialsSource } = await import('../../lib/util/auth-error.js')
+      assert.strictEqual(resolveCredentialsSource(null, { PORT: '8080', GCP_STDIO: 'true' }), 'cache')
+    })
+
+    test('When neither env var is set, then it defaults to cache', async () => {
+      const { resolveCredentialsSource } = await import('../../lib/util/auth-error.js')
+      assert.strictEqual(resolveCredentialsSource(null, {}), 'cache')
+    })
+  })
+
+  describe('getAuthErrorMessage with dynamic sources', () => {
+    test('When source is bearer and status is 401, then it returns Bearer token expired message', async () => {
+      const { getAuthErrorMessage } = await import('../../lib/util/auth-error.js')
+      const error = new Error('Unauthenticated')
+      error.status = 401
+      const msg = getAuthErrorMessage(error, 'bearer')
+      assert.match(msg, /inbound Bearer token has expired/)
+      assert.match(msg, /Re-authenticate through your MCP client/)
+    })
+
+    test('When source is bearer and status is 403, then it returns Bearer principal lacks permissions message', async () => {
+      const { getAuthErrorMessage } = await import('../../lib/util/auth-error.js')
+      const error = new Error('Permission Denied')
+      error.status = 403
+      const msg = getAuthErrorMessage(error, 'bearer')
+      assert.match(msg, /principal lacks the required permissions/)
+      assert.match(msg, /Verify Workspace Roles/)
+    })
+
+    test('When source is adc and status is 401, then it returns Service Account invalid message', async () => {
+      const { getAuthErrorMessage } = await import('../../lib/util/auth-error.js')
+      const error = new Error('Invalid grant')
+      error.status = 401
+      const msg = getAuthErrorMessage(error, 'adc')
+      assert.match(msg, /Service Account credentials \(ADC\) are invalid/)
+      assert.match(msg, /GOOGLE_APPLICATION_CREDENTIALS file path/)
+    })
+
+    test('When source is adc and status is 403, then it returns Domain-Wide Delegation message', async () => {
+      const { getAuthErrorMessage } = await import('../../lib/util/auth-error.js')
+      const error = new Error('Permission Denied')
+      error.status = 403
+      const msg = getAuthErrorMessage(error, 'adc')
+      assert.match(msg, /Domain-Wide Delegation/)
+      assert.match(msg, /CEP_IMPERSONATE_SUBJECT/)
+    })
+
+    test('When source is provided and status is 401, then it returns custom AuthClient invalid message', async () => {
+      const { getAuthErrorMessage } = await import('../../lib/util/auth-error.js')
+      const error = new Error('Invalid token')
+      error.status = 401
+      const msg = getAuthErrorMessage(error, 'provided')
+      assert.match(msg, /caller-provided custom AuthClient/)
+      assert.match(msg, /expired credentials/)
+    })
+  })
 })

--- a/test/local/auth.test.js
+++ b/test/local/auth.test.js
@@ -181,7 +181,7 @@ describe('Auth', () => {
       assert.match(message, /auth-bring-your-own-oauth-client\.md/)
     })
 
-    test('When the error reports SERVICE_DISABLED for the default managed OAuth project, then it instructs to reach out to a Chrome Enterprise Premium team member', async () => {
+    test('When the error reports SERVICE_DISABLED for the default managed OAuth project, then it instructs to file a GitHub issue', async () => {
       const { getAuthErrorMessage } = await import('../../lib/util/auth-error.js')
       const error = new Error(
         'Admin SDK API has not been used in project 947770278602 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/admin.googleapis.com/overview?project=947770278602 then retry.',
@@ -189,7 +189,7 @@ describe('Auth', () => {
       const message = getAuthErrorMessage(error)
 
       assert.match(message, /default Google-managed 1P OAuth project/)
-      assert.match(message, /reach out to a Chrome Enterprise Premium team member/)
+      assert.match(message, /file an issue on our GitHub repository/)
       assert.match(message, /enable the missing API on project 947770278602/)
       assert.match(message, /check_and_enable_cep_api/)
     })
@@ -251,7 +251,7 @@ describe('Auth', () => {
       error.status = 403
       const msg = getAuthErrorMessage(error, 'bearer')
       assert.match(msg, /default Google-managed 1P OAuth project/)
-      assert.match(msg, /reach out to a Chrome Enterprise Premium team member/)
+      assert.match(msg, /file an issue on our GitHub repository/)
       assert.match(msg, /enable the missing API on project 947770278602/)
     })
 

--- a/test/local/auth.test.js
+++ b/test/local/auth.test.js
@@ -210,24 +210,9 @@ describe('Auth', () => {
       assert.strictEqual(resolveCredentialsSource('test-token', {}), 'bearer')
     })
 
-    test('When GOOGLE_APPLICATION_CREDENTIALS is set in env, then it resolves to adc', async () => {
-      const { resolveCredentialsSource } = await import('../../lib/util/auth-error.js')
-      assert.strictEqual(resolveCredentialsSource(null, { GOOGLE_APPLICATION_CREDENTIALS: '/path/to/key.json' }), 'adc')
-    })
-
-    test('When PORT is set in env indicating Knative/CloudRun, then it resolves to adc', async () => {
-      const { resolveCredentialsSource } = await import('../../lib/util/auth-error.js')
-      assert.strictEqual(resolveCredentialsSource(null, { PORT: '8080' }), 'adc')
-    })
-
-    test('When PORT is set but GCP_STDIO is true indicating local debugging, then it resolves to cache', async () => {
-      const { resolveCredentialsSource } = await import('../../lib/util/auth-error.js')
-      assert.strictEqual(resolveCredentialsSource(null, { PORT: '8080', GCP_STDIO: 'true' }), 'cache')
-    })
-
     test('When neither env var is set, then it defaults to cache', async () => {
       const { resolveCredentialsSource } = await import('../../lib/util/auth-error.js')
-      assert.strictEqual(resolveCredentialsSource(null, {}), 'cache')
+      assert.strictEqual(resolveCredentialsSource(null), 'cache')
     })
   })
 
@@ -248,24 +233,6 @@ describe('Auth', () => {
       const msg = getAuthErrorMessage(error, 'bearer')
       assert.match(msg, /principal lacks the required permissions/)
       assert.match(msg, /Verify Workspace Roles/)
-    })
-
-    test('When source is adc and status is 401, then it returns Service Account invalid message', async () => {
-      const { getAuthErrorMessage } = await import('../../lib/util/auth-error.js')
-      const error = new Error('Invalid grant')
-      error.status = 401
-      const msg = getAuthErrorMessage(error, 'adc')
-      assert.match(msg, /Service Account credentials \(ADC\) are invalid/)
-      assert.match(msg, /GOOGLE_APPLICATION_CREDENTIALS file path/)
-    })
-
-    test('When source is adc and status is 403, then it returns Domain-Wide Delegation message', async () => {
-      const { getAuthErrorMessage } = await import('../../lib/util/auth-error.js')
-      const error = new Error('Permission Denied')
-      error.status = 403
-      const msg = getAuthErrorMessage(error, 'adc')
-      assert.match(msg, /Domain-Wide Delegation/)
-      assert.match(msg, /CEP_IMPERSONATE_SUBJECT/)
     })
 
     test('When source is provided and status is 401, then it returns custom AuthClient invalid message', async () => {

--- a/tools/utils/wrapper.js
+++ b/tools/utils/wrapper.js
@@ -23,6 +23,7 @@ import { logger } from '../../lib/util/logger.js'
 import { validateAndGetOrgUnitId } from './org-unit.js'
 import { isTokenLocallyValid } from '../../lib/util/credential/auth_login.js'
 import { cliInvocation } from '../../lib/util/cli_invocation.js'
+import { getAuthErrorMessage, resolveCredentialsSource } from '../../lib/util/auth-error.js'
 
 /**
  * Builds an MCP tool response signalling that sign-in is needed before any tool can run.
@@ -52,35 +53,6 @@ function buildAuthRequiredResponse({ reason, expiresAt }) {
     // By using unstructured text, we keep data schemas strict while maintaining agent utility.
     isError: true,
   }
-}
-
-/**
- * Generates a proactive remediation message for authentication errors.
- * @param {number} status - HTTP status code (401 or 403)
- * @param {boolean} bearerInbound - True if request used inbound Bearer auth
- * @returns {string} Human-readable remediation instructions
- */
-function getAuthRemediationMessage(status, bearerInbound = false) {
-  if (bearerInbound) {
-    if (status === 401) {
-      return `Authentication required. The inbound Bearer token has expired or is invalid. Re-authenticate through your MCP client to refresh the token.`
-    }
-    return `Permission denied. The authenticated principal lacks the required permissions, or the necessary Google Cloud APIs are not enabled.
-
-1. **Re-authenticate:** Refresh the inbound Bearer token through your MCP client.
-2. **Verify APIs are enabled:** Run the \`check_and_enable_cep_api\` tool against your project, or enable the API set listed in \`lib/constants.js#SERVICE_NAMES\`.`
-  }
-
-  const manualLogin = cliInvocation('auth login')
-  if (status === 401) {
-    return `Authentication required. Run the \`cep_auth\` tool to sign in, or run \`${manualLogin}\` at the shell to authorize the server (it caches the access token at ~/.config/cep-mcp/tokens.json). To use a service account, set GOOGLE_APPLICATION_CREDENTIALS to a service-account key file.`
-  }
-
-  return `Permission denied. Your account lacks the required permissions or the necessary Google Cloud APIs are not enabled.
-
-1. **Re-authenticate with all required scopes:** Run the \`cep_auth\` tool, or run \`${manualLogin}\` at the shell, to re-consent. The required scope set is defined in lib/constants.js#SCOPES.
-2. **Verify APIs are enabled:** Run the \`check_and_enable_cep_api\` tool against your project, or enable the API set listed in lib/constants.js#SERVICE_NAMES.
-`
 }
 
 /**
@@ -278,8 +250,9 @@ export function guardedToolCall(
           errorMessage.includes('invalid_grant')
             ? 401
             : 403)
-        const bearerInbound = !!context?.authToken || !!context?.requestInfo?.headers?.authorization
-        const remediationMessage = getAuthRemediationMessage(resolvedStatus, bearerInbound)
+        error.status = resolvedStatus
+        const source = options.apiOptions?.auth ? 'provided' : resolveCredentialsSource(authToken)
+        const remediationMessage = getAuthErrorMessage(error, source)
         return {
           content: [{ type: 'text', text: remediationMessage }],
           isError: true,


### PR DESCRIPTION
## Motivation
Currently, the MCP server has a single hardcoded error-handling copy that assumes the user is using the local OAuth cache (`auth login`). If an API call fails inside the Gemini CLI (using an inbound Bearer token), the server outputs impossible advice to run `auth login` inside a non-existent shell. 

This PR resolves this by introducing targeted, context-aware remediation advice based on the actual credential source used.

## User Experience (UX) Improvements (Before vs. After)

### Scenario 1: Expired Token in Gemini CLI (Inbound Bearer Token, 401)
*   **Before:** User sees generic advice to run a terminal command:
    > `Authentication required. Run the cep_auth tool to sign in, or run npm run auth login at the shell to authorize the server (it caches the access token at ~/.config/cep-mcp/tokens.json).`
    *(Frustrating because the user is in a hosted chat CLI and has no shell access to the server).*
*   **After:** Server detects the Bearer token and guides the user to the CLI's native command:
    > `Authentication required. The inbound Bearer token has expired or is invalid. Please re-authenticate or refresh the connection in your client application. If you are using the Gemini CLI, you can run '/mcp reauth'.`

### Scenario 2: Generic 403 / Disabled API in Gemini CLI (Bearer Token, 403)
*   **Before (Treated as local cache, giving un-actionable terminal commands):**
    > `A required API is not enabled in the Google Cloud project that owns your OAuth client.`
    > 
    > `Enable the required APIs in that project:`
    > `  gcloud services enable admin.googleapis.com chromeanalyses.googleapis.com --project=YOUR_PROJECT_ID`
    > 
    > `Or call the check_and_enable_cep_api tool against your project.`
    > 
    > `Original error message from Google Auth Library: Google API has not been used in project...`
    *(Useless because the user is in the Gemini CLI chat and cannot run gcloud commands).*
*   **After (Tailored for Bearer token context):**
    > `Permission denied. The authenticated principal lacks the required permissions, or the necessary Google Cloud APIs are not enabled.`
    > 
    > `1. **Re-authenticate:** Refresh the inbound Bearer token through your client application (for example, by running '/mcp reauth' in Gemini CLI or restarting the session) to ensure it is fresh.`
    > `2. **Verify Workspace Roles:** Ensure the Google account you signed in with has the necessary Chrome Enterprise or Workspace delegated administrator roles.`
    > `3. **Verify APIs are enabled:** Ask your Google Cloud administrator to enable the required APIs listed in lib/constants.js#SERVICE_NAMES.`

## Main Changes
*   **Dynamic Source Resolution:** Added a `resolveCredentialsSource(authToken)` helper in `lib/util/auth-error.js` that dynamically classifies the active session credential (`provided`, `bearer`, or `cache`).
*   **Tailored Remediation Copy:** Normalized `getAuthErrorMessage(error, source)` in `lib/util/auth-error.js` to dynamically choose separate 401/403 instructions for all three sources. This provides precise, actionable steps for inbound Bearer token clients (refreshing client-side tokens) vs. local CLI developers (`auth login` CLI commands).
*   **DRY Consolidation:** Deleted the redundant duplicate `getAuthRemediationMessage` copy inside `tools/utils/wrapper.js` and integrated the unified error formatter directly into the `guardedToolCall` wrapper.
*   **Unit Test Coverage:** Added comprehensive unit tests in `test/local/auth.test.js` validating source resolution heuristics and the exact tailored copy matches for all three credential sources.

## Design Decisions
*   **Wrapper-Level Resolution:** Resolving the credential source dynamically inside the tool wrapper (based on active headers) keeps the refactoring extremely clean and localized. It avoids the need to thread new parameters through the entire API client stack, preserving the streamlined client architecture.
*   **DRY Consolidation:** Consolidating all auth remediation messaging inside `auth-error.js` creates a single, maintainable source of truth for user-facing error copy, simplifying future additions.
