### PR TITLE
feat(auth): implement remote overrides and concise layout ergonomics for cep_auth

### DIFF
--- a/lib/util/credential/auth_login.js
+++ b/lib/util/credential/auth_login.js
@@ -160,6 +160,7 @@ export function canLaunchBrowser({ env = process.env, platform = process.platfor
  * @param {(env: object) => object} [opts.configResolver] OAuth client-config resolver.
  * @param {string} [opts.cachePath] Token cache path.
  * @param {string[]} [opts.scopes] Scopes to request on the consent screen.
+ * @param {'auto'|'browser'|'manual'} [opts.authMethod] The authentication method to use.
  * @returns {Promise<StartToolAuthResult>} The flow result — either 'completed' (signed in) or 'awaiting' (URL ready for paste-back).
  */
 export async function startToolAuth({
@@ -171,6 +172,7 @@ export async function startToolAuth({
   configResolver = resolveOAuthClientConfig,
   cachePath = TokenCache.defaultPath(),
   scopes = Object.values(SCOPES),
+  authMethod = 'auto',
 } = {}) {
   const config = configResolver(env)
   if (pendingAuth) {
@@ -213,7 +215,13 @@ export async function startToolAuth({
   }
   pendingAuth = pending
 
-  const browserAttempted = browserAvailable({ env })
+  let browserAttempted = false
+  if (authMethod === 'browser') {
+    browserAttempted = true
+  } else if (authMethod === 'auto') {
+    browserAttempted = browserAvailable({ env })
+  }
+
   let browserOpened = false
   if (browserAttempted) {
     try {

--- a/test/local/auth-tool.test.js
+++ b/test/local/auth-tool.test.js
@@ -220,7 +220,10 @@ describe('cep_auth Tool', () => {
     assert.strictEqual(result.structuredContent.browserOpened, true)
     assert.match(result.content[0].text, /A browser tab should have opened/)
     assert.match(result.content[0].text, /Once you sign in and see the "Signed in" success message/)
-    assert.match(result.content[0].text, /If the browser did not open, run `cep_auth` with `authMethod: 'manual'`/)
+    assert.match(
+      result.content[0].text,
+      /If the browser did not open, please ask your agent to help you sign in manually/,
+    )
     // Verify it does NOT contain the long manual instructions steps
     assert.ok(!result.content[0].text.includes('1. Open the URL below'))
     assert.ok(!result.content[0].text.includes('2. Sign in with your Google account'))

--- a/test/local/auth-tool.test.js
+++ b/test/local/auth-tool.test.js
@@ -220,9 +220,7 @@ describe('cep_auth Tool', () => {
     assert.strictEqual(result.structuredContent.browserOpened, true)
     assert.match(result.content[0].text, /A browser tab should have opened/)
     assert.match(result.content[0].text, /Once you sign in and see the "Signed in" success message/)
-    assert.match(result.content[0].text, /If the browser did not open, you can click or copy this link/)
-    assert.match(result.content[0].text, /accounts\.google\.com/)
-    assert.match(result.content[0].text, /After signing in, paste the redirect URL back/)
+    assert.match(result.content[0].text, /If the browser did not open, run `cep_auth` with `authMethod: 'manual'`/)
     // Verify it does NOT contain the long manual instructions steps
     assert.ok(!result.content[0].text.includes('1. Open the URL below'))
     assert.ok(!result.content[0].text.includes('2. Sign in with your Google account'))

--- a/test/local/auth-tool.test.js
+++ b/test/local/auth-tool.test.js
@@ -19,11 +19,12 @@ import { describe, test, mock, beforeEach } from 'node:test'
 import esmock from 'esmock'
 import { cliInvocation } from '../../lib/util/cli_invocation.js'
 
-async function loadToolWithMocks({ startToolAuth, completeToolAuth }) {
+async function loadToolWithMocks({ startToolAuth, completeToolAuth, canLaunchBrowser }) {
   return esmock('../../tools/definitions/auth.js', {
     '../../lib/util/credential/auth_login.js': {
       startToolAuth,
       completeToolAuth,
+      canLaunchBrowser,
     },
   })
 }
@@ -63,12 +64,16 @@ describe('cep_auth Tool', () => {
     handler = null
   })
 
-  async function register(mocks) {
+  async function getHandler(toolName, mocks) {
     const { registerAuthTool } = await loadToolWithMocks(mocks)
     registerAuthTool(server)
-    const call = server.registerTool.mock.calls.find(c => c.arguments[0] === 'cep_auth')
-    assert.ok(call, 'cep_auth was not registered')
-    handler = call.arguments[2]
+    const call = server.registerTool.mock.calls.find(c => c.arguments[0] === toolName)
+    assert.ok(call, `${toolName} was not registered`)
+    return call.arguments[2]
+  }
+
+  async function register(mocks) {
+    handler = await getHandler('cep_auth', mocks)
   }
 
   test('When cep_auth is invoked and returns status=awaiting, then it prints the plain URL once and sets correct structured content', async () => {
@@ -195,5 +200,80 @@ describe('cep_auth Tool', () => {
         `Expected output to contain env exports and running: "${manualLogin}"`,
       )
     })
+  })
+
+  test('When cep_auth awaits and browserOpened is true, then it displays a concise instruction set without detailed steps', async () => {
+    const startToolAuth = mock.fn(async () => ({
+      status: 'awaiting',
+      authUrl: 'https://accounts.google.com/o/oauth2/v2/auth?state=ABC',
+      browserAttempted: true,
+      browserOpened: true,
+      expiresAt: new Date(Date.now() + 300_000),
+      source: 'managed',
+    }))
+    const completeToolAuth = mock.fn()
+    await register({ startToolAuth, completeToolAuth })
+
+    const result = await handler({}, {})
+
+    assert.strictEqual(result.structuredContent.status, 'awaiting')
+    assert.strictEqual(result.structuredContent.browserOpened, true)
+    assert.match(result.content[0].text, /A browser tab should have opened/)
+    assert.match(result.content[0].text, /Once you sign in and see the "Signed in" success message/)
+    assert.match(result.content[0].text, /If the browser did not open, run `cep_auth` with `authMethod: 'manual'`/)
+    // Verify it does NOT contain the long manual instructions steps
+    assert.ok(!result.content[0].text.includes('1. Open the URL below'))
+    assert.ok(!result.content[0].text.includes('2. Sign in with your Google account'))
+  })
+
+  test('When cep_auth awaits and browserOpened is false, then it displays the full manual instructions', async () => {
+    const startToolAuth = mock.fn(async () => ({
+      status: 'awaiting',
+      authUrl: 'https://accounts.google.com/o/oauth2/v2/auth?state=ABC',
+      browserAttempted: false,
+      browserOpened: false,
+      expiresAt: new Date(Date.now() + 300_000),
+      source: 'managed',
+    }))
+    const completeToolAuth = mock.fn()
+    await register({ startToolAuth, completeToolAuth })
+
+    const result = await handler({}, {})
+
+    assert.strictEqual(result.structuredContent.status, 'awaiting')
+    assert.strictEqual(result.structuredContent.browserOpened, false)
+    assert.match(result.content[0].text, /I cannot open a browser in this environment/)
+    assert.match(result.content[0].text, /1\. Open the URL below/)
+    assert.match(result.content[0].text, /2\. Sign in with your Google account/)
+    assert.match(result.content[0].text, /3\. Copy that entire new address/)
+  })
+
+  test('When cep_auth is called with authMethod, then it passes it down to startToolAuth', async () => {
+    const startToolAuth = mock.fn(async () => ({
+      status: 'completed',
+      source: 'managed',
+    }))
+    const completeToolAuth = mock.fn()
+    await register({ startToolAuth, completeToolAuth })
+
+    await handler({ authMethod: 'manual' }, {})
+
+    assert.strictEqual(startToolAuth.mock.callCount(), 1)
+    assert.deepStrictEqual(startToolAuth.mock.calls[0].arguments, [{ authMethod: 'manual' }])
+  })
+
+  test('When cep_auth_status is called, then it includes canLaunchBrowser in the response status data', async () => {
+    const canLaunchBrowserMock = mock.fn(() => true)
+    const statusHandler = await getHandler('cep_auth_status', {
+      canLaunchBrowser: canLaunchBrowserMock,
+      startToolAuth: mock.fn(),
+      completeToolAuth: mock.fn(),
+    })
+
+    const result = await statusHandler({}, {})
+
+    assert.strictEqual(result.isError, undefined)
+    assert.strictEqual(result.structuredContent.status.canLaunchBrowser, true)
+    assert.strictEqual(canLaunchBrowserMock.mock.callCount(), 1)
   })
 })

--- a/test/local/auth-tool.test.js
+++ b/test/local/auth-tool.test.js
@@ -220,7 +220,9 @@ describe('cep_auth Tool', () => {
     assert.strictEqual(result.structuredContent.browserOpened, true)
     assert.match(result.content[0].text, /A browser tab should have opened/)
     assert.match(result.content[0].text, /Once you sign in and see the "Signed in" success message/)
-    assert.match(result.content[0].text, /If the browser did not open, run `cep_auth` with `authMethod: 'manual'`/)
+    assert.match(result.content[0].text, /If the browser did not open, you can click or copy this link/)
+    assert.match(result.content[0].text, /accounts\.google\.com/)
+    assert.match(result.content[0].text, /After signing in, paste the redirect URL back/)
     // Verify it does NOT contain the long manual instructions steps
     assert.ok(!result.content[0].text.includes('1. Open the URL below'))
     assert.ok(!result.content[0].text.includes('2. Sign in with your Google account'))

--- a/test/local/auth_login.test.js
+++ b/test/local/auth_login.test.js
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import assert from 'node:assert/strict'
-import { describe, test, beforeEach, afterEach } from 'node:test'
+import { describe, test, beforeEach, afterEach, mock } from 'node:test'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import os from 'node:os'
@@ -354,6 +354,54 @@ describe('startToolAuth', () => {
     const cached = JSON.parse(await fs.readFile(cachePath, 'utf8'))
     assert.strictEqual(cached.access_token, 'tok-late-code')
     assert.ok(server.wasStopped())
+  })
+
+  test('When startToolAuth is called with authMethod="manual", then it does not check browserAvailable or attempt browser launch', async () => {
+    const { client } = makeFakeOAuth2Client()
+    const server = makeFakeServer()
+    const browserAvailable = mock.fn(() => true)
+    const openBrowser = mock.fn(async () => true)
+
+    const result = await startToolAuth({
+      authMethod: 'manual',
+      browserAvailable,
+      openBrowser,
+      startServer: async () => server,
+      oauth2ClientFactory: () => client,
+      configResolver: () => FAKE_CONFIG,
+      cachePath,
+      scopes: ['scope-a'],
+    })
+
+    assert.strictEqual(result.status, 'awaiting')
+    assert.strictEqual(result.browserAttempted, false)
+    assert.strictEqual(result.browserOpened, false)
+    assert.strictEqual(browserAvailable.mock.callCount(), 0)
+    assert.strictEqual(openBrowser.mock.callCount(), 0)
+  })
+
+  test('When startToolAuth is called with authMethod="browser", then it attempts browser launch regardless of browserAvailable', async () => {
+    const { client } = makeFakeOAuth2Client()
+    const server = makeFakeServer()
+    const browserAvailable = mock.fn(() => false)
+    const openBrowser = mock.fn(async () => true)
+
+    const result = await startToolAuth({
+      authMethod: 'browser',
+      browserAvailable,
+      openBrowser,
+      startServer: async () => server,
+      oauth2ClientFactory: () => client,
+      configResolver: () => FAKE_CONFIG,
+      cachePath,
+      scopes: ['scope-a'],
+    })
+
+    assert.strictEqual(result.status, 'awaiting')
+    assert.strictEqual(result.browserAttempted, true)
+    assert.strictEqual(result.browserOpened, true)
+    assert.strictEqual(browserAvailable.mock.callCount(), 0)
+    assert.strictEqual(openBrowser.mock.callCount(), 1)
   })
 })
 

--- a/tools/definitions/auth.js
+++ b/tools/definitions/auth.js
@@ -275,15 +275,7 @@ function awaitingResponse(result) {
       'Once you sign in and see the "Signed in" success message, you can close that tab and return here to continue.',
     )
     lines.push('')
-    lines.push('If the browser did not open, you can click or copy this link to sign in manually:')
-    lines.push('')
-    if (supportsHyperlinks()) {
-      lines.push(`🔗 ${osc8(result.authUrl, 'Click here to open the Google Sign-in page')}`)
-      lines.push('')
-    }
-    lines.push(result.authUrl)
-    lines.push('')
-    lines.push('After signing in, paste the redirect URL back as the `redirectUrl` argument.')
+    lines.push("If the browser did not open, run `cep_auth` with `authMethod: 'manual'` to get a copy-paste link.")
   } else {
     if (result.browserAttempted) {
       lines.push('Failed to open browser automatically. Please complete sign-in manually:')

--- a/tools/definitions/auth.js
+++ b/tools/definitions/auth.js
@@ -23,7 +23,7 @@ limitations under the License.
 
 import { z } from 'zod'
 import { logger } from '../../lib/util/logger.js'
-import { startToolAuth, completeToolAuth } from '../../lib/util/credential/auth_login.js'
+import { startToolAuth, completeToolAuth, canLaunchBrowser } from '../../lib/util/credential/auth_login.js'
 import { TokenCache } from '../../lib/util/credential/token_cache.js'
 import { oauthFlowCredential } from '../../lib/util/credential/oauth_flow.js'
 import { resolveOAuthClientConfig } from '../../lib/util/credential/oauth_client_config.js'
@@ -125,6 +125,14 @@ export function registerAuthTools(server, options, sessionState) {
           .describe(
             'The full URL the browser was redirected to after consent (looks like http://127.0.0.1:PORT/?code=...&state=...). Omit to start a fresh sign-in.',
           ),
+        authMethod: z
+          .enum(['auto', 'browser', 'manual'])
+          .optional()
+          .default('auto')
+          .describe(
+            'The authentication method to use: "auto" (attempts browser, falls back to manual), ' +
+              '"browser" (forces opening browser), "manual" (skips browser and directly provides URL for manual copy-paste).',
+          ),
       },
       outputSchema: z.looseObject({
         status: z.enum(['completed', 'awaiting', 'error']),
@@ -134,7 +142,7 @@ export function registerAuthTools(server, options, sessionState) {
         expiresAt: z.string().optional(),
       }),
     },
-    async ({ redirectUrl }, context) => {
+    async ({ redirectUrl, authMethod }, context) => {
       if (context?.requestInfo?.headers?.authorization) {
         const msg =
           'This server received an inbound Bearer token, so sign-in via cep_auth does not apply. ' +
@@ -150,7 +158,10 @@ export function registerAuthTools(server, options, sessionState) {
           const result = await completeToolAuth({ redirectUrl })
           return successResponse(result)
         }
-        const result = await startToolAuth({})
+        const result = await startToolAuth({ authMethod })
+        if (result.status === 'completed') {
+          return successResponse(result)
+        }
         return awaitingResponse(result)
       } catch (err) {
         logger.error(`${TAGS.MCP} cep_auth failed:`, err?.message || err)
@@ -185,6 +196,7 @@ export function registerAuthTools(server, options, sessionState) {
           // Enhance the probe data with friendly names for the user/agent
           const statusReport = {
             ...probe,
+            canLaunchBrowser: canLaunchBrowser(),
             granted: (probe.grantedScopes || []).map(url => OAUTH_SCOPE_REGISTRY[url]?.name || url),
             missing: (probe.missingScopes || []).map(url => OAUTH_SCOPE_REGISTRY[url]?.name || url),
           }
@@ -192,7 +204,7 @@ export function registerAuthTools(server, options, sessionState) {
           return formatToolResponse({
             summary: formatAuthStatusSummary(probe),
             data: { status: statusReport },
-            structuredContent: { status: probe },
+            structuredContent: { status: statusReport },
           })
         },
         skipAutoResolve: true,
@@ -263,21 +275,32 @@ function awaitingResponse(result) {
       'Once you sign in and see the "Signed in" success message, you can close that tab and return here to continue.',
     )
     lines.push('')
-    lines.push('If the browser did not open, you can complete sign-in manually:')
+    lines.push("If the browser did not open, run `cep_auth` with `authMethod: 'manual'` to get a copy-paste link.")
   } else {
-    lines.push('I cannot open a browser in this environment. Please complete sign-in manually:')
+    if (result.browserAttempted) {
+      lines.push('Failed to open browser automatically. Please complete sign-in manually:')
+    } else {
+      lines.push('I cannot open a browser in this environment. Please complete sign-in manually:')
+    }
+    lines.push('')
+    lines.push('1. Open the URL below in your local browser:')
+    lines.push('')
+    if (supportsHyperlinks()) {
+      lines.push(`🔗 ${osc8(result.authUrl, 'Click here to open the Google Sign-in page in your browser')}`)
+      lines.push('')
+      lines.push('Or copy and paste this URL if the link above does not work:')
+      lines.push('')
+    }
+    lines.push(result.authUrl)
+    lines.push('')
+    lines.push(
+      '2. Sign in with your Google account. After signing in, your browser will redirect to a 127.0.0.1 address and show a "Connection Refused" error—this is expected.',
+    )
+    lines.push("3. Copy that entire new address from your browser's address bar and paste it back here.")
+    lines.push('')
+    lines.push(cliFallbackLine(resolveOAuthClientConfig().source))
   }
 
-  lines.push('1. Open the URL below in your local browser:')
-  lines.push('')
-  lines.push(result.authUrl)
-  lines.push('')
-  lines.push(
-    '2. Sign in with your Google account. After signing in, your browser will redirect to a 127.0.0.1 address and show a "Connection Refused" error—this is expected.',
-  )
-  lines.push("3. Copy that entire new address from your browser's address bar and paste it back here.")
-  lines.push('')
-  lines.push(cliFallbackLine(resolveOAuthClientConfig().source))
   const expiresAt = result.expiresAt instanceof Date ? result.expiresAt.toISOString() : undefined
   return {
     content: [{ type: 'text', text: lines.join('\n') }],

--- a/tools/definitions/auth.js
+++ b/tools/definitions/auth.js
@@ -275,7 +275,15 @@ function awaitingResponse(result) {
       'Once you sign in and see the "Signed in" success message, you can close that tab and return here to continue.',
     )
     lines.push('')
-    lines.push("If the browser did not open, run `cep_auth` with `authMethod: 'manual'` to get a copy-paste link.")
+    lines.push('If the browser did not open, you can click or copy this link to sign in manually:')
+    lines.push('')
+    if (supportsHyperlinks()) {
+      lines.push(`🔗 ${osc8(result.authUrl, 'Click here to open the Google Sign-in page')}`)
+      lines.push('')
+    }
+    lines.push(result.authUrl)
+    lines.push('')
+    lines.push('After signing in, paste the redirect URL back as the `redirectUrl` argument.')
   } else {
     if (result.browserAttempted) {
       lines.push('Failed to open browser automatically. Please complete sign-in manually:')

--- a/tools/definitions/auth.js
+++ b/tools/definitions/auth.js
@@ -71,6 +71,61 @@ function cliFallbackLine(source) {
   )
 }
 
+/* OSC 8 hyperlink: ESC ] 8 ; ; URI ST text ESC ] 8 ; ; ST, where ST is ESC \. */
+const OSC = '\x1b]8;;'
+const ST = '\x1b\x5c'
+
+/**
+ * Detects if the current terminal environment is likely to support OSC 8 hyperlinks.
+ * Checks environment variables FORCE_HYPERLINK, DOMTERM, VTE_VERSION, TERM_PROGRAM,
+ * TERM, and NO_COLOR.
+ * @returns {boolean} True if the terminal likely supports hyperlinks.
+ */
+function supportsHyperlinks() {
+  if (process.env.FORCE_HYPERLINK === '1') {
+    return true
+  }
+  if (process.env.FORCE_HYPERLINK === '0') {
+    return false
+  }
+  if (process.env.NO_COLOR) {
+    return false
+  }
+
+  const env = process.env
+  if (env.DOMTERM) {
+    return true
+  }
+  if (env.TERM_PROGRAM) {
+    const program = env.TERM_PROGRAM.toLowerCase()
+    if (['hyper', 'iterm.app', 'wezterm', 'vscode'].includes(program)) {
+      return true
+    }
+  }
+  if (env.TERM === 'xterm-kitty') {
+    return true
+  }
+  if (env.VTE_VERSION) {
+    const version = parseInt(env.VTE_VERSION, 10)
+    if (version >= 4902) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * Wraps a URL in OSC 8 hyperlink escapes. Modern terminals render the visible
+ * text as a clickable link to the same URL; others show the URL bytes plus
+ * a few stray escape chars but the URL itself remains selectable.
+ * @param {string} url The URL to render as a hyperlink.
+ * @param {string} [label] The visible text label. Defaults to the URL itself.
+ * @returns {string} The OSC 8 wrapped URL.
+ */
+function osc8(url, label = url) {
+  return `${OSC}${url}${ST}${label}${OSC}${ST}`
+}
+
 /**
  * Formats the OAuth probe result into a human-friendly summary string.
  * @param {object} probe The result from oauthFlowCredential().probe().
@@ -275,7 +330,7 @@ function awaitingResponse(result) {
       'Once you sign in and see the "Signed in" success message, you can close that tab and return here to continue.',
     )
     lines.push('')
-    lines.push("If the browser did not open, run `cep_auth` with `authMethod: 'manual'` to get a copy-paste link.")
+    lines.push('If the browser did not open, please ask your agent to help you sign in manually.')
   } else {
     if (result.browserAttempted) {
       lines.push('Failed to open browser automatically. Please complete sign-in manually:')


### PR DESCRIPTION
feat(auth): implement remote overrides and concise layout ergonomics for cep_auth

**Depends on #303** (This PR is staged on top of #303 and contains its changes. Only the commits starting from `refactor(auth): support forcing manual auth method...` are new here.)

## Motivation

Now that `cep_auth` returns instantly and operates asynchronously in the background (#303), we want to optimize the interactive terminal layout. Currently, the full copy-paste instructions are very long and "steal the show" in standard desktop environments where a browser tab is successfully opened automatically. Additionally, remote/headless users need a way to explicitly bypass browser launches or query browser availability.

This PR introduces interactive, custom ergonomics to make the authentication flow extremely seamless and clean across both local and remote workstations.

## Main Changes

### Core
1. **lib/util/credential/auth_login.js**:
   - **Auth Flow Overrides**: Added support for the `authMethod` parameter (`auto`, `browser`, `manual`) in `startToolAuth` to allow callers to explicitly force a manual copy-paste flow or force browser launching.

### Tools
1. **tools/definitions/auth.js**:
   - **Input Schema Override**: Added `authMethod` to the `cep_auth` tool arguments. Passing `authMethod: 'manual'` completely bypasses attempting a local desktop browser launch and immediately yields manual copy-paste steps.
   - **Concise Awaiting Layout**: If a browser is successfully launched, it returns a clean, compact **3-line instruction message** instead of dumping the entire manual copy-paste steps. It cleanly prompts: *"If the browser did not open, please ask your agent to help you sign in manually."*, leveraging natural agentic interaction instead of directing the user to run shell commands.
   - **Capability Status Reporting**: Enhanced `cep_auth_status` to include `canLaunchBrowser` in its structured details. This allows client agents to inspect local display availability before initiating authentication.

### Tests
1. **test/local/auth_login.test.js**:
   - **Override Tests**: Added unit tests verifying `startToolAuth` respects `authMethod="manual"` (skipping browser launch) and `authMethod="browser"` (forcing launch).

2. **test/local/auth-tool.test.js**:
   - **Compact Layout Tests**: Added unit tests verifying that the concise layout is displayed when `browserOpened` is true, and full detailed instructions are rendered when false.
   - **Parameter Forwarding**: Added a unit test verifying `cep_auth` forwards `authMethod` into the core login module.
   - **Browser Availability Check**: Added a unit test verifying `cep_auth_status` returns the `canLaunchBrowser` field.
