### PR TITLE
feat(api): add enableSecurityInsights to ChromeManagementClient

### DIFF
--- a/lib/api/chrome_management_client.js
+++ b/lib/api/chrome_management_client.js
@@ -109,20 +109,25 @@ export class ChromeManagementClient {
   /**
    * Enables security insights for a specific customer.
    * @param {string} customerId The customer ID.
+   * @param {string[]} [targetOus] Optional list of organizational unit IDs to target.
    * @param {string} [authToken] Optional OAuth 2.0 access token.
    * @returns {Promise<object>} The security insights status.
    * @throws {Error} If customerId is missing or the API call fails.
    */
-  async enableSecurityInsights(customerId, authToken) {
-    logger.debug(`${TAGS.API} enableSecurityInsights called with customerId: ${customerId}`)
+  async enableSecurityInsights(customerId, targetOus, authToken) {
+    logger.debug(`${TAGS.API} enableSecurityInsights called with customerId: ${customerId}, targetOus: ${targetOus}`)
     if (!customerId) {
       throw new Error('customerId is required for enableSecurityInsights')
     }
     const client = await this.getClient(authToken)
     try {
       const name = `customers/${customerId}/enterprise/securityInsights`
+      const request = { name }
+      if (targetOus && targetOus.length > 0) {
+        request.requestBody = { targetOus }
+      }
       const response = await callWithRetry(
-        () => client.customers.enterprise.securityInsights.enable({ name }),
+        () => client.customers.enterprise.securityInsights.enable(request),
         'customers.enterprise.securityInsights.enable',
       )
       return response.data

--- a/lib/api/chrome_management_client.js
+++ b/lib/api/chrome_management_client.js
@@ -44,7 +44,12 @@ export class ChromeManagementClient {
     return createApiClient(
       google.chromemanagement,
       API_VERSIONS.CHROME_MANAGEMENT,
-      [SCOPES.CHROME_MANAGEMENT_REPORTS_READONLY, SCOPES.CHROME_MANAGEMENT_PROFILES_READONLY],
+      [
+        SCOPES.CHROME_MANAGEMENT_REPORTS_READONLY,
+        SCOPES.CHROME_MANAGEMENT_PROFILES_READONLY,
+        SCOPES.CHROME_MANAGEMENT_POLICY,
+        SCOPES.CHROME_MANAGEMENT_SECURITYINSIGHTS,
+      ],
       authToken,
       this.apiOptions,
     )
@@ -98,6 +103,31 @@ export class ChromeManagementClient {
       return response.data.chromeBrowserProfiles
     } catch (error) {
       handleApiError(error, TAGS.API, 'listing customer profiles')
+    }
+  }
+
+  /**
+   * Enables security insights for a specific customer.
+   * @param {string} customerId The customer ID.
+   * @param {string} [authToken] Optional OAuth 2.0 access token.
+   * @returns {Promise<object>} The security insights status.
+   * @throws {Error} If customerId is missing or the API call fails.
+   */
+  async enableSecurityInsights(customerId, authToken) {
+    logger.debug(`${TAGS.API} enableSecurityInsights called with customerId: ${customerId}`)
+    if (!customerId) {
+      throw new Error('customerId is required for enableSecurityInsights')
+    }
+    const client = await this.getClient(authToken)
+    try {
+      const name = `customers/${customerId}/enterprise/securityInsights`
+      const response = await callWithRetry(
+        () => client.customers.enterprise.securityInsights.enable({ name }),
+        'customers.enterprise.securityInsights.enable',
+      )
+      return response.data
+    } catch (error) {
+      handleApiError(error, TAGS.API, 'enabling security insights')
     }
   }
 }

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -59,6 +59,11 @@ export const OAUTH_SCOPE_CONFIG = Object.freeze({
     name: 'Chrome Profiles',
     category: 'Chrome browser management',
   },
+  CHROME_MANAGEMENT_SECURITYINSIGHTS: {
+    url: 'https://www.googleapis.com/auth/chrome.management.securityinsights',
+    name: 'Chrome Security Insights',
+    category: 'Chrome browser management',
+  },
   ADMIN_REPORTS_AUDIT_READONLY: {
     url: 'https://www.googleapis.com/auth/admin.reports.audit.readonly',
     name: 'Admin Audit Reports',

--- a/test/helpers/fake-api-server.js
+++ b/test/helpers/fake-api-server.js
@@ -429,6 +429,17 @@ export function createFakeApp() {
     res.json({ chromeBrowserProfiles: state.profiles })
   })
 
+  // Chrome Management: Enable Security Insights
+  app.post('/v1/customers/:customerId/enterprise/securityInsights\\:enable', (req, res) => {
+    const customerId = requireCustomer(state, req.params.customerId, res)
+    if (!customerId) {
+      return
+    }
+    res.json({
+      insightsState: 'INSIGHTS_ENABLED',
+    })
+  })
+
   // Chrome Policy: Resolve Policies
   app.post('/v1/customers/:customerId/policies\\:resolve', (req, res) => {
     const customerId = requireCustomer(state, req.params.customerId, res)

--- a/test/local/chromemanagement.test.js
+++ b/test/local/chromemanagement.test.js
@@ -222,8 +222,35 @@ describe('Chrome Management API', () => {
           },
         }
       }
-      await client.enableSecurityInsights('C0123', 'TEST_BEARER_TOKEN')
+      await client.enableSecurityInsights('C0123', null, 'TEST_BEARER_TOKEN')
       assert.strictEqual(observedAuth, 'TEST_BEARER_TOKEN')
+    })
+
+    test('When enableSecurityInsights is called with targetOus, then it passes them in the requestBody to enable', async () => {
+      const { ChromeManagementClient } = await import('../../lib/api/chrome_management_client.js')
+      const client = new ChromeManagementClient()
+      let observedRequest = null
+      client.getClient = async () => {
+        return {
+          customers: {
+            enterprise: {
+              securityInsights: {
+                enable: async req => {
+                  observedRequest = req
+                  return { data: { insightsState: 'INSIGHTS_ENABLED' } }
+                },
+              },
+            },
+          },
+        }
+      }
+      await client.enableSecurityInsights('C0123', ['ou1', 'ou2'])
+      assert.deepStrictEqual(observedRequest, {
+        name: 'customers/C0123/enterprise/securityInsights',
+        requestBody: {
+          targetOus: ['ou1', 'ou2'],
+        },
+      })
     })
   })
 })

--- a/test/local/chromemanagement.test.js
+++ b/test/local/chromemanagement.test.js
@@ -205,5 +205,25 @@ describe('Chrome Management API', () => {
       await client.listCustomerProfiles('C0123', 'TEST_BEARER_TOKEN')
       assert.strictEqual(observedAuth, 'TEST_BEARER_TOKEN')
     })
+
+    test('When enableSecurityInsights is called with an authToken, then it is forwarded to getClient', async () => {
+      const { ChromeManagementClient } = await import('../../lib/api/chrome_management_client.js')
+      const client = new ChromeManagementClient()
+      let observedAuth = 'sentinel-not-set'
+      client.getClient = async authToken => {
+        observedAuth = authToken
+        return {
+          customers: {
+            enterprise: {
+              securityInsights: {
+                enable: async () => ({ data: { insightsState: 'INSIGHTS_ENABLED' } }),
+              },
+            },
+          },
+        }
+      }
+      await client.enableSecurityInsights('C0123', 'TEST_BEARER_TOKEN')
+      assert.strictEqual(observedAuth, 'TEST_BEARER_TOKEN')
+    })
   })
 })


### PR DESCRIPTION
Adds a wrapper for calling the Chrome Security Insights API method to enable insights for a domain. 