### PR TITLE
feat: replace incorrect dashboard roles with correct privileges

### DIFF
--- a/gemini-extension/CONTEXT.md
+++ b/gemini-extension/CONTEXT.md
@@ -18,7 +18,7 @@ _When these topics appear in search results, ensure these specific facts are pre
 
 - **Pricing**: $6 USD list price; Credit Card support; Volume discounts.
 - **Trial**: 60-day; Workspace/Cloud Console start; NO automatic charge.
-- **IAM Roles**: 'Cloud BeyondCorp Admin' (Org-level) for purchase; 'Security Center Admin'/'Mobile Admin' for dashboards; 'DLP Administrator' for rules.
+- **IAM Roles**: 'Cloud BeyondCorp Admin' (Org-level) for purchase; 'View/Manage Chrome Insights Settings' or 'Chrome Enterprise Security Service' (APP_ADMIN) for dashboards; 'DLP Administrator' for rules.
 - **Syncing**: macOS user profiles may require manually clicking 'Sync Now' to pull new extension policies; CEP license assignment changes can take up to 24h to propagate.
 - **Deployment**: 'ExtensionInstallForcelist' policy for EV; Native Helper MSI/PKG required.
 - **Client Tools**: `chrome://policy` for verification; `chrome://safe-browsing/#tab-reporting` for logs.

--- a/lib/knowledge/0-agent-capabilities.md
+++ b/lib/knowledge/0-agent-capabilities.md
@@ -80,7 +80,7 @@ For security and architectural reasons, the agent has explicit limitations:
 - **Pricing:** Standard list price is **$6/user/month**.
 - **Payment:** Supports credit card self-service or **traditional offline invoicing**.
 - **Trial:** The agent can help you start a **60-day free trial** for up to **5,000 users**.
-- **Permissions (IAM Roles):** Management requires the **Cloud BeyondCorp Admin** role at the Organization level and the **Security Center Admin** role for dashboards/telemetry.
+- **Permissions (IAM Roles):** Management requires the **Cloud BeyondCorp Admin** role at the Organization level. To view security dashboards, administrators require **any one** of the following delegated privileges: **View Chrome Insights Settings**, **Manage Chrome Insights Settings**, or **Chrome Enterprise Security Service (APP_ADMIN)**.
 
 ### 3. Client-Side Actions
 

--- a/test/evals/cases/knowledge/k07-helpdesk_role.eval.js
+++ b/test/evals/cases/knowledge/k07-helpdesk_role.eval.js
@@ -18,12 +18,12 @@ export default {
   id: 'k07',
   priority: 'P1',
   tags: ['iam', 'roles'],
-  requiredPatterns: ['Security Center Admin', 'DLP'],
+  requiredPatterns: ['Chrome Insights Settings', 'DLP'],
   prompt: `Our Helpdesk team needs to view CEP security dashboards and adjust DLP rules,
-but we cannot give them 'Super Admin' access. What roles are required?`,
-  goldenResponse: `Use delegated administrator roles rather than Super Admin:
+but we cannot give them 'Super Admin' access. What privileges/roles are required?`,
+  goldenResponse: `Use delegated administrator privileges rather than Super Admin:
 
-- **Viewing dashboards:** Assign the Security Center Admin (Custom Role).
+- **Viewing dashboards:** Assign either 'View Chrome Insights Settings', 'Manage Chrome Insights Settings', or the 'Chrome Enterprise Security Service' (APP_ADMIN) privilege.
 - **Managing DLP rules:** Assign the DLP Administrator (Custom Role).`,
-  judgeInstructions: `The agent must recommend delegated roles or custom roles for dashboard viewing and DLP management. The agent MUST specifically mention 'Security Center Admin' and either 'DLP Administrator' or 'Cloud BeyondCorp Admin'.`,
+  judgeInstructions: `The agent must recommend delegated privileges or custom roles for dashboard viewing and DLP management. The agent MUST specifically mention 'View Chrome Insights Settings' (or 'Manage Chrome Insights Settings' / 'Chrome Enterprise Security Service') and either 'DLP Administrator' or 'Cloud BeyondCorp Admin'.`,
 }

--- a/test/helpers/fake-api-server.js
+++ b/test/helpers/fake-api-server.js
@@ -316,7 +316,7 @@ export function createFakeApp() {
           <h1>Administrator Privilege Definitions</h1>
           <p>Recommended delegated roles for custom admin configurations:</p>
           <ul>
-            <li><strong>Security Center Admin</strong>: Assign this custom role to view dashboards and security insights.</li>
+            <li><strong>View Chrome Insights Settings / Manage Chrome Insights Settings</strong>: Assign this delegated privilege to view dashboards and security insights. Alternatively, assign <strong>Chrome Enterprise Security Service (APP_ADMIN)</strong>.</li>
             <li><strong>DLP Administrator</strong>: Assign this custom role to adjust, edit, or view DLP rules.</li>
           </ul>
         </article>

--- a/test/local/fake-api-server.test.js
+++ b/test/local/fake-api-server.test.js
@@ -247,7 +247,7 @@ describe('Fake API Server', () => {
       assert.strictEqual(res.status, 200)
       const html = await res.text()
       assert.ok(html.includes('Administrator Privilege Definitions'))
-      assert.ok(html.includes('Security Center Admin'))
+      assert.ok(html.includes('View Chrome Insights Settings'))
       assert.ok(html.includes('DLP Administrator'))
     })
 


### PR DESCRIPTION
Replaced the incorrect 'Security Center Admin' and 'Mobile Admin' delegated roles with the exact privileges required for accessing CEP dashboards and security insights: 'View/Manage Chrome Insights Settings' or 'Chrome Enterprise Security Service' (APP_ADMIN).

Closes b/519318549