### PR TITLE
fix(test): allow 'latest' version in gemini-extension.json

### DIFF
--- a/test/local/extension_version.test.js
+++ b/test/local/extension_version.test.js
@@ -47,6 +47,10 @@ test('gemini-extension.json package version matches package.json version', () =>
   const rangeString = packageArg.slice(lastAtIndex + 1)
   assert.ok(rangeString, 'Could not extract version range from argument')
 
+  if (rangeString === 'latest') {
+    return
+  }
+
   assert.ok(rangeString.startsWith('^'), 'Version range must start with ^ for semantic versioning')
   const rangeVersion = rangeString.slice(1)
   const [rMajor, rMinor, rPatch] = rangeVersion.split('.').map(Number)


### PR DESCRIPTION
### Description

This PR fixes a CI failure in the unit tests that was blocking the release PR (#300).

### Root Cause
In PR #309, `gemini-extension.json` was updated to use `@google/chrome-enterprise-premium-mcp@latest` instead of a pinned version range (like `^1.4.0`). 

However, the unit test `test/local/extension_version.test.js` was strictly enforcing that the version range must start with `^` for semantic versioning validation:
```javascript
assert.ok(rangeString.startsWith('^'), 'Version range must start with ^ for semantic versioning')
```
This caused the unit tests to fail with `AssertionError [ERR_ASSERTION]: Version range must start with ^ for semantic versioning` when running on the release branch and on `main`.

### Fix
This PR updates the test to explicitly check for and allow `latest` as a valid version range, bypassing the semantic version comparison checks in that case.

### Verification
- Verified locally that `npm run test:unit` now passes.
- Verified that GitHub Actions CI checks pass on this PR.

### Preventive Actions
To prevent broken code from being merged into `main` in the future, we have enabled a branch protection ruleset called **`Protect Main`** for the `main` branch. This ruleset enforces that key status checks (including Unit Tests, Integration Tests, Lint, and Smoke tests) must pass before a PR can be merged.

TAG=agy
CONV=c9ca1c90-a212-4d21-9d92-14954e518ca1