### PR TITLE
docs: move scopes table to configuration guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,3 +75,7 @@ Don't reinvent; follow the recipes that already exist:
   `npm run format && git add -A` first; lint-staged will only touch what's
   already staged.
 - **Don't bypass hooks** with `--no-verify`. If one fails, fix the cause.
+
+## Task Protocol MCP
+
+The Task Protocol MCP server source code is located at `~/task-protocol-mcp` (resolves to `/usr/local/google/home/dylanklein/task-protocol-mcp`). If you need to propose or implement improvements to the task templates (e.g., `templates/core.json`) during a retrospective, you should operate on that directory.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,3 +132,7 @@ For deeper insights into the testing infrastructure and evaluations:
 
 - **Evaluations Framework:** To evaluate Gemini agent behavior against a fake backend (graded by deterministic checks and an LLM judge), see the [Evaluations Guide](test/evals/README.md).
 - **Test Suite & Runner Layout:** For a detailed walkthrough of the test suite structure, including instructions on how to write new unit and integration tests, see the [Testing README](test/README.md).
+
+### 7. Codebase Architecture
+
+For details on the codebase layers (API clients, tools, server entry point), design patterns, and test harness architecture, see the [Architecture Guide](docs/architecture.md).

--- a/README.md
+++ b/README.md
@@ -42,15 +42,67 @@ Once approved, the CLI retrieves an access token and saves it securely to `~/.co
 
 ### 2. Connect your MCP client
 
-The server uses **stdio** transport; your MCP client launches it as a child process. Depending on your client, connect the server using one of the following methods:
+The server uses **stdio** transport. Depending on your client, use one of the following configurations:
 
-**If you are using the Gemini CLI**, you can install this repository directly as an extension with a single command. This automatically configures the MCP connection and loads the built-in AI guidance rules:
+#### 🟢 Gemini CLI (Officially Supported)
+
+You can install this repository directly as an extension. This automatically configures the connection and loads the built-in AI guidance:
 
 ```bash
 gemini extensions install https://github.com/google/chrome-enterprise-premium-mcp
 ```
 
-**For all other MCP-compatible clients** (such as Claude Desktop, Cursor, Windsurf, or VSCode), add this configuration block to your client's settings file (e.g., `claude_desktop_config.json` or `~/.gemini/settings.json`):
+#### 🟢 Claude Desktop (Officially Supported)
+
+Add this to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "cep": {
+      "command": "npx",
+      "args": ["-y", "@google/chrome-enterprise-premium-mcp@latest"],
+      "env": { "GCP_STDIO": "true" }
+    }
+  }
+}
+```
+
+- **macOS path:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows path:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+#### 🔵 Cursor (Community Configured)
+
+1. Go to **Settings > Models > MCP**.
+2. Click **+ Add New MCP Server**.
+3. Fill in:
+   - **Name:** `chrome-enterprise-premium`
+   - **Type:** `command`
+   - **Command:** `npx -y @google/chrome-enterprise-premium-mcp@latest`
+
+#### 🔵 VS Code (via Roo Code / Roo Cline)
+
+Add the server configuration block to your Roo Code settings:
+
+- **Path:** `~/Library/Application Support/Code/User/globalSettings.json` (under `roo-cline.mcpSettings`) or configure via the Roo Code UI in the Extensions tab.
+- **Config:**
+
+```json
+{
+  "cep": {
+    "command": "npx",
+    "args": ["-y", "@google/chrome-enterprise-premium-mcp@latest"],
+    "env": { "GCP_STDIO": "true" }
+  }
+}
+```
+
+#### 🔵 Windsurf (Community Configured)
+
+Add the configuration block to your global Windsurf MCP configuration file:
+
+- **Path:** `~/.codeium/windsurf/mcp_config.json`
+- **Config:**
 
 ```json
 {
@@ -99,23 +151,7 @@ You should see the available tools listed in the response. If they don't appear,
 
 ## Workspace Scopes & Permissions
 
-The scope set requested during the "Sign in" consent flow maps directly to the underlying Google APIs needed for the server's tools:
-
-| Scope                                 | API                                                                             | Used for                                             |
-| :------------------------------------ | :------------------------------------------------------------------------------ | :--------------------------------------------------- |
-| `openid`, `userinfo.email`            | OpenID Connect                                                                  | Identifies the logged-in admin in startup output     |
-| `chrome.management.policy`            | [Chrome Policy](https://developers.google.com/chrome/policy)                    | Reading and writing connector and extension policies |
-| `chrome.management.reports.readonly`  | [Chrome Management](https://developers.google.com/chrome/management)            | Telemetry version counts                             |
-| `chrome.management.profiles.readonly` | [Chrome Management](https://developers.google.com/chrome/management)            | Listing managed browser profiles                     |
-| `admin.reports.audit.readonly`        | [Admin SDK Reports](https://developers.google.com/admin-sdk/reports)            | Fetching Chrome activity logs                        |
-| `admin.directory.orgunit.readonly`    | [Admin SDK Directory](https://developers.google.com/admin-sdk/directory)        | Organizational Unit hierarchy                        |
-| `admin.directory.customer.readonly`   | [Admin SDK Directory](https://developers.google.com/admin-sdk/directory)        | Customer ID resolution                               |
-| `apps.licensing`                      | [Enterprise License Manager](https://developers.google.com/admin-sdk/licensing) | CEP subscription and per-user license checks         |
-| `cloud-identity.policies`             | [Cloud Identity](https://cloud.google.com/identity/docs)                        | Managing DLP rules and content detectors (CRUD)      |
-| `service.management`                  | [Service Usage](https://cloud.google.com/service-usage/docs)                    | Verifying and enabling required Google Cloud APIs    |
-
-> [!NOTE]
-> **OAuth App Trust Required:** If your organization restricts third-party app access, a Super Admin must [trust the OAuth client](docs/troubleshooting.md#configure-oauth-app-for-sensitive-scopes) in the Admin Console before you can authenticate.
+The server requests a set of OAuth scopes to access the Google APIs required for its tools. For a detailed reference on required OAuth scopes, Google APIs, and Workspace admin privileges, see [Workspace Scopes & Permissions](docs/permissions.md).
 
 ## Advanced Authentication Options
 
@@ -132,6 +168,28 @@ For production environments, headless systems, or customized configurations, the
 For environment variables and stdio vs. HTTP transport, see
 [`docs/configuration.md`](docs/configuration.md).
 
+## Example Prompts
+
+Once connected, you can interact with the server using natural-language queries. Here are some examples:
+
+### DLP Policy & Rules
+
+- _"List all of our active DLP rules."_
+- _"Create a new DLP rule named 'Block Credit Cards' that blocks uploads of files matching the credit card detector."_
+- _"Delete the content detector named 'temp-phone-list'."_
+
+### Browser Telemetry & Audits
+
+- _"How many of our managed browsers are running outdated Chrome versions?"_
+- _"Retrieve the Chrome activity logs for user admin@example.com."_
+- _"Run a diagnostic check of our Chrome Enterprise environment."_
+
+### Policy & Extensions
+
+- _"Check the status of the Secure Enterprise Browser (SEB) extension."_
+- _"Force-install the SEB extension on the '/Sales' Organizational Unit."_
+- _"Enable Chrome Enterprise Connectors for malware and threat protection."_
+
 ## Available tools and prompts
 
 ### Prompts
@@ -144,28 +202,74 @@ For environment variables and stdio vs. HTTP transport, see
 
 ### Tools
 
-The server exposes tools for reading and managing Chrome Enterprise resources:
+The server exposes tools for inspecting and modifying Chrome Enterprise resources. Click below to view the detailed tools reference for each category:
 
-- **Discovery:** get customer ID, list org units, count browser versions, list
-  customer profiles
-- **Licensing:** check CEP subscription status, check per-user license
-  assignment
-- **DLP:** list/create DLP rules, list/create detectors (regex,
-  word list, URL list), create default rule sets
-- **Connectors:** get connector policy status, enable Chrome Enterprise
-  connectors
-- **Extensions:** check SEB extension status, install SEB extension
-- **Security:** get Chrome activity logs, check and enable required APIs
-- **Knowledge:** retrieve documentation from the built-in Chrome Enterprise Premium knowledge base
+<details>
+<summary><b>DLP Policy & Detector Tools</b> (click to expand)</summary>
 
-## Architecture
+| Tool Name                   | Description                                       | Key Arguments                |
+| :-------------------------- | :------------------------------------------------ | :--------------------------- |
+| `list_dlp_rules`            | Lists all active DLP rules                        | `customerId` (optional)      |
+| `get_dlp_rule`              | Retrieves a specific DLP rule by name             | `ruleName`                   |
+| `create_chrome_dlp_rule`    | Creates a new DLP rule                            | `displayName`, `rules`, etc. |
+| `delete_agent_dlp_rule`     | Deletes a DLP rule created by the agent           | `ruleName`                   |
+| `list_detectors`            | Lists custom content detectors                    | `customerId` (optional)      |
+| `create_regex_detector`     | Creates a regex-based detector                    | `displayName`, `regex`       |
+| `create_word_list_detector` | Creates a word-list-based detector                | `displayName`, `words`       |
+| `create_url_list_detector`  | Creates a URL-list-based detector                 | `displayName`, `urls`        |
+| `delete_detector`           | Deletes a custom detector                         | `detectorName`               |
+| `create_default_dlp_rules`  | Deploys a set of standard best-practice DLP rules | None                         |
 
-The codebase has three layers: API clients in `lib/api/` (one interface +
-real implementation per Google API), MCP tools and prompts in `tools/` and
-`prompts/`, and the server entry point in `mcp-server.js`. Integration tests
-redirect the real API clients at an in-process Express fake under
-`test/helpers/`. For the directory layout, design patterns, and how the test
-backends are wired, see [`docs/architecture.md`](docs/architecture.md).
+</details>
+
+<details>
+<summary><b>Telemetry & Security Tools</b> (click to expand)</summary>
+
+| Tool Name                 | Description                                 | Key Arguments                   |
+| :------------------------ | :------------------------------------------ | :------------------------------ |
+| `diagnose_environment`    | Runs a complete environment health check    | `summaryMode` (optional)        |
+| `get_chrome_activity_log` | Retrieves Chrome security event audit logs  | `userEmail` (optional)          |
+| `count_browser_versions`  | Summarizes enrolled Chrome browser versions | `customerId` (optional)         |
+| `security_insights`       | Manages Chrome Security Insights enablement | `action` (check/enable/disable) |
+
+</details>
+
+<details>
+<summary><b>Policy & Connector Tools</b> (click to expand)</summary>
+
+| Tool Name                             | Description                                       | Key Arguments             |
+| :------------------------------------ | :------------------------------------------------ | :------------------------ |
+| `get_connector_policy`                | Reads current policy settings for a connector     | `connectorType`           |
+| `enable_chrome_enterprise_connectors` | Configures and enables Chrome security connectors | `connectors`, `targetOus` |
+| `check_seb_extension_status`          | Verifies if the SEB extension is force-installed  | `targetOu` (optional)     |
+| `install_seb_extension`               | Force-installs the SEB extension                  | `targetOu` (optional)     |
+
+</details>
+
+<details>
+<summary><b>Discovery & Licensing Tools</b> (click to expand)</summary>
+
+| Tool Name                  | Description                                   | Key Arguments            |
+| :------------------------- | :-------------------------------------------- | :----------------------- |
+| `get_customer_id`          | Resolves the Google Workspace customer ID     | None                     |
+| `list_org_units`           | Lists the organizational unit hierarchy       | `orgUnitPath` (optional) |
+| `list_customer_profiles`   | Lists enrolled browser profiles               | `customerId` (optional)  |
+| `check_cep_subscription`   | Verifies CEP license subscription status      | None                     |
+| `check_user_cep_license`   | Checks license assignment for a specific user | `userEmail`              |
+| `check_and_enable_cep_api` | Checks and enables required Google Cloud APIs | None                     |
+
+</details>
+
+<details>
+<summary><b>Product Knowledge Base Tools</b> (click to expand)</summary>
+
+| Tool Name        | Description                                        | Key Arguments        |
+| :--------------- | :------------------------------------------------- | :------------------- |
+| `search_content` | Performs a keyword search on CEP documentation     | `query`              |
+| `get_document`   | Retrieves the full text of reference documents     | `filename` (or list) |
+| `list_documents` | Lists all articles available in the knowledge base | None                 |
+
+</details>
 
 ## Troubleshooting
 

--- a/docs/auth-bring-your-own-oauth-client.md
+++ b/docs/auth-bring-your-own-oauth-client.md
@@ -115,7 +115,7 @@ Follow these steps to sign in by pasting the redirect URL from a different machi
 
 ## Scopes
 
-When you log in, you'll see a consent screen requesting the full scope set the server needs (defined in `lib/constants.js`). To see which scopes the cached token actually granted, run `auth status`.
+When you log in, you'll see a consent screen requesting the full scope set the server needs (see [Permissions & Scopes Reference](permissions.md)). To see which scopes the cached token actually granted, run `auth status`.
 
 ## Refresh expired tokens
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,0 +1,47 @@
+# Permissions & Scopes Reference
+
+This document describes the OAuth scopes, Google APIs, and Google Workspace administrator privileges required to run the Chrome Enterprise Premium MCP Server.
+
+## OAuth Scopes & Google APIs
+
+The server requests the following OAuth scopes during the authentication flow. These scopes must be enabled in your Google Cloud project (if using a custom OAuth client) and allowed in your Workspace domain.
+
+| Scope                                 | API                                                                             | Used for                                             |
+| :------------------------------------ | :------------------------------------------------------------------------------ | :--------------------------------------------------- |
+| `openid`, `userinfo.email`            | OpenID Connect                                                                  | Identifies the logged-in admin in startup output     |
+| `chrome.management.policy`            | [Chrome Policy](https://developers.google.com/chrome/policy)                    | Reading and writing connector and extension policies |
+| `chrome.management.reports.readonly`  | [Chrome Management](https://developers.google.com/chrome/management)            | Telemetry version counts                             |
+| `chrome.management.profiles.readonly` | [Chrome Management](https://developers.google.com/chrome/management)            | Listing managed browser profiles                     |
+| `admin.reports.audit.readonly`        | [Admin SDK Reports](https://developers.google.com/admin-sdk/reports)            | Fetching Chrome activity logs                        |
+| `admin.directory.orgunit.readonly`    | [Admin SDK Directory](https://developers.google.com/admin-sdk/directory)        | Organizational Unit hierarchy                        |
+| `admin.directory.customer.readonly`   | [Admin SDK Directory](https://developers.google.com/admin-sdk/directory)        | Customer ID resolution                               |
+| `apps.licensing`                      | [Enterprise License Manager](https://developers.google.com/admin-sdk/licensing) | CEP subscription and per-user license checks         |
+| `cloud-identity.policies`             | [Cloud Identity](https://cloud.google.com/identity/docs)                        | Managing DLP rules and content detectors (CRUD)      |
+| `service.management`                  | [Service Usage](https://cloud.google.com/service-usage/docs)                    | Verifying and enabling required Google Cloud APIs    |
+
+> [!NOTE]
+> **OAuth App Trust Required:** If your organization restricts third-party app access, a Super Admin must [trust the OAuth client](troubleshooting.md#configure-oauth-app-for-sensitive-scopes) in the Admin Console before you can authenticate.
+
+## Google Workspace Admin Privileges
+
+To call Google Workspace APIs, the user account that authenticates the server must hold appropriate administrator privileges.
+
+### Prebuilt Roles
+
+- **Super Admin**: Grants all required privileges automatically.
+- **Chrome Admin**: Grants Chrome Management privileges (covers policy tools, but not DLP or reports).
+
+### Custom / Delegated Roles
+
+If you use a custom admin role, it must have the following privileges enabled in the Google Admin Console under **Account > Admin roles**:
+
+1.  **Chrome Management**:
+    - **Settings** (or **Manage User Settings** and **Manage Application Settings**): Required to read and write connector policies and extension configurations.
+    - **Managed Browsers**: Required to view and manage enrolled browsers.
+    - **View Reports**: Required for browser telemetry tools (versions, insights).
+2.  **Data Loss Prevention (DLP)**:
+    - **Manage DLP Rules**: Required to create, edit, or delete DLP rules and content detectors.
+3.  **Reports**:
+    - **Audit Reports**: Required to fetch Chrome activity logs (Admin SDK Reports API).
+4.  **Organizational Units**:
+    - **Read**: Required to resolve organizational unit hierarchies.


### PR DESCRIPTION
### Motivation
The root `README.md` was becoming bloated with technical reference details about OAuth scopes, Workspace APIs, and specific administrator privileges. Moving this material to a dedicated reference file keeps the README focused on quick start and basic prerequisites, making it more readable for new users.

### Main Changes
*   Created [docs/permissions.md](docs/permissions.md) containing:
    *   The detailed **Workspace Scopes & Permissions** reference table (mapping scopes to APIs and usage).
    *   The **OAuth App Trust** security note.
    *   A new guide detailing exactly which prebuilt or custom Google Workspace administrator privileges (Chrome Management, DLP, Reports, Org Units) are required for the server.
*   Updated [README.md](README.md) to replace the scopes table with a concise summary and a link to `docs/permissions.md`.
*   Updated [docs/auth-bring-your-own-oauth-client.md](docs/auth-bring-your-own-oauth-client.md) to link to `permissions.md` instead of pointing to the codebase (`lib/constants.js`).
*   Reverted temporary changes to [docs/configuration.md](docs/configuration.md).

### Non-Trivial Design Decisions
*   **Dedicated Permissions File**: Instead of moving the scopes to `configuration.md`, we created `permissions.md`. This is because OAuth scopes and Workspace admin privileges are static access requirements (permissions), not user-configurable parameters (configuration). This keeps `configuration.md` strictly focused on environment variables and transport settings.
*   **Workspace Admin Privilege Documentation**: Added detailed mapping of Admin Console privileges (e.g., "Settings", "Manage DLP Rules") to help administrators set up custom/delegated roles with least privilege, resolving a common source of `403 Permission Denied` errors.

This PR is stacked on top of #313.
