### PR TITLE
fix(eval): simplify judge instructions in i12

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -6,10 +6,7 @@
   "mcpServers": {
     "chrome-enterprise-premium": {
       "command": "npx",
-      "args": [
-        "-y",
-        "@google/chrome-enterprise-premium-mcp@latest"
-      ]
+      "args": ["-y", "@google/chrome-enterprise-premium-mcp@latest"]
     }
   }
 }

--- a/test/evals/cases/inspection/i12-check_security_insights.eval.js
+++ b/test/evals/cases/inspection/i12-check_security_insights.eval.js
@@ -25,5 +25,6 @@ export default {
   goldenResponse:
     'The agent should call the `security_insights` tool with the `action` parameter set to "check" to query the tenant-wide status. It should report back in plain language whether the feature is enabled or disabled.',
   judgeInstructions:
-    'Verify the agent successfully called the `security_insights` tool with `action: "check"` and reported the resulting enablement state cleanly in plain language. Do not penalize for omitting raw payload contents.',
+    'Verify the agent reported the enablement state of Chrome Security Insights cleanly in plain language. ' +
+    'Do not penalize the agent for omitting tool execution details or raw payload contents.',
 }


### PR DESCRIPTION
Simplifies the judge instructions in `i12-check_security_insights.eval.js` to avoid penalizing the agent for omitting tool execution details in its response text, since the deterministic `expectedTools` assertion already verifies the tool call.