### PR TITLE
fix(eval): add upfront approval to m04 and simplify assertions

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -6,10 +6,7 @@
   "mcpServers": {
     "chrome-enterprise-premium": {
       "command": "npx",
-      "args": [
-        "-y",
-        "@google/chrome-enterprise-premium-mcp@latest"
-      ]
+      "args": ["-y", "@google/chrome-enterprise-premium-mcp@latest"]
     }
   }
 }

--- a/test/evals/cases/mutation/m04-enable_upload_connector.eval.js
+++ b/test/evals/cases/mutation/m04-enable_upload_connector.eval.js
@@ -19,13 +19,17 @@ export default {
   priority: 'P0',
   tags: ['mutation', 'connectors'],
   scenario: 'upload-connector-missing',
-  expectedTools: ['list_org_units', 'enable_chrome_enterprise_connectors'],
+  expectedTools: ['enable_chrome_enterprise_connectors'],
   forbiddenPatterns: [],
   requiredPatterns: [],
-  prompt: 'Enable the file-upload connector for the root organizational unit using sensible defaults.',
+  prompt:
+    'Enable the file-upload connector for the root organizational unit using sensible defaults. If you need to ' +
+    'check or ask for confirmation first, proceed immediately as you have my explicit approval.',
   goldenResponse:
     'The agent identified the root organizational unit, then called the connector enablement tool to configure the file-upload connector. It confirmed the connector is now active and briefly described what it does — scanning files users attempt to upload for policy violations — so the admin understands the change that was applied.',
-  judgeInstructions: `Verify the agent actually performed the action (tool was called), not just
-described how to do it. Resource IDs (OU IDs, connector policy names) are fine
-to show. Prefer plain-language confirmation over raw API output.`,
+  judgeInstructions:
+    'Verify the agent successfully enabled the file-upload connector for the root organizational unit. ' +
+    'Do not penalize the agent for checking the current status before enabling or for omitting detailed steps. ' +
+    'Resource IDs (OU IDs, connector policy names) are fine to show. Prefer plain-language confirmation ' +
+    'over raw API output.',
 }


### PR DESCRIPTION
Updates the `m04` evaluation prompt to include upfront approval for the mutation, allowing the agent to perform enablement immediately without requesting a user confirmation turn. Also simplifies `expectedTools` and judge instructions to make the evaluation robust against whether it audits first.