### PR TITLE
fix(eval): clear activities in no-dlp-rules scenario

### DIFF
--- a/test/evals/scenarios/no-dlp-rules.js
+++ b/test/evals/scenarios/no-dlp-rules.js
@@ -27,5 +27,6 @@ export function mutate(state) {
       delete state.policies[key]
     }
   }
+  state.activities = []
   return state
 }


### PR DESCRIPTION
Fixes a state mismatch in evaluations like `pr08` and `d03`. When the `no-dlp-rules` scenario is activated, it now correctly clears the mock `activities` array alongside active policies. This prevents the agent from reporting existing rules based on legacy activity log matches.