### PR TITLE
feat: implement security_insights_data tool and tests

### DIFF
--- a/test/local/security_insights_data.test.js
+++ b/test/local/security_insights_data.test.js
@@ -1,0 +1,172 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import assert from 'node:assert/strict'
+import { describe, test, mock, beforeEach } from 'node:test'
+import { registerTools } from '../../tools/index.js'
+import { FeatureFlags } from '../../lib/util/feature_flags.js'
+import { registerSecurityInsightsDataTool } from '../../tools/definitions/security-insights-data-tool.js'
+
+describe('security_insights_data Tool', () => {
+  let server
+
+  beforeEach(() => {
+    server = {
+      registerTool: mock.fn(),
+    }
+  })
+
+  describe('Feature Flag Gating', () => {
+    test('When EXPERIMENT_SECURITY_INSIGHTS_DATA_TOOL_ENABLED flag is enabled, then it registers the tool', () => {
+      const flags = new FeatureFlags({ EXPERIMENT_SECURITY_INSIGHTS_DATA_TOOL_ENABLED: 'true' })
+      registerTools(server, { featureFlags: flags })
+
+      const registeredToolNames = server.registerTool.mock.calls.map(call => call.arguments[0])
+      assert.ok(
+        registeredToolNames.includes('security_insights_data'),
+        'security_insights_data tool should be registered when flag is enabled',
+      )
+    })
+
+    test('When EXPERIMENT_SECURITY_INSIGHTS_DATA_TOOL_ENABLED flag is disabled, then it does NOT register the tool', () => {
+      const flags = new FeatureFlags({ EXPERIMENT_SECURITY_INSIGHTS_DATA_TOOL_ENABLED: 'false' })
+      registerTools(server, { featureFlags: flags })
+
+      const registeredToolNames = server.registerTool.mock.calls.map(call => call.arguments[0])
+      assert.ok(
+        !registeredToolNames.includes('security_insights_data'),
+        'security_insights_data tool should NOT be registered when flag is disabled',
+      )
+    })
+  })
+
+  describe('Handler Logic', () => {
+    let mockClient
+    let handler
+    const customerId = 'C0123'
+
+    beforeEach(() => {
+      mockClient = {
+        queryContentTransfers: mock.fn(async () => ({
+          summaries: [{ metric: 'CONTENT_TRANSFERS_METRIC_TOTAL_TRANSFERS', count: '100' }],
+        })),
+        queryContentTransfersBreakdowns: mock.fn(async () => ({
+          contentTransfersBreakdowns: [{ user: 'user@test.com', summary: { count: '50' } }],
+        })),
+        queryUrlVisits: mock.fn(async () => ({
+          summaries: [{ metric: 'URL_VISITS_METRIC_TOTAL_SUSPICIOUS_URL_VISITS', count: '5' }],
+        })),
+        queryUrlVisitsBreakdowns: mock.fn(async () => ({
+          urlVisitsBreakdowns: [{ user: 'user@test.com', summary: { count: '2' } }],
+        })),
+      }
+
+      const options = {
+        chromeManagementClient: mockClient,
+        apiClients: {
+          adminSdk: {
+            getCustomerId: mock.fn(async () => ({ id: customerId })),
+          },
+        },
+      }
+
+      registerSecurityInsightsDataTool(server, options, { customerId: null })
+      handler = server.registerTool.mock.calls[0].arguments[2]
+    })
+
+    test('When queryContentTransfers is called, then it calls API and returns formatted summaries', async () => {
+      const result = await handler(
+        { action: 'queryContentTransfers', customerId, filter: 'event_time >= "2026-01-01T00:00:00Z"' },
+        { requestInfo: {} },
+      )
+
+      assert.strictEqual(mockClient.queryContentTransfers.mock.callCount(), 1)
+      const callArgs = mockClient.queryContentTransfers.mock.calls[0].arguments
+      assert.strictEqual(callArgs[0], customerId)
+      assert.deepStrictEqual(callArgs[1], { filter: 'event_time >= "2026-01-01T00:00:00Z"' })
+
+      assert.ok(result.content[0].text.includes('Security Insights action `queryContentTransfers` completed.'))
+      assert.ok(result.content[0].text.includes('Found 1 summaries.'))
+      assert.deepStrictEqual(result.structuredContent.summaries[0].count, '100')
+    })
+
+    test('When queryContentTransfersBreakdowns is called, then it calls API and returns formatted breakdowns', async () => {
+      const result = await handler(
+        {
+          action: 'queryContentTransfersBreakdowns',
+          customerId,
+          pageSize: 10,
+          breakdown: 'USER',
+          fixedTimeRange: 'FIXED_TIME_RANGE_ONE_WEEK',
+        },
+        { requestInfo: {} },
+      )
+
+      assert.strictEqual(mockClient.queryContentTransfersBreakdowns.mock.callCount(), 1)
+      const callArgs = mockClient.queryContentTransfersBreakdowns.mock.calls[0].arguments
+      assert.strictEqual(callArgs[0], customerId)
+      assert.deepStrictEqual(callArgs[1], {
+        pageSize: 10,
+        breakdown: 'USER',
+        fixedTimeRange: 'FIXED_TIME_RANGE_ONE_WEEK',
+      })
+
+      assert.ok(
+        result.content[0].text.includes('Security Insights action `queryContentTransfersBreakdowns` completed.'),
+      )
+      assert.ok(result.content[0].text.includes('Found 1 breakdowns.'))
+      assert.deepStrictEqual(result.structuredContent.contentTransfersBreakdowns[0].user, 'user@test.com')
+    })
+
+    test('When queryUrlVisits is called, then it calls API and returns formatted summaries', async () => {
+      const result = await handler({ action: 'queryUrlVisits', customerId }, { requestInfo: {} })
+
+      assert.strictEqual(mockClient.queryUrlVisits.mock.callCount(), 1)
+      assert.strictEqual(mockClient.queryUrlVisits.mock.calls[0].arguments[0], customerId)
+
+      assert.ok(result.content[0].text.includes('Security Insights action `queryUrlVisits` completed.'))
+      assert.deepStrictEqual(result.structuredContent.summaries[0].count, '5')
+    })
+
+    test('When queryUrlVisitsBreakdowns is called, then it calls API and returns formatted breakdowns', async () => {
+      const result = await handler(
+        { action: 'queryUrlVisitsBreakdowns', customerId, breakdown: 'EVENT_DOMAIN' },
+        { requestInfo: {} },
+      )
+
+      assert.strictEqual(mockClient.queryUrlVisitsBreakdowns.mock.callCount(), 1)
+      const callArgs = mockClient.queryUrlVisitsBreakdowns.mock.calls[0].arguments
+      assert.strictEqual(callArgs[0], customerId)
+      assert.deepStrictEqual(callArgs[1], { breakdown: 'EVENT_DOMAIN' })
+
+      assert.ok(result.content[0].text.includes('Security Insights action `queryUrlVisitsBreakdowns` completed.'))
+      assert.deepStrictEqual(result.structuredContent.urlVisitsBreakdowns[0].user, 'user@test.com')
+    })
+
+    test('When customerId is omitted, then it resolves it using adminSdk', async () => {
+      // We need to trigger resolution, which happens in guardedToolCall.
+      // So we must use a handler that was registered with the full registerTools flow,
+      // or manually trigger guardedToolCall logic.
+      // Actually, since we mocked registerSecurityInsightsDataTool with options containing apiClients,
+      // guardedToolCall will call options.apiClients.adminSdk.getCustomerId if customerId is undefined.
+      await handler({ action: 'queryContentTransfers' }, { requestInfo: {} })
+
+      assert.strictEqual(mockClient.queryContentTransfers.mock.callCount(), 1)
+      // The resolved customerId 'C0123' should be passed to the API client
+      assert.strictEqual(mockClient.queryContentTransfers.mock.calls[0].arguments[0], customerId)
+    })
+  })
+})

--- a/tools/definitions/security-insights-data-tool.js
+++ b/tools/definitions/security-insights-data-tool.js
@@ -1,0 +1,163 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file Tool definition for querying Chrome Security Insights data.
+ */
+
+import { z } from 'zod'
+import { guardedToolCall, formatToolResponse, safeFormatResponse } from '../utils/wrapper.js'
+import { TAGS } from '../../lib/constants.js'
+import { logger } from '../../lib/util/logger.js'
+
+/**
+ * Registers the 'security_insights_data' tool with the MCP server.
+ * @param {import('@modelcontextprotocol/sdk/server/mcp.js').McpServer} server - The MCP server instance.
+ * @param {object} options - Configuration options for the tool.
+ * @param {import('../../lib/api/chrome_management_client.js').ChromeManagementClient} options.chromeManagementClient - The Chrome Management client instance.
+ * @param {object} sessionState - The session state object for caching.
+ * @returns {void}
+ */
+export function registerSecurityInsightsDataTool(server, options, sessionState) {
+  const { chromeManagementClient } = options
+  logger.debug(`${TAGS.MCP} Registering 'security_insights_data' tool...`)
+
+  server.registerTool(
+    'security_insights_data',
+    {
+      description: `Queries Chrome Enterprise Security Insights data.
+Allows retrieving summaries and breakdowns of content transfers (uploads, downloads, prints) and URL visits.
+Supports filtering by event time, user, domain, or content category depending on the query action.`,
+      inputSchema: z.object({
+        action: z
+          .enum([
+            'queryContentTransfers',
+            'queryContentTransfersBreakdowns',
+            'queryUrlVisits',
+            'queryUrlVisitsBreakdowns',
+          ])
+          .describe('The query action to perform.'),
+        customerId: z.string().optional().describe('The Chrome customer ID (e.g. C012345). Defaults to "my_customer".'),
+        filter: z
+          .string()
+          .optional()
+          .describe(
+            'AIP-160 filter string. E.g., for transfers: `event_time >= "2024-01-01T00:00:00Z" AND event_time <= "2024-01-02T00:00:00Z"`. For breakdowns: `user = "testuser" AND event_time <= "2024-01-02T00:00:00Z"`.',
+          ),
+        pageSize: z
+          .number()
+          .int()
+          .min(1)
+          .max(1000)
+          .optional()
+          .describe('Maximum number of breakdowns to return (default 50, max 1000). Only for breakdown actions.'),
+        pageToken: z
+          .string()
+          .optional()
+          .describe('Page token received from a previous breakdown call to retrieve the next page.'),
+        metric: z
+          .string()
+          .optional()
+          .describe(
+            'The metric to return breakdowns for. E.g., for transfers: CONTENT_TRANSFERS_METRIC_TOTAL_TRANSFERS, CONTENT_TRANSFERS_METRIC_TOTAL_SENSITIVE_TRANSFERS, etc. For URL visits: URL_VISITS_METRIC_TOTAL_SUSPICIOUS_URL_VISITS, etc.',
+          ),
+        breakdown: z
+          .string()
+          .optional()
+          .describe(
+            'The dimension to break down by. For transfers: USER, EVENT_DOMAIN, CONTENT_CATEGORY. For URL visits: USER, EVENT_DOMAIN.',
+          ),
+        fixedTimeRange: z
+          .enum([
+            'FIXED_TIME_RANGE_UNSPECIFIED',
+            'FIXED_TIME_RANGE_FOUR_HOURS',
+            'FIXED_TIME_RANGE_ONE_DAY',
+            'FIXED_TIME_RANGE_ONE_WEEK',
+            'FIXED_TIME_RANGE_FOUR_WEEKS',
+          ])
+          .optional()
+          .describe(
+            'Fixed time range for precomputed breakdowns (default: FIXED_TIME_RANGE_FOUR_WEEKS). Only for breakdown actions.',
+          ),
+      }),
+      outputSchema: z.looseObject({}),
+    },
+    guardedToolCall(
+      {
+        handler: async (
+          { action, customerId = 'my_customer', filter, pageSize, pageToken, metric, breakdown, fixedTimeRange },
+          { _requestInfo, authToken },
+        ) => {
+          logger.debug(`${TAGS.MCP} Calling 'security_insights_data' with action: ${action}, customerId: ${customerId}`)
+
+          const queryOptions = {}
+          if (filter !== undefined) {
+            queryOptions.filter = filter
+          }
+          if (pageSize !== undefined) {
+            queryOptions.pageSize = pageSize
+          }
+          if (pageToken !== undefined) {
+            queryOptions.pageToken = pageToken
+          }
+          if (metric !== undefined) {
+            queryOptions.metric = metric
+          }
+          if (breakdown !== undefined) {
+            queryOptions.breakdown = breakdown
+          }
+          if (fixedTimeRange !== undefined) {
+            queryOptions.fixedTimeRange = fixedTimeRange
+          }
+
+          let result
+          if (action === 'queryContentTransfers') {
+            result = await chromeManagementClient.queryContentTransfers(customerId, queryOptions, authToken)
+          } else if (action === 'queryContentTransfersBreakdowns') {
+            result = await chromeManagementClient.queryContentTransfersBreakdowns(customerId, queryOptions, authToken)
+          } else if (action === 'queryUrlVisits') {
+            result = await chromeManagementClient.queryUrlVisits(customerId, queryOptions, authToken)
+          } else if (action === 'queryUrlVisitsBreakdowns') {
+            result = await chromeManagementClient.queryUrlVisitsBreakdowns(customerId, queryOptions, authToken)
+          }
+
+          return safeFormatResponse({
+            rawData: result,
+            toolName: 'security_insights_data',
+            formatFn: raw => {
+              let summaryText = `Security Insights action \`${action}\` completed.`
+              if (action === 'queryContentTransfers' || action === 'queryUrlVisits') {
+                const summaries = raw?.summaries || []
+                summaryText += ` Found ${summaries.length} summaries.`
+              } else {
+                const breakdowns = raw?.contentTransfersBreakdowns || raw?.urlVisitsBreakdowns || []
+                summaryText += ` Found ${breakdowns.length} breakdowns.`
+              }
+
+              return formatToolResponse({
+                summary: summaryText,
+                data: raw,
+                structuredContent: raw,
+              })
+            },
+          })
+        },
+      },
+      options,
+      sessionState,
+    ),
+  )
+}

--- a/tools/index.js
+++ b/tools/index.js
@@ -47,6 +47,7 @@ import { registerDiagnoseEnvironmentTool } from './definitions/diagnose_environm
 import { registerKnowledgeTools } from './definitions/knowledge.js'
 import { registerAuthTools } from './definitions/auth.js'
 import { registerSecurityInsightsTool } from './definitions/security_insights.js'
+import { registerSecurityInsightsDataTool } from './definitions/security-insights-data-tool.js'
 import { featureFlags, FLAGS } from '../lib/util/feature_flags.js'
 
 /**
@@ -94,6 +95,12 @@ export function registerTools(server, options = {}, sessionState) {
   registerCountBrowserVersionsTool(server, { ...commonOpts, chromeManagementClient }, state)
   registerCustomerProfileTool(server, { ...commonOpts, chromeManagementClient }, state)
   registerSecurityInsightsTool(server, { ...commonOpts, chromeManagementClient }, state)
+  if (flags.isEnabled(FLAGS.SECURITY_INSIGHTS_DATA_TOOL_ENABLED)) {
+    logger.debug(
+      `${TAGS.MCP} Registering 'security_insights_data' tool (EXPERIMENT_SECURITY_INSIGHTS_DATA_TOOL_ENABLED is active)`,
+    )
+    registerSecurityInsightsDataTool(server, { ...commonOpts, chromeManagementClient }, state)
+  }
   registerGetConnectorPolicyTool(server, { chromePolicyClient }, state)
   registerGetChromeActivityLogTool(server, { ...commonOpts, chromeManagementClient }, state)
   registerListDlpRulesTool(server, { cloudIdentityClient }, state)


### PR DESCRIPTION
# Commit Summary: `704766b6114eb5d8a7df11add9fb2f0e05d2a5fa`

**Message**: `feat: implement security_insights_data tool and tests`
**Author**: Sahil Madeka <sahilmadeka@google.com>
**Date**: Wed Jun 10 12:51:06 2026 -0700

This commit implements the `security_insights_data` MCP tool to allow querying Chrome Enterprise Security Insights data (summaries and breakdowns of content transfers and URL visits), along with its registration and unit tests.

---

## Files Changed

### 1. `tools/definitions/security-insights-data-tool.js` (NEW)
*   Defines and registers the `security_insights_data` MCP tool.
*   Supports four query actions:
    *   `queryContentTransfers` (calls `chromeManagementClient.queryContentTransfers`)
    *   `queryContentTransfersBreakdowns` (calls `chromeManagementClient.queryContentTransfersBreakdowns`)
    *   `queryUrlVisits` (calls `chromeManagementClient.queryUrlVisits`)
    *   `queryUrlVisitsBreakdowns` (calls `chromeManagementClient.queryUrlVisitsBreakdowns`)
*   Implements Zod input validation schema supporting parameters:
    *   `action` (Required, enum of the 4 actions above)
    *   `customerId` (Optional, defaults to `"my_customer"`)
    *   `filter` (Optional, AIP-160 filter string)
    *   `pageSize` (Optional, integer 1-1000, for breakdowns)
    *   `pageToken` (Optional, for breakdown pagination)
    *   `metric` (Optional, metric name for breakdowns)
    *   `breakdown` (Optional, dimension to break down by)
    *   `fixedTimeRange` (Optional, precomputed breakdown time range enum)
*   Uses `guardedToolCall` to handle authentication, retry logic, and automatic `customerId` resolution via `adminSdk` if omitted.
*   Formats the API JSON responses into human-readable text summaries and includes the raw structured data.

### 2. `tools/index.js`
*   Imports `registerSecurityInsightsDataTool`.
*   Registers the `security_insights_data` tool, gated by the `SECURITY_INSIGHTS_DATA_TOOL_ENABLED` feature flag.

### 3. `test/local/security_insights_data.test.js` (NEW)
*   Implements unit tests for the `security_insights_data` tool using Node's built-in `node:test` framework.
*   **Feature Flag Gating Tests**: Verifies the tool is registered only when `EXPERIMENT_SECURITY_INSIGHTS_DATA_TOOL_ENABLED` is set to `"true"`.
*   **Handler Logic Tests**:
    *   Mocks `ChromeManagementClient` query methods and verifies they are called with correct parameters.
    *   Verifies output formatting for both summary and breakdown actions.
    *   Verifies automatic customer ID resolution using `adminSdk` when `customerId` is omitted in the tool call.

## Manual test

Asked Gemini CLI to query content transfers for my domain, give me a breakdown of content transfers for my domain, asked "what urls are being visited in chrome in my domain". For the first case it called queryContentTransfers only and summarized its output, the second case it called queryContentTransfersBreakdowns only and summarized its output, and in the third case it called both queryUrlVisits and queryUrlVisits breakdowns and summarized the output of both using tables. 

In the next PR I will add a knowledge document to give more context about each of these APIs along with eval test cases