### PR TITLE
feat(eval): implement daily evaluation trend reporter and scheduler

### DIFF
--- a/.github/workflows/agent-evals.yml
+++ b/.github/workflows/agent-evals.yml
@@ -31,6 +31,11 @@ jobs:
           cache: npm
       - run: npm ci
 
+      - name: Download history
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node test/evals/download_history.js
+
       # The runner exits 1 on any FAIL. We let it; the diff step is what
       # decides whether the workflow goes red, so the runner's own exit code
       # must not abort the rest of the job.
@@ -39,6 +44,18 @@ jobs:
         run: |
           mkdir -p results
           node test/evals/run.js --output results/eval-latest.json
+
+      - name: Run Trend Reporter
+        run: |
+          if [ -f results/eval-latest.json ]; then
+            TIMESTAMP=$(date +%s)
+            VERSION=$(node --input-type=module -e "import fs from 'fs'; console.log(JSON.parse(fs.readFileSync('package.json', 'utf8')).version);")
+            mkdir -p test/evals/runs
+            cp results/eval-latest.json "test/evals/runs/run-${VERSION}-${TIMESTAMP}000.json"
+            node test/evals/reporter.js | tee -a "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Latest evaluation result not found. Skipping trend reporter."
+          fi
 
       - name: Upload eval results
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ coverage/
 results/
 eval_results*
 results*.json
+test/evals/runs/*
+!test/evals/runs/.gitkeep
 
 # Commit messages
 .commitmsg

--- a/test/evals/daily_runner.sh
+++ b/test/evals/daily_runner.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Exit on error
+set -e
+
+# Change directory to the workspace root
+cd /usr/local/google/home/tushardey/chrome-enterprise-premium-mcp
+
+# Source user's shell profile to import GEMINI_API_KEY
+if [ -f "$HOME/.bashrc" ]; then
+  source "$HOME/.bashrc"
+elif [ -f "$HOME/.bash_profile" ]; then
+  source "$HOME/.bash_profile"
+elif [ -f "$HOME/.zshrc" ]; then
+  source "$HOME/.zshrc"
+fi
+
+# Also load from App Data .env file if present
+if [ -f "/usr/local/google/home/tushardey/.gemini/jetski/.env" ]; then
+  export $(grep -v '^#' /usr/local/google/home/tushardey/.gemini/jetski/.env | xargs)
+fi
+
+# 1. Run evaluations and write JSON output
+TIMESTAMP=$(date +%s)
+VERSION=$(node --input-type=module -e "import fs from 'fs'; console.log(JSON.parse(fs.readFileSync('package.json', 'utf8')).version);")
+npm run eval -- --output "test/evals/runs/run-${VERSION}-${TIMESTAMP}000.json"
+
+# 2. Run reporter
+node test/evals/reporter.js

--- a/test/evals/daily_runner.sh
+++ b/test/evals/daily_runner.sh
@@ -3,7 +3,8 @@
 set -e
 
 # Change directory to the workspace root
-cd /usr/local/google/home/tushardey/chrome-enterprise-premium-mcp
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+cd "$SCRIPT_DIR/../.."
 
 # Source user's shell profile to import GEMINI_API_KEY
 if [ -f "$HOME/.bashrc" ]; then
@@ -15,8 +16,8 @@ elif [ -f "$HOME/.zshrc" ]; then
 fi
 
 # Also load from App Data .env file if present
-if [ -f "/usr/local/google/home/tushardey/.gemini/jetski/.env" ]; then
-  export $(grep -v '^#' /usr/local/google/home/tushardey/.gemini/jetski/.env | xargs)
+if [ -f "$HOME/.gemini/jetski/.env" ]; then
+  export $(grep -v '^#' "$HOME/.gemini/jetski/.env" | xargs)
 fi
 
 # 1. Run evaluations and write JSON output

--- a/test/evals/download_history.js
+++ b/test/evals/download_history.js
@@ -1,0 +1,106 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file Downloads previous evaluation run artifacts from GitHub Actions to construct run history.
+ */
+
+import { execSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const RUNS_DIR = path.resolve(__dirname, 'runs')
+
+// Read current version as fallback
+const packageJsonPath = path.resolve(__dirname, '../../package.json')
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+const currentVersion = packageJson.version
+
+/**
+ * Executes a shell command and returns stdout.
+ * @param {string} cmd The command to execute.
+ * @returns {string} The command output.
+ */
+function runCmd(cmd) {
+  try {
+    return execSync(cmd, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim()
+  } catch (err) {
+    console.error(`Error running command: ${cmd}`, err.message)
+    return ''
+  }
+}
+
+/**
+ * Main function to download run history from GitHub Actions.
+ */
+function main() {
+  if (!fs.existsSync(RUNS_DIR)) {
+    fs.mkdirSync(RUNS_DIR, { recursive: true })
+  }
+
+  console.log('Fetching list of recent successful workflow runs...')
+  const runsJson = runCmd(
+    'gh run list --workflow agent-evals.yml --status success --limit 7 --json databaseId,createdAt',
+  )
+
+  if (!runsJson) {
+    console.log('No successful runs found or GitHub CLI is not configured/authenticated.')
+    return
+  }
+
+  const runs = JSON.parse(runsJson)
+  console.log(`Found ${runs.length} successful run(s). Downloading artifacts...`)
+
+  runs.forEach(run => {
+    const runId = run.databaseId
+    const createdAtMs = new Date(run.createdAt).getTime()
+    const tmpDir = path.join(RUNS_DIR, `tmp-${runId}`)
+
+    console.log(`Downloading artifact for run ${runId}...`)
+    runCmd(`gh run download ${runId} --name eval-results --dir "${tmpDir}"`)
+
+    const evalFile = path.join(tmpDir, 'eval-latest.json')
+    if (fs.existsSync(evalFile)) {
+      try {
+        const fileContent = fs.readFileSync(evalFile, 'utf8')
+        const data = JSON.parse(fileContent)
+
+        // Determine version and timestamp
+        const version = data.version || currentVersion
+        const timestamp = data.timestamp ? new Date(data.timestamp).getTime() : createdAtMs
+
+        const destFile = path.join(RUNS_DIR, `run-${version}-${timestamp}.json`)
+        fs.writeFileSync(destFile, JSON.stringify(data, null, 2) + '\n')
+        console.log(`Saved run to: test/evals/runs/run-${version}-${timestamp}.json`)
+      } catch (err) {
+        console.error(`Failed to parse evaluation output for run ${runId}:`, err.message)
+      }
+    } else {
+      console.log(`Artifact file eval-latest.json not found in download for run ${runId}.`)
+    }
+
+    // Clean up temporary download directory
+    if (fs.existsSync(tmpDir)) {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  console.log('History download completed successfully.\n')
+}
+
+main()

--- a/test/evals/lib/reporter.js
+++ b/test/evals/lib/reporter.js
@@ -20,7 +20,13 @@ limitations under the License.
 
 import fs from 'node:fs'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { Status } from './transient.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const packageJsonPath = path.resolve(__dirname, '../../../package.json')
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+const currentVersion = packageJson.version
 
 const ANSI = Object.freeze({
   reset: '\x1b[0m',
@@ -413,6 +419,7 @@ function writeJson(results, filepath, { inconclusive = false } = {}) {
 
   const output = {
     timestamp: new Date().toISOString(),
+    version: currentVersion,
     summary: {
       passed: overall.passed,
       failed: overall.failed,

--- a/test/evals/reporter.js
+++ b/test/evals/reporter.js
@@ -1,0 +1,192 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file Daily evaluation trend and regression reporter.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const RUNS_DIR = path.resolve(__dirname, 'runs')
+
+// Read package.json to get version
+const packageJsonPath = path.resolve(__dirname, '../../package.json')
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+const currentVersion = packageJson.version
+
+/**
+ * Scans the runs directory and returns sorted runs details.
+ * @returns {Array<{file: string, filepath: string, version: string, timestamp: number}>} Sorted runs.
+ */
+function getRunFiles() {
+  if (!fs.existsSync(RUNS_DIR)) {
+    return []
+  }
+  return fs
+    .readdirSync(RUNS_DIR)
+    .filter(file => file.startsWith('run-') && file.endsWith('.json'))
+    .map(file => {
+      const parts = file
+        .replace(/^run-/, '')
+        .replace(/\.json$/, '')
+        .split('-')
+      let version = ''
+      let timestamp = 0
+      if (parts.length === 2) {
+        version = parts[0]
+        timestamp = parseInt(parts[1], 10)
+      } else {
+        timestamp = parseInt(parts[0], 10)
+      }
+      return {
+        file,
+        filepath: path.join(RUNS_DIR, file),
+        version,
+        timestamp,
+      }
+    })
+    .sort((a, b) => b.timestamp - a.timestamp)
+}
+
+/**
+ * Main execution of the evaluation reporter.
+ */
+function run() {
+  const runFiles = getRunFiles()
+  if (runFiles.length === 0) {
+    console.log('No evaluation runs found in test/evals/runs/')
+    return
+  }
+
+  // 1. Get the last 7 runs
+  const lastRuns = runFiles.slice(0, 7)
+  console.log(`Analyzing last ${lastRuns.length} run(s) from history...\n`)
+
+  const failCounts = {}
+  const totalCounts = {}
+  const evalCategories = {}
+
+  lastRuns.forEach(runInfo => {
+    try {
+      const data = JSON.parse(fs.readFileSync(runInfo.filepath, 'utf8'))
+      const evals = data.evaluations || []
+      evals.forEach(ev => {
+        const id = ev.id
+        evalCategories[id] = ev.category
+        if (!failCounts[id]) {
+          failCounts[id] = 0
+          totalCounts[id] = 0
+        }
+        totalCounts[id] += ev.total
+        failCounts[id] += ev.failed
+      })
+    } catch (err) {
+      console.error(`Failed to parse run file ${runInfo.file}:`, err.message)
+    }
+  })
+
+  // Filter evals that failed more than 3 times
+  const persistentFailures = Object.keys(failCounts)
+    .map(id => ({
+      id,
+      category: evalCategories[id],
+      failures: failCounts[id],
+      totalRuns: totalCounts[id],
+    }))
+    .filter(item => item.failures > 3)
+    .sort((a, b) => b.failures - a.failures)
+
+  // Print persistent failures
+  console.log('## ⚠️ Persistent Failures Alert (> 3 failures in last 7 runs)')
+  if (persistentFailures.length === 0) {
+    console.log('No persistent failures found. Clean bill of health across recent runs! 🎉\n')
+  } else {
+    console.log('| Eval ID | Category | Failure Count | Total Runs checked |')
+    console.log('| :--- | :--- | :--- | :--- |')
+    persistentFailures.forEach(item => {
+      console.log(`| **${item.id}** | ${item.category} | ${item.failures} | ${item.totalRuns} |`)
+    })
+    console.log()
+  }
+
+  // 2. Golden Run Comparison
+  const goldenRunInfo = runFiles.find(runInfo => runInfo.version && runInfo.version !== currentVersion)
+  const latestRunInfo = runFiles[0]
+
+  if (latestRunInfo && goldenRunInfo) {
+    console.log(`## 🏆 Golden Run Comparison`)
+    console.log(`- **Latest Run (Current Version ${currentVersion}):** ${latestRunInfo.file}`)
+    console.log(`- **Golden Run (Previous Version ${goldenRunInfo.version}):** ${goldenRunInfo.file}\n`)
+
+    try {
+      const latestData = JSON.parse(fs.readFileSync(latestRunInfo.filepath, 'utf8'))
+      const goldenData = JSON.parse(fs.readFileSync(goldenRunInfo.filepath, 'utf8'))
+
+      const latestStatus = {}
+      ;(latestData.evaluations || []).forEach(ev => {
+        latestStatus[ev.id] = ev.failed === 0
+      })
+
+      const goldenStatus = {}
+      ;(goldenData.evaluations || []).forEach(ev => {
+        goldenStatus[ev.id] = ev.failed === 0
+      })
+
+      const regressions = []
+      const improvements = []
+
+      Object.keys(latestStatus).forEach(id => {
+        const latestPassed = latestStatus[id]
+        const goldenPassed = goldenStatus[id]
+
+        if (goldenPassed === undefined) {
+          return
+        }
+
+        if (goldenPassed && !latestPassed) {
+          regressions.push(id)
+        } else if (!goldenPassed && latestPassed) {
+          improvements.push(id)
+        }
+      })
+
+      if (regressions.length === 0 && improvements.length === 0) {
+        console.log('No regressions or improvements detected compared to the golden release run. Stable! 🟢\n')
+      } else {
+        if (regressions.length > 0) {
+          console.log(`### 🔴 Regressions (Passed in Golden, now Failing):`)
+          regressions.forEach(id => console.log(`- **${id}** (${evalCategories[id]})`))
+          console.log()
+        }
+        if (improvements.length > 0) {
+          console.log(`### 🟢 Improvements (Failed in Golden, now Passing):`)
+          improvements.forEach(id => console.log(`- **${id}** (${evalCategories[id]})`))
+          console.log()
+        }
+      }
+    } catch (err) {
+      console.error('Failed to compare with golden run:', err.message)
+    }
+  } else {
+    console.log('## 🏆 Golden Run Comparison')
+    console.log('Golden run (previous version) or latest run details not found for comparison. ⚪\n')
+  }
+}
+
+run()

--- a/test/evals/reporter.js
+++ b/test/evals/reporter.js
@@ -48,9 +48,9 @@ function getRunFiles() {
         .split('-')
       let version = ''
       let timestamp = 0
-      if (parts.length === 2) {
-        version = parts[0]
-        timestamp = parseInt(parts[1], 10)
+      if (parts.length >= 2) {
+        timestamp = parseInt(parts[parts.length - 1], 10)
+        version = parts.slice(0, -1).join('-')
       } else {
         timestamp = parseInt(parts[0], 10)
       }

--- a/test/evals/runs/.gitkeep
+++ b/test/evals/runs/.gitkeep
@@ -1,0 +1,1 @@
+# Keep directory

--- a/test/integration/server/eval-reporter.test.js
+++ b/test/integration/server/eval-reporter.test.js
@@ -22,7 +22,7 @@ import { fileURLToPath } from 'node:url'
 import { execSync } from 'node:child_process'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
-const RUNS_DIR = path.resolve(__dirname, '../evals/runs')
+const RUNS_DIR = path.resolve(__dirname, '../../evals/runs')
 
 test('Daily Trend Reporter', async t => {
   // Setup: create runs directory if not exists
@@ -41,7 +41,7 @@ test('Daily Trend Reporter', async t => {
   }
 
   await t.test('reports correctly when no runs are present', () => {
-    const stdout = execSync(`node ${path.resolve(__dirname, '../evals/reporter.js')}`, { encoding: 'utf8' })
+    const stdout = execSync(`node ${path.resolve(__dirname, '../../evals/reporter.js')}`, { encoding: 'utf8' })
     assert.match(stdout, /No evaluation runs found/)
   })
 
@@ -69,7 +69,7 @@ test('Daily Trend Reporter', async t => {
     }
     fs.writeFileSync(path.join(RUNS_DIR, 'run-1.9.0-1700000000001.json'), JSON.stringify(latestRun))
 
-    const stdout = execSync(`node ${path.resolve(__dirname, '../evals/reporter.js')}`, { encoding: 'utf8' })
+    const stdout = execSync(`node ${path.resolve(__dirname, '../../evals/reporter.js')}`, { encoding: 'utf8' })
 
     // Check golden comparison outputs
     assert.match(stdout, /Golden Run Comparison/)
@@ -108,7 +108,7 @@ test('Daily Trend Reporter', async t => {
       fs.writeFileSync(path.join(RUNS_DIR, `run-1.9.0-170000000000${i}.json`), JSON.stringify(run))
     }
 
-    const stdout = execSync(`node ${path.resolve(__dirname, '../evals/reporter.js')}`, { encoding: 'utf8' })
+    const stdout = execSync(`node ${path.resolve(__dirname, '../../evals/reporter.js')}`, { encoding: 'utf8' })
 
     // Check persistent failure alert on m03
     assert.match(stdout, /Persistent Failures Alert/)

--- a/test/integration/server/eval-reporter.test.js
+++ b/test/integration/server/eval-reporter.test.js
@@ -19,7 +19,7 @@ import assert from 'node:assert'
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { execSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const RUNS_DIR = path.resolve(__dirname, '../../evals/runs')
@@ -41,7 +41,9 @@ test('Daily Trend Reporter', async t => {
   }
 
   await t.test('reports correctly when no runs are present', () => {
-    const stdout = execSync(`node ${path.resolve(__dirname, '../../evals/reporter.js')}`, { encoding: 'utf8' })
+    const stdout = execFileSync(process.execPath, [path.resolve(__dirname, '../../evals/reporter.js')], {
+      encoding: 'utf8',
+    })
     assert.match(stdout, /No evaluation runs found/)
   })
 
@@ -69,7 +71,9 @@ test('Daily Trend Reporter', async t => {
     }
     fs.writeFileSync(path.join(RUNS_DIR, 'run-1.9.0-1700000000001.json'), JSON.stringify(latestRun))
 
-    const stdout = execSync(`node ${path.resolve(__dirname, '../../evals/reporter.js')}`, { encoding: 'utf8' })
+    const stdout = execFileSync(process.execPath, [path.resolve(__dirname, '../../evals/reporter.js')], {
+      encoding: 'utf8',
+    })
 
     // Check golden comparison outputs
     assert.match(stdout, /Golden Run Comparison/)
@@ -108,7 +112,9 @@ test('Daily Trend Reporter', async t => {
       fs.writeFileSync(path.join(RUNS_DIR, `run-1.9.0-170000000000${i}.json`), JSON.stringify(run))
     }
 
-    const stdout = execSync(`node ${path.resolve(__dirname, '../../evals/reporter.js')}`, { encoding: 'utf8' })
+    const stdout = execFileSync(process.execPath, [path.resolve(__dirname, '../../evals/reporter.js')], {
+      encoding: 'utf8',
+    })
 
     // Check persistent failure alert on m03
     assert.match(stdout, /Persistent Failures Alert/)

--- a/test/local/eval-reporter.test.js
+++ b/test/local/eval-reporter.test.js
@@ -45,6 +45,41 @@ test('Daily Trend Reporter', async t => {
     assert.match(stdout, /No evaluation runs found/)
   })
 
+  await t.test('supports hyphenated pre-release version names in files', () => {
+    // Populate fake runs
+    const goldenRun = {
+      timestamp: new Date().toISOString(),
+      summary: { passed: 10, failed: 2, total: 12, passRate: 83.3 },
+      evaluations: [
+        { id: 'm01', category: 'mutation', failed: 0, total: 1 },
+        { id: 'm02', category: 'mutation', failed: 1, total: 1 },
+        { id: 'm03', category: 'mutation', failed: 1, total: 1 },
+      ],
+    }
+    fs.writeFileSync(path.join(RUNS_DIR, 'run-1.8.0-beta-1700000000000.json'), JSON.stringify(goldenRun))
+
+    const latestRun = {
+      timestamp: new Date().toISOString(),
+      summary: { passed: 11, failed: 1, total: 12, passRate: 91.7 },
+      evaluations: [
+        { id: 'm01', category: 'mutation', failed: 0, total: 1 },
+        { id: 'm02', category: 'mutation', failed: 0, total: 1 },
+        { id: 'm03', category: 'mutation', failed: 1, total: 1 },
+      ],
+    }
+    fs.writeFileSync(path.join(RUNS_DIR, 'run-1.9.0-1700000000001.json'), JSON.stringify(latestRun))
+
+    const stdout = execSync(`node ${path.resolve(__dirname, '../evals/reporter.js')}`, { encoding: 'utf8' })
+
+    // Check golden comparison outputs
+    assert.match(stdout, /Golden Run Comparison/)
+    assert.match(stdout, /Golden Run \(Previous Version 1.8.0-beta\)/)
+
+    // Cleanup fake runs
+    const files = fs.readdirSync(RUNS_DIR).filter(f => f.startsWith('run-') && f.endsWith('.json'))
+    files.forEach(f => fs.unlinkSync(path.join(RUNS_DIR, f)))
+  })
+
   await t.test('analyzes recent runs and highlights failures & improvements', () => {
     // Populate fake runs
     // Older runs: version 1.8.0

--- a/test/local/eval-reporter.test.js
+++ b/test/local/eval-reporter.test.js
@@ -1,0 +1,100 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import test from 'node:test'
+import assert from 'node:assert'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { execSync } from 'node:child_process'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const RUNS_DIR = path.resolve(__dirname, '../evals/runs')
+
+test('Daily Trend Reporter', async t => {
+  // Setup: create runs directory if not exists
+  if (!fs.existsSync(RUNS_DIR)) {
+    fs.mkdirSync(RUNS_DIR, { recursive: true })
+  }
+
+  // Back up existing run files
+  const existingFiles = fs.readdirSync(RUNS_DIR).filter(f => f.startsWith('run-') && f.endsWith('.json'))
+  const backupDir = path.join(RUNS_DIR, 'backup-test-temp')
+  if (existingFiles.length > 0) {
+    fs.mkdirSync(backupDir, { recursive: true })
+    existingFiles.forEach(f => {
+      fs.renameSync(path.join(RUNS_DIR, f), path.join(backupDir, f))
+    })
+  }
+
+  await t.test('reports correctly when no runs are present', () => {
+    const stdout = execSync(`node ${path.resolve(__dirname, '../evals/reporter.js')}`, { encoding: 'utf8' })
+    assert.match(stdout, /No evaluation runs found/)
+  })
+
+  await t.test('analyzes recent runs and highlights failures & improvements', () => {
+    // Populate fake runs
+    // Older runs: version 1.8.0
+    const goldenRun = {
+      timestamp: new Date().toISOString(),
+      summary: { passed: 10, failed: 2, total: 12, passRate: 83.3 },
+      evaluations: [
+        { id: 'm01', category: 'mutation', failed: 0, total: 1 },
+        { id: 'm02', category: 'mutation', failed: 1, total: 1 },
+        { id: 'm03', category: 'mutation', failed: 1, total: 1 },
+      ],
+    }
+    fs.writeFileSync(path.join(RUNS_DIR, 'run-1.8.0-1700000000000.json'), JSON.stringify(goldenRun))
+
+    // 7 recent runs: version 1.9.0
+    for (let i = 1; i <= 7; i++) {
+      const run = {
+        timestamp: new Date().toISOString(),
+        summary: { passed: 11, failed: 1, total: 12, passRate: 91.7 },
+        evaluations: [
+          { id: 'm01', category: 'mutation', failed: 0, total: 1 },
+          { id: 'm02', category: 'mutation', failed: 0, total: 1 }, // m02 improved!
+          { id: 'm03', category: 'mutation', failed: 1, total: 1 }, // m03 failed consistently!
+        ],
+      }
+      fs.writeFileSync(path.join(RUNS_DIR, `run-1.9.0-170000000000${i}.json`), JSON.stringify(run))
+    }
+
+    const stdout = execSync(`node ${path.resolve(__dirname, '../evals/reporter.js')}`, { encoding: 'utf8' })
+
+    // Check persistent failure alert on m03
+    assert.match(stdout, /Persistent Failures Alert/)
+    assert.match(stdout, /m03/)
+
+    // Check golden comparison
+    assert.match(stdout, /Golden Run Comparison/)
+    assert.match(stdout, /Improvements \(Failed in Golden, now Passing\)/)
+    assert.match(stdout, /m02/) // m02 was failed in 1.8.0, now passing in 1.9.0
+
+    // Cleanup fake runs
+    const files = fs.readdirSync(RUNS_DIR).filter(f => f.startsWith('run-') && f.endsWith('.json'))
+    files.forEach(f => fs.unlinkSync(path.join(RUNS_DIR, f)))
+  })
+
+  // Teardown: restore backed up run files
+  if (fs.existsSync(backupDir)) {
+    const backups = fs.readdirSync(backupDir)
+    backups.forEach(f => {
+      fs.renameSync(path.join(backupDir, f), path.join(RUNS_DIR, f))
+    })
+    fs.rmdirSync(backupDir)
+  }
+})


### PR DESCRIPTION
Implements the daily evaluation trend reporter. Includes: 1. `test/evals/reporter.js` to track trends across the last 7 runs and highlight persistent failures or regressions compared to golden release runs. 2. `test/evals/daily_runner.sh` to run the full suite and output JSON. 3. Configures a scheduled background sidecar task.