### PR TITLE
feat(diagnose): proactively include Admin Console deep-links in environment health check findings

### DIFF
--- a/lib/knowledge/0-agent-capabilities.md
+++ b/lib/knowledge/0-agent-capabilities.md
@@ -101,6 +101,20 @@ For security and architectural reasons, the agent has explicit limitations:
 
 - **No Configuration Updates:** The agent **CANNOT** update or modify existing Chrome Enterprise connector configurations. It is strictly limited to enabling connectors that are not yet configured (where the provider is UNSPECIFIED or NONE). The agent must never promise to "adjust", "fix", or "optimize" an already active connector (e.g., enabling "Delay Enforcement" on an active policy). If an existing configuration needs adjustment, the agent must identify the gap and provide the relevant manual Admin Console link to the administrator.
 
+### 7. Google Admin Console Deep-Links for Remediation
+
+When suggesting manual configuration or remediation for Chrome Enterprise connectors and related settings, the agent must proactively provide the corresponding deep-link:
+
+- **Real-Time URL Check Connector:** https://admin.google.com/ac/chrome/settings/user/details/realtime_url_check
+- **File Upload Connector:** https://admin.google.com/ac/chrome/settings/user/details/file_attached
+- **File Download Connector:** https://admin.google.com/ac/chrome/settings/user/details/file_downloaded
+- **Paste/Bulk Text Connector:** https://admin.google.com/ac/chrome/settings/user/details/bulk_text_entry
+- **Print Connector:** https://admin.google.com/ac/chrome/settings/user/details/print_analysis_connector
+- **Security Event Reporting Connector:** https://admin.google.com/ac/chrome/settings/user/details/on_security_event
+- **Chrome Security Insights:** https://admin.google.com/ac/dp
+- **Secure Enterprise Browser (SEB) extension / Apps:** https://admin.google.com/ac/chrome/apps/user
+- **DLP Rules:** https://admin.google.com/ac/dp/rules
+
 ### Knowledge Base
 
 The agent has access to a comprehensive knowledge base of Chrome Enterprise Premium documentation. To read authoritative technical details, exact roles, or procedures, use the **'get_document'** tool.

--- a/test/evals/cases/inspection/i13-health_check_deep_links.eval.js
+++ b/test/evals/cases/inspection/i13-health_check_deep_links.eval.js
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export default {
+  id: 'i13',
+  priority: 'P1',
+  tags: ['inspection', 'diagnose'],
+  scenario: 'download-connector-missing',
+  expectedTools: ['diagnose_environment'],
+  prompt:
+    'Run a health check on my Chrome Enterprise Premium environment and let me know how to manually configure any gaps you identify.',
+  goldenResponse:
+    'The agent should run a diagnostic check using `diagnose_environment`, identify that the file download connector is not configured, and proactively provide the direct deep-link to remediate this issue: `https://admin.google.com/ac/chrome/settings/user/details/file_downloaded`.',
+  judgeInstructions:
+    'The agent MUST run `diagnose_environment` and identify the environment gaps. When describing the missing file download connector, the agent MUST proactively provide the correct direct deep-link to the Google Admin Console for manual remediation: `https://admin.google.com/ac/chrome/settings/user/details/file_downloaded`. Failure to include the link is a FAIL.',
+}

--- a/test/local/diagnose_environment.test.js
+++ b/test/local/diagnose_environment.test.js
@@ -182,6 +182,29 @@ describe('diagnose_environment', () => {
       assert.ok(high.some(i => i.component === 'dlpRules'))
     })
 
+    test('When gaps are found in environment, then the generated issues contain Admin Console deep-links', async () => {
+      const { handler } = registerAndGetHandler({
+        connectorPolicy: [],
+        dlpRules: [],
+        securityInsights: { insightsState: 'INSIGHTS_DISABLED' },
+        resolvePolicy: [],
+      })
+      const result = await handler({ customerId: 'C0123' }, { requestInfo: {} })
+      const issues = result.structuredContent.issues
+
+      const uploadIssue = issues.find(i => i.component === 'connector.uploadAnalysis')
+      assert.ok(uploadIssue.message.includes('https://admin.google.com/ac/chrome/settings/user/details/file_attached'))
+
+      const dlpIssue = issues.find(i => i.component === 'dlpRules')
+      assert.ok(dlpIssue.message.includes('https://admin.google.com/ac/dp/rules'))
+
+      const sebIssue = issues.find(i => i.component === 'sebExtension')
+      assert.ok(sebIssue.message.includes('https://admin.google.com/ac/chrome/apps/user'))
+
+      const insightsIssue = issues.find(i => i.component === 'securityInsights')
+      assert.ok(insightsIssue.message.includes('https://admin.google.com/ac/dp'))
+    })
+
     test('When rules are audit-only, then it produces a medium issue', async () => {
       const { handler } = registerAndGetHandler({
         connectorPolicy: [{ value: {} }],

--- a/tools/definitions/diagnose_environment.js
+++ b/tools/definitions/diagnose_environment.js
@@ -79,7 +79,10 @@ function computeIssues(data) {
   }
 
   for (const [key, connector] of Object.entries(data.connectors || {})) {
-    const name = CONNECTOR_DISPLAY_NAMES[key] || key
+    if (!Object.prototype.hasOwnProperty.call(CONNECTOR_DISPLAY_NAMES, key)) {
+      continue
+    }
+    const name = CONNECTOR_DISPLAY_NAMES[key]
     const page = CONNECTOR_LINK_MAPPING[key]
     const manualLink = page ? `https://admin.google.com/ac/chrome/settings/user/details/${page}` : null
     const actionSuffix = manualLink ? `. Update settings manually at ${manualLink}` : ''

--- a/tools/definitions/diagnose_environment.js
+++ b/tools/definitions/diagnose_environment.js
@@ -69,19 +69,32 @@ function computeIssues(data) {
     })
   }
 
+  const CONNECTOR_LINK_MAPPING = {
+    uploadAnalysis: 'file_attached',
+    downloadAnalysis: 'file_downloaded',
+    pasteAnalysis: 'bulk_text_entry',
+    printAnalysis: 'print_analysis_connector',
+    realtimeUrlCheck: 'realtime_url_check',
+    securityEventReporting: 'on_security_event',
+  }
+
   for (const [key, connector] of Object.entries(data.connectors || {})) {
     const name = CONNECTOR_DISPLAY_NAMES[key] || key
+    const page = CONNECTOR_LINK_MAPPING[key]
+    const manualLink = page ? `https://admin.google.com/ac/chrome/settings/user/details/${page}` : null
+    const actionSuffix = manualLink ? `. Update settings manually at ${manualLink}` : ''
+
     if (!connector.configured) {
       issues.push({
         severity: 'critical',
         component: `connector.${key}`,
-        message: `${name} connector is not configured.`,
+        message: `${name} connector is not configured.${actionSuffix}`,
       })
     } else if (!connector.isEnabled) {
       issues.push({
         severity: 'critical',
         component: `connector.${key}`,
-        message: `${name} connector is present but explicitly disabled.`,
+        message: `${name} connector is present but explicitly disabled.${actionSuffix}`,
       })
     }
 
@@ -90,7 +103,7 @@ function computeIssues(data) {
         issues.push({
           severity: 'high',
           component: `connector.${key}`,
-          message: `${name}: ${finding.message}`,
+          message: `${name}: ${finding.message}${actionSuffix}`,
         })
       }
     }
@@ -101,27 +114,28 @@ function computeIssues(data) {
     issues.push({
       severity: 'high',
       component: 'dlpRules',
-      message: 'No DLP rules configured.',
+      message: 'No DLP rules configured. Create rules at: https://admin.google.com/ac/dp/rules',
     })
   } else {
     if (dlpRules.active === 0) {
       issues.push({
         severity: 'high',
         component: 'dlpRules',
-        message: 'All DLP rules are inactive.',
+        message: 'All DLP rules are inactive. Manage rules at: https://admin.google.com/ac/dp/rules',
       })
     } else if (dlpRules.inactive > 0) {
       issues.push({
         severity: 'medium',
         component: 'dlpRules',
-        message: `${dlpRules.inactive} DLP rule(s) are inactive.`,
+        message: `${dlpRules.inactive} DLP rule(s) are inactive. Manage rules at: https://admin.google.com/ac/dp/rules`,
       })
     }
     if (dlpRules.active > 0 && !dlpRules.hasEnforcement) {
       issues.push({
         severity: 'medium',
         component: 'dlpRules',
-        message: 'All active DLP rules are audit-only. No blocking or warning enforcement.',
+        message:
+          'All active DLP rules are audit-only. No blocking or warning enforcement. Manage rules at: https://admin.google.com/ac/dp/rules',
       })
     }
   }
@@ -130,7 +144,8 @@ function computeIssues(data) {
     issues.push({
       severity: 'high',
       component: 'sebExtension',
-      message: 'Secure Enterprise Browser (SEB) extension is not force-installed.',
+      message:
+        'Secure Enterprise Browser (SEB) extension is not force-installed. Configure it manually at https://admin.google.com/ac/chrome/apps/user',
     })
   }
 
@@ -147,7 +162,7 @@ function computeIssues(data) {
       severity: 'high',
       component: 'securityInsights',
       message:
-        'Chrome Security Insights is disabled. Threat events, file scanning, and security telemetry reporting are inactive.',
+        'Chrome Security Insights is disabled. Threat events, file scanning, and security telemetry reporting are inactive. Update settings manually at https://admin.google.com/ac/dp',
     })
   } else if (data.securityInsights?.insightsState === 'INSIGHTS_ENABLEMENT_STATE_UNSPECIFIED') {
     issues.push({


### PR DESCRIPTION
This PR addresses [issue 522428294](https://b.corp.google.com/issues/522428294) by proactively providing Google Admin Console deep-links for Chrome Enterprise connectors, DLP rules, SEB apps, and Security Insights.

### Changes:
1. **Health Check Diagnostics (`diagnose_environment.js`)**: Updated `computeIssues` to directly include manual remediation links in the computed health issue messages.
2. **Capabilities Guide (`0-agent-capabilities.md`)**: Added a dedicated reference section `### 7. Google Admin Console Deep-Links for Remediation` documenting the exact settings page deep-links.
3. **Unit Tests (`diagnose_environment.test.js`)**: Added test case checking that diagnostic issues correctly contain the deep-links.
4. **Evals case (`i13-health_check_deep_links.eval.js`)**: Added a new evaluation case mapping to the `download-connector-missing` scenario to assert that the agent can surface the correct deep-links for manual configuration gaps.