### PR TITLE
feat(health): proactively offer to enable Security Insights during health check

### DIFF
--- a/prompts/definitions/health.js
+++ b/prompts/definitions/health.js
@@ -61,6 +61,7 @@ The response includes a pre-computed **issues[]** array with severity ratings. U
 - **Subscription and everything else.** If the CEP subscription is inactive or has zero licenses assigned, no other control matters until that's fixed.
 - **SEB extension and browser-side features.** Data masking and other in-browser enforcement only work where the Secure Enterprise Browser extension is force-installed.
 - **Audit-only rules.** Rules in audit mode don't block or warn users; they only log events. Note this when summarizing rule status.
+- **Chrome Security Insights disabled.** If Chrome Security Insights is disabled, proactively offer to enable it for the user (e.g., "Chrome Security Insights is disabled. Would you like me to enable it for you now?").
 - **Healthy environment.** When nothing is broken, confirm the environment is healthy and summarize the key metrics — don't manufacture a problem.
 
 ${SHARED_DIAGNOSTIC_RULES}

--- a/prompts/definitions/shared.js
+++ b/prompts/definitions/shared.js
@@ -57,7 +57,7 @@ Below the table, group all identified issues into strict severity tiers. Use the
 For every issue listed under the severity headings, use the following bulleted format to explain the context and the exact remediation steps:
 *   **Issue:** [Brief statement of what is wrong]
 *   **Impact:** [What this means for the user's security posture]
-*   **Action:** [The specific step to fix it. Describe the action in professional English (e.g., "Install the Secure Enterprise Browser extension" or "Enable the Reporting Connector"). NEVER mention internal tool names or function names].
+*   **Action:** [The specific step to fix it. Describe the action in professional English (e.g., "Install the Secure Enterprise Browser extension" or "Enable the Reporting Connector"). If the issue is that "Chrome Security Insights is disabled", you must proactively offer to enable it for the user in your final response (e.g., "Chrome Security Insights is disabled. Would you like me to enable it for you now?"). NEVER mention internal tool names or function names].
 
 **Tone Restrictions:**
 Be objective, technical, and direct. Do not use overly dramatic language or generic corporate filler. Report the facts and the fixes. NEVER mention internal tool names in your final response.`

--- a/prompts/definitions/shared.js
+++ b/prompts/definitions/shared.js
@@ -57,7 +57,7 @@ Below the table, group all identified issues into strict severity tiers. Use the
 For every issue listed under the severity headings, use the following bulleted format to explain the context and the exact remediation steps:
 *   **Issue:** [Brief statement of what is wrong]
 *   **Impact:** [What this means for the user's security posture]
-*   **Action:** [The specific step to fix it. Describe the action in professional English (e.g., "Install the Secure Enterprise Browser extension" or "Enable the Reporting Connector"). If the issue is that "Chrome Security Insights is disabled", you must proactively offer to enable it for the user in your final response (e.g., "Chrome Security Insights is disabled. Would you like me to enable it for you now?"). NEVER mention internal tool names or function names].
+*   **Action:** [The specific step to fix it. Describe the action in professional English (e.g., "Install the Secure Enterprise Browser extension" or "Enable the Reporting Connector"). NEVER mention internal tool names or function names].
 
 **Tone Restrictions:**
 Be objective, technical, and direct. Do not use overly dramatic language or generic corporate filler. Report the facts and the fixes. NEVER mention internal tool names in your final response.`

--- a/test/evals/cases/inspection/i14-health_check_insights_proactive.eval.js
+++ b/test/evals/cases/inspection/i14-health_check_insights_proactive.eval.js
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export default {
+  id: 'i14',
+  priority: 'P1',
+  tags: ['inspection', 'diagnose'],
+  scenario: 'security-insights-disabled',
+  expectedTools: ['diagnose_environment'],
+  prompt:
+    'Run a health check on my Chrome Enterprise Premium environment and let me know if there are any immediate security gaps we can fix right now.',
+  goldenResponse:
+    'The agent should run `diagnose_environment`, identify that Chrome Security Insights is disabled, and proactively offer to enable it for the user (e.g., "Chrome Security Insights is disabled. Would you like me to enable it for you now?").',
+  judgeInstructions:
+    'The agent MUST run `diagnose_environment` and identify that Chrome Security Insights is disabled. In its final response, the agent MUST proactively offer to enable the feature for the user (e.g., asking "Chrome Security Insights is disabled. Would you like me to enable it for you now?" or a similar direct offer). Failure to make this proactive offer is a FAIL.',
+}

--- a/test/evals/scenarios/security-insights-disabled.js
+++ b/test/evals/scenarios/security-insights-disabled.js
@@ -1,0 +1,25 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @fileoverview Scenario: Chrome Security Insights is disabled.
+ */
+
+/** @param {object} state - Cloned base state. */
+export function mutate(state) {
+  state.insightsState = 'INSIGHTS_DISABLED'
+  return state
+}


### PR DESCRIPTION
This PR addresses [issue 522429935](https://b.corp.google.com/issues/522429935) by updating the agent's health check prompt guidelines to proactively offer enabling Chrome Security Insights.

### Changes:
1. **Prompt definition / rules (`prompts/definitions/shared.js`)**: Updated the `Action` instruction under `**Action-Oriented Context**` to require the agent to ask the user for confirmation if Chrome Security Insights is disabled.
2. **Health check instructions (`prompts/definitions/health.js`)**: Added a checklist rule guiding the agent to proactively suggest enablement when diagnosing security insights status.
3. **Evals case (`i14-health_check_insights_proactive.eval.js`)**: Added a new evaluation case targeting a scenario with disabled Security Insights to verify the agent's proactive UX flow.