### PR TITLE
feat(diagnose): escalate Security Insights disabled findings to critical severity

### DIFF
--- a/prompts/definitions/shared.js
+++ b/prompts/definitions/shared.js
@@ -49,7 +49,7 @@ If any data is missing because of API errors, permission blocks, or missing scop
 
 **Severity-Based Categorization**
 Below the table, group all identified issues into strict severity tiers. Use the following headings exactly:
-*   ### 🔴 CRITICAL (e.g., zero visibility, no enrollment, inactive connectors)
+*   ### 🔴 CRITICAL (e.g., zero visibility, no enrollment, inactive connectors, disabled Security Insights)
 *   ### 🟠 HIGH (e.g., missing prerequisite extensions like SEB, delayed enforcement disabled)
 *   ### 🟡 MEDIUM (e.g., missing specific rules but infrastructure is otherwise active)
 

--- a/test/local/diagnose_environment.test.js
+++ b/test/local/diagnose_environment.test.js
@@ -222,12 +222,12 @@ describe('diagnose_environment', () => {
       assert.ok(medium.length > 0)
     })
 
-    test('When Security Insights is disabled, then it produces a high issue with remediation action in summary', async () => {
+    test('When Security Insights is disabled, then it produces a critical issue with remediation action in summary', async () => {
       const { handler } = registerAndGetHandler({ securityInsights: { insightsState: 'INSIGHTS_DISABLED' } })
       const result = await handler({ customerId: 'C0123' }, { requestInfo: {} })
       const issues = result.structuredContent.issues.filter(i => i.component === 'securityInsights')
       assert.strictEqual(issues.length, 1)
-      assert.strictEqual(issues[0].severity, 'high')
+      assert.strictEqual(issues[0].severity, 'critical')
       assert.ok(result.content[0].text.includes('security_insights enable'), 'Summary should suggest enabling the tool')
     })
 

--- a/tools/definitions/diagnose_environment.js
+++ b/tools/definitions/diagnose_environment.js
@@ -78,6 +78,21 @@ function computeIssues(data) {
     securityEventReporting: 'on_security_event',
   }
 
+  if (data.securityInsights?.insightsState === 'INSIGHTS_DISABLED') {
+    issues.push({
+      severity: 'critical',
+      component: 'securityInsights',
+      message:
+        'Chrome Security Insights is disabled. Threat events, file scanning, and security telemetry reporting are inactive. Update settings manually at https://admin.google.com/ac/dp',
+    })
+  } else if (data.securityInsights?.insightsState === 'INSIGHTS_ENABLEMENT_STATE_UNSPECIFIED') {
+    issues.push({
+      severity: 'medium',
+      component: 'securityInsights',
+      message: 'Chrome Security Insights status is unspecified or could not be retrieved.',
+    })
+  }
+
   for (const [key, connector] of Object.entries(data.connectors || {})) {
     if (!Object.prototype.hasOwnProperty.call(CONNECTOR_DISPLAY_NAMES, key)) {
       continue
@@ -160,22 +175,15 @@ function computeIssues(data) {
     })
   }
 
-  if (data.securityInsights?.insightsState === 'INSIGHTS_DISABLED') {
-    issues.push({
-      severity: 'high',
-      component: 'securityInsights',
-      message:
-        'Chrome Security Insights is disabled. Threat events, file scanning, and security telemetry reporting are inactive. Update settings manually at https://admin.google.com/ac/dp',
-    })
-  } else if (data.securityInsights?.insightsState === 'INSIGHTS_ENABLEMENT_STATE_UNSPECIFIED') {
-    issues.push({
-      severity: 'medium',
-      component: 'securityInsights',
-      message: 'Chrome Security Insights status is unspecified or could not be retrieved.',
-    })
+  const SEVERITY_ORDER = {
+    critical: 0,
+    high: 1,
+    medium: 2,
   }
 
-  return issues
+  return issues.sort((a, b) => {
+    return (SEVERITY_ORDER[a.severity] ?? 99) - (SEVERITY_ORDER[b.severity] ?? 99)
+  })
 }
 
 /**
@@ -474,7 +482,7 @@ function buildSummaryResponse(env) {
     for (const issue of sc.issues) {
       const icon = issue.severity === 'critical' ? '🔴' : issue.severity === 'high' ? '🟠' : '🟡'
       let remediation = ''
-      if (issue.component === 'securityInsights' && issue.severity === 'high') {
+      if (issue.component === 'securityInsights' && issue.severity === 'critical') {
         remediation =
           ' -> Action: Use the `security_insights` tool to enable this feature (e.g. `security_insights enable`).'
       }


### PR DESCRIPTION
This PR addresses [issue 522460971](https://b.corp.google.com/issues/522460971) by escalating the severity of disabled Chrome Security Insights findings to `critical` and ensuring they are prioritized first in diagnostic check outputs.

### Changes:
1. **Tool Definition (`diagnose_environment.js`)**:
   - Escalate Security Insights disabled status from `high` to `critical`.
   - Repositioned the Security Insights check to the top section of the issues collection code and implemented sorting of `issues` by severity levels (`critical` > `high` > `medium`) to ensure `critical` findings are always presented first.
2. **Guidelines (`shared.js`)**: Updated severity categorization examples to list disabled Security Insights under CRITICAL.
3. **Unit Tests (`diagnose_environment.test.js`)**: Updated expectations to assert that Security Insights status is returned as `critical`.