### PR TITLE
ci: require at least 2 approvers for non-Googlers or non-team-members

### DIFF
--- a/.github/workflows/pr-approvals-check.yml
+++ b/.github/workflows/pr-approvals-check.yml
@@ -1,0 +1,99 @@
+name: PR Approvals Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check-approvals:
+    name: Verify PR Approvals
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check reviews
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          AUTHOR="${{ github.event.pull_request.user.login }}"
+          REPO="${{ github.repository }}"
+
+          echo "Checking approvals for PR #${PR_NUMBER} by @${AUTHOR}"
+
+          # Check if author is in google org
+          is_googler=false
+          if gh api orgs/google/members/${AUTHOR} --silence-failures >/dev/null; then
+            is_googler=true
+          fi
+
+          # Check if any commit in PR is by a google.com email
+          commit_emails=$(gh api repos/${REPO}/pulls/${PR_NUMBER}/commits --jq '.[].commit.author.email')
+          for email in $commit_emails; do
+            if [[ "$email" == *@google.com ]]; then
+              is_googler=true
+            fi
+          done
+
+          # Check if author is a collaborator/team member
+          is_team_member=false
+          if gh api repos/${REPO}/collaborators/${AUTHOR} --silence-failures >/dev/null; then
+            is_team_member=true
+          fi
+
+          echo "PR Author is Googler: ${is_googler}"
+          echo "PR Author is Team Member: ${is_team_member}"
+
+          if [ "$is_googler" = "true" ] && [ "$is_team_member" = "true" ]; then
+            required_approvals=1
+          else
+            required_approvals=2
+          fi
+
+          echo "Required approvals: ${required_approvals}"
+
+          # Fetch all reviews and get the last review status for each user
+          reviews=$(gh api repos/${REPO}/pulls/${PR_NUMBER}/reviews \
+            --jq 'group_by(.user.login) | map(last) | .[] | select(.state == "APPROVED") | .user.login' 2>/dev/null || true)
+
+          approval_count=0
+          approvers=""
+          for approver in $reviews; do
+            # The author cannot approve their own PR
+            if [ "$approver" = "$AUTHOR" ]; then
+              continue
+            fi
+
+            # Check if the approver is a collaborator or in google org
+            is_collab=false
+            if gh api repos/${REPO}/collaborators/${approver} --silence-failures >/dev/null; then
+              is_collab=true
+            fi
+
+            is_app_googler=false
+            if gh api orgs/google/members/${approver} --silence-failures >/dev/null; then
+              is_app_googler=true
+            fi
+
+            if [ "$is_collab" = "true" ] || [ "$is_app_googler" = "true" ]; then
+              approval_count=$((approval_count + 1))
+              approvers="${approvers} @${approver}"
+            fi
+          done
+
+          echo "Valid approvals found: ${approval_count} (${approvers})"
+
+          if [ $approval_count -lt $required_approvals ]; then
+            echo "::error::PR requires at least ${required_approvals} approvals from Googlers or repository team members. Found: ${approval_count} approvals."
+            exit 1
+          fi
+
+          echo "Approval check passed!"


### PR DESCRIPTION
Resolves b/522465723.

Enforces that if the PR author is a non-Googler or non-team-member of the repository, the workflow requires at least 2 approvals from Googlers or repository team members to pass. If they are both a Googler and team member, 1 approval is sufficient.

### How Googler & Team Member Status is Verified:
1. **Googler Verification:**
   - The workflow checks if the PR author is a member of the `google` GitHub organization (`gh api orgs/google/members/username`).
   - As a reliable fallback (since many Googlers keep their org membership private), the workflow also checks the commit authors' emails in the PR (`gh api repos/:owner/:repo/pulls/:number/commits`). If any of the commit emails end with `@google.com`, the user is recognized as a Googler.
2. **Team Member Verification:**
   - The workflow checks if the PR author is a collaborator with write or admin permissions in the repository (`gh api repos/:owner/:repo/collaborators/username`). If the API returns a `204 No Content` response, they are recognized as a team member of the repo.