### PR TITLE
test(evals): add security insights data telemetry evals i15 and i16

### DIFF
--- a/test/evals/cases/inspection/i15-security_insights_data.eval.js
+++ b/test/evals/cases/inspection/i15-security_insights_data.eval.js
@@ -1,0 +1,47 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export default {
+  id: 'i15',
+  priority: 'P1',
+  tags: ['inspection'],
+  scenario: 'security-insights-telemetry',
+  expectedTools: ['security_insights_data', 'get_chrome_activity_log'],
+  prompt: 'Can you tell me what urls are being visited in my domain',
+  goldenResponse:
+    'Based on the Chrome Enterprise security telemetry for your domain\n' +
+    "  (securityinsights-e2e-readonly-prod.apollo-df.dev), I've identified several categories\n" +
+    '  of URL activity being monitored and visited:\n\n' +
+    '  1. Suspicious and Unsafe Site Visits\n' +
+    '  In the last 4 weeks, there have been 8,627 suspicious URL visits recorded. The most\n' +
+    '  frequently visited suspicious domains are:\n' +
+    '   * protegotollamadummyurl-higher.com: 2,713 visits\n' +
+    '   * protegotollamadummyurl-high.com: 2,713 visits\n' +
+    '   * protegotollamadummyurl.com: 2,709 visits\n\n' +
+    '  These visits are being flagged with high, medium, and low risk levels. Detailed\n' +
+    '  activity logs show specific paths such as https://protegotollamadummyurl.com/PHISHING,\n' +
+    '  which are being detected and logged as UNSAFE_SITE_VISIT events.',
+  judgeInstructions:
+    'Verify that the agent successfully retrieves and reports the following key details:\n' +
+    '1. The domain name: securityinsights-e2e-readonly-prod.apollo-df.dev\n' +
+    '2. The total count of 8,627 suspicious URL visits.\n' +
+    '3. The top 3 suspicious domains with their exact visit counts:\n' +
+    '   - protegotollamadummyurl-higher.com (2,713 visits)\n' +
+    '   - protegotollamadummyurl-high.com (2,713 visits)\n' +
+    '   - protegotollamadummyurl.com (2,709 visits)\n' +
+    '4. The specific unsafe path (https://protegotollamadummyurl.com/PHISHING) and that it was logged as an UNSAFE_SITE_VISIT event.\n' +
+    'The agent must use both security_insights_data and get_chrome_activity_log to compile this information.',
+}

--- a/test/evals/cases/inspection/i16-security_insights_content_transfers.eval.js
+++ b/test/evals/cases/inspection/i16-security_insights_content_transfers.eval.js
@@ -1,0 +1,38 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export default {
+  id: 'i16',
+  priority: 'P1',
+  tags: ['inspection'],
+  scenario: 'security-insights-telemetry',
+  expectedTools: ['security_insights_data'],
+  prompt: 'Can you give me a summary of the content transfers in my domain?',
+  goldenResponse:
+    'Based on the security telemetry for your domain (securityinsights-e2e-readonly-prod.apollo-df.dev),\n' +
+    'there have been a total of 12,500 content transfers recorded in the last 4 weeks.\n' +
+    'Out of these, 450 transfers were flagged as containing sensitive data.\n' +
+    'The top contributors to sensitive transfers are:\n' +
+    ' - alice@securityinsights-e2e-readonly-prod.apollo-df.dev (150 transfers)\n' +
+    ' - bob@securityinsights-e2e-readonly-prod.apollo-df.dev (92 transfers)',
+  judgeInstructions:
+    'Verify that the agent successfully retrieves and reports the following key details:\n' +
+    '1. The domain name: securityinsights-e2e-readonly-prod.apollo-df.dev\n' +
+    '2. The total count of 12,500 content transfers.\n' +
+    '3. The sensitive transfers count of 450.\n' +
+    '4. The top users contributing to these transfers: alice (150) and bob (92).\n' +
+    'The agent must use the security_insights_data tool to retrieve this information.',
+}

--- a/test/evals/scenarios/security-insights-telemetry.js
+++ b/test/evals/scenarios/security-insights-telemetry.js
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @fileoverview Scenario: Chrome Security Insights telemetry data and activities.
+ */
+
+/**
+ * Mutates the base state to set up Security Insights telemetry and activities.
+ * @param {object} state - Cloned base state.
+ * @returns {object} The mutated state.
+ */
+export function mutate(state) {
+  state.insightsState = 'INSIGHTS_ENABLED'
+
+  // Set the domain to match the golden response
+  const customerId = state.defaultCustomerId
+  if (state.customers[customerId]) {
+    state.customers[customerId].customerDomain = 'securityinsights-e2e-readonly-prod.apollo-df.dev'
+  }
+
+  // Set the pre-computed telemetry data
+  state.securityInsightsData = {
+    contentTransfers: {
+      summaries: [
+        {
+          metric: 'CONTENT_TRANSFERS_METRIC_TOTAL_TRANSFERS',
+          count: '12500',
+        },
+        {
+          metric: 'CONTENT_TRANSFERS_METRIC_SENSITIVE_DATA_TRANSFERS',
+          count: '450',
+        },
+      ],
+    },
+    contentTransfersBreakdowns: {
+      contentTransfersBreakdowns: [
+        {
+          user: 'alice@securityinsights-e2e-readonly-prod.apollo-df.dev',
+          summary: { count: '150' },
+        },
+        {
+          user: 'bob@securityinsights-e2e-readonly-prod.apollo-df.dev',
+          summary: { count: '92' },
+        },
+      ],
+    },
+    urlVisits: {
+      summaries: [
+        {
+          metric: 'URL_VISITS_METRIC_TOTAL_SUSPICIOUS_URL_VISITS',
+          count: '8627',
+        },
+      ],
+    },
+    urlVisitsBreakdowns: {
+      urlVisitsBreakdowns: [
+        {
+          eventDomain: 'protegotollamadummyurl-higher.com',
+          summary: { count: '2713' },
+        },
+        {
+          eventDomain: 'protegotollamadummyurl-high.com',
+          summary: { count: '2713' },
+        },
+        {
+          eventDomain: 'protegotollamadummyurl.com',
+          summary: { count: '2709' },
+        },
+      ],
+    },
+  }
+
+  // Add the specific activity log for the unsafe site visit
+  state.activities = [
+    {
+      kind: 'admin#reports#activity',
+      id: {
+        time: '2026-04-10T14:22:00Z',
+        applicationName: 'chrome',
+        customerId: customerId,
+      },
+      actor: { email: 'user@securityinsights-e2e-readonly-prod.apollo-df.dev' },
+      events: [
+        {
+          type: 'UNSAFE_SITE_VISIT_TYPE',
+          name: 'UNSAFE_SITE_VISIT',
+          parameters: [
+            { name: 'URL', value: 'https://protegotollamadummyurl.com/PHISHING' },
+            { name: 'THREAT_TYPE', value: 'PHISHING' },
+          ],
+        },
+      ],
+    },
+  ]
+
+  return state
+}


### PR DESCRIPTION
# Commit Summary: Security Insights Data Telemetry Evals (i15 & i16)

*   **Commit Hash**: `85a2fe5a7201b17b2b51cc12fcc04a434c442437`
*   **Branch**: `security-insights-data-evals`
*   **Author**: Sahil Madeka 
*   **Message**: `test(evals): add security insights data telemetry evals i15 and i16`

---

## 📋 Overview

This commit adds two new comprehensive evaluation cases (`i15` and `i16`) to the Chrome Enterprise Premium MCP server eval suite under the `inspection` category. These evals are designed to test the agent's ability to retrieve and synthesize security telemetry using the `security_insights_data` tool and the `get_chrome_activity_log` tool. A new shared mock data scenario was also created to support both tests.

---

## 🛠️ Detailed Changes

### 1. Shared Telemetry Scenario (New File)
*   **File**: `test/evals/scenarios/security-insights-telemetry.js`
    *   Mutates the base state to simulate a healthy environment with active Chrome Security Insights.
    *   Configures the tenant domain as `securityinsights-e2e-readonly-prod.apollo-df.dev`.
    *   Mocks **URL Visits** telemetry:
        *   Total suspicious visits: **`8,627`**
        *   Breakdown domains: `protegotollamadummyurl-higher.com` (2,713), `protegotollamadummyurl-high.com` (2,713), and `protegotollamadummyurl.com` (2,709).
    *   Mocks **Content Transfers** telemetry:
        *   Total transfers: **`12,500`**
        *   Sensitive transfers: **`450`**
        *   Breakdown users: `alice` (150) and `bob` (92).
    *   Injects a specific threat activity in the log: an `UNSAFE_SITE_VISIT` event for `https://protegotollamadummyurl.com/PHISHING` by a user.

### 2. URL Visits Evaluation Case (New File)
*   **File**: `test/evals/cases/inspection/i15-security_insights_data.eval.js`
    *   **Prompt**: `"Can you tell me what urls are being visited in my domain"`
    *   **Expected Tools**: `['security_insights_data', 'get_chrome_activity_log']` (requires both telemetry and activity log queries to answer fully).
    *   **Golden Response**: Confirms the domain, reports the 8,627 suspicious visits, lists the top 3 domains with their exact counts, and details the specific `UNSAFE_SITE_VISIT` phishing path from the activity logs.
    *   **Judge Rubric**: Instructs the LLM judge to verify that the agent successfully reports all of these exact numbers, domains, and the specific threat event path.

### 3. Content Transfers Evaluation Case (New File)
*   **File**: `test/evals/cases/inspection/i16-security_insights_content_transfers.eval.js`
    *   **Prompt**: `"Can you give me a summary of the content transfers in my domain?"`
    *   **Expected Tools**: `['security_insights_data']` (only requires the telemetry tool).
    *   **Golden Response**: Reports the 12,500 total transfers, the 450 sensitive transfers, and the top 2 user contributors (`alice` with 150 and `bob` with 92).
    *   **Judge Rubric**: Instructs the LLM judge to verify the domain name, total/sensitive counts, and the top user breakdown.

---

## 🧪 Verification & Testing

To verify the correctness of the new evaluation configurations, a **dry-run validation** was conducted. The dry-run loads the new files, applies the scenario mutation, and validates the evaluation structure and golden responses without needing a live Gemini API key.

### Test Execution Command:
```bash
npx prettier --check . && npm run eval -- --id i15,i16 --dry-run