### PR TITLE
refactor: pivot cep_auth tool to Flow Singleton + Idempotency pattern

### DIFF
--- a/lib/util/credential/auth_login.js
+++ b/lib/util/credential/auth_login.js
@@ -25,8 +25,10 @@ limitations under the License.
  * stdio mode cannot do (stdin is owned by the MCP transport).
  */
 
-/* `pendingAuths` manages multi-flight authentication attempts in a Map keyed by OAuth state.
-   Any successful token exchange consumes all pending attempts. */
+/* eslint-disable require-atomic-updates */
+/* `pendingAuth` is a Flow Singleton: if a sign-in is already awaiting consent,
+   subsequent `startToolAuth` calls return the active session rather than spawning
+   redundant listeners. Successful exchange or cancellation clears the singleton. */
 
 import { randomBytes } from 'node:crypto'
 import fsSync from 'node:fs'
@@ -39,7 +41,7 @@ import { SCOPES } from '../../constants.js'
 
 const PENDING_TTL_MS = 15 * 60 * 1000
 
-const pendingAuths = new Map()
+let pendingAuth = null
 
 /**
  * @typedef {object} TokenValidity
@@ -140,6 +142,7 @@ export function canLaunchBrowser({ env = process.env, platform = process.platfor
  * @property {boolean} [browserOpened] Whether a browser process spawned successfully; present when status is 'awaiting'.
  * @property {'managed'|'custom'} [source] Which OAuth client was resolved.
  * @property {Date|null} [expiresAt] For 'completed', when the new token expires; for 'awaiting', when this pending sign-in expires.
+ * @property {'auto'|'browser'|'manual'} [authMethod] The method used to initiate the flow.
  */
 
 /**
@@ -174,6 +177,34 @@ export async function startToolAuth({
 } = {}) {
   const config = configResolver(env)
 
+  const validity = await isTokenLocallyValid({ cachePath, scopes, now: Date.now() })
+  if (validity.ok) {
+    return {
+      status: 'completed',
+      expiresAt: validity.expiresAt,
+      source: config.source,
+    }
+  }
+
+  if (pendingAuth && pendingAuth.expiresAt > Date.now()) {
+    if (authMethod === 'browser') {
+      try {
+        await openBrowser(pendingAuth.authUrl)
+      } catch {
+        /* ignore */
+      }
+    }
+    return {
+      status: 'awaiting',
+      authUrl: pendingAuth.authUrl,
+      browserAttempted: pendingAuth.browserAttempted || authMethod === 'browser',
+      browserOpened: pendingAuth.browserOpened || authMethod === 'browser',
+      source: config.source,
+      expiresAt: new Date(pendingAuth.expiresAt),
+      authMethod,
+    }
+  }
+
   const server = await startServer()
   const oauth2 = oauth2ClientFactory({
     clientId: config.clientId,
@@ -198,6 +229,9 @@ export async function startToolAuth({
     server,
     scopes,
     cachePath,
+    authUrl,
+    browserAttempted: false,
+    browserOpened: false,
     expiresAt: Date.now() + PENDING_TTL_MS,
     cancel: async () => {
       try {
@@ -207,7 +241,7 @@ export async function startToolAuth({
       }
     },
   }
-  pendingAuths.set(state, pending)
+  pendingAuth = pending
 
   let browserAttempted = false
   if (authMethod === 'browser') {
@@ -224,28 +258,33 @@ export async function startToolAuth({
       browserOpened = false
     }
   }
+  pending.browserAttempted = browserAttempted
+  pending.browserOpened = browserOpened
   // Start background exchange listener (do not await it!)
   server
     .waitForCode()
     .then(async r => {
-      if (!pendingAuths.has(state) || pendingAuths.get(state) !== pending) {
+      if (pendingAuth !== pending) {
         return
       }
       const isErr = r.error || r.state !== state || !r.code
       if (isErr) {
-        pendingAuths.delete(state)
+        pendingAuth = null
         await pending.cancel()
         return
       }
       try {
-        if (!pendingAuths.has(state) || pendingAuths.get(state) !== pending) {
+        if (pendingAuth !== pending) {
           return
         }
         await exchangeAndCache({ oauth2, code: r.code, codeVerifier, scopes, cachePath })
-        await clearAllPendingAuths()
+        if (pendingAuth === pending) {
+          pendingAuth = null
+          await pending.cancel()
+        }
       } catch (_err) {
-        if (pendingAuths.has(state) && pendingAuths.get(state) === pending) {
-          pendingAuths.delete(state)
+        if (pendingAuth === pending) {
+          pendingAuth = null
           await pending.cancel()
         }
       }
@@ -254,8 +293,8 @@ export async function startToolAuth({
   // Clean up after 15 minutes if unused
 
   setTimeout(() => {
-    if (pendingAuths.has(state) && pendingAuths.get(state) === pending) {
-      pendingAuths.delete(state)
+    if (pendingAuth === pending) {
+      pendingAuth = null
       pending.cancel()
     }
   }, PENDING_TTL_MS).unref?.()
@@ -267,6 +306,7 @@ export async function startToolAuth({
     browserOpened,
     source: config.source,
     expiresAt: new Date(pending.expiresAt),
+    authMethod,
   }
 }
 
@@ -288,7 +328,7 @@ export async function completeToolAuth({ redirectUrl, cachePath = TokenCache.def
     }
   }
 
-  if (pendingAuths.size === 0) {
+  if (!pendingAuth || pendingAuth.expiresAt <= Date.now()) {
     throw makeError('NO_PENDING_AUTH', 'No sign-in is in progress. Run the cep_auth tool with no arguments first.')
   }
   let parsed
@@ -304,9 +344,9 @@ export async function completeToolAuth({ redirectUrl, cachePath = TokenCache.def
   const returnedState = parsed.searchParams.get('state')
   const callbackError = parsed.searchParams.get('error')
   if (callbackError) {
-    if (returnedState && pendingAuths.has(returnedState)) {
-      const p = pendingAuths.get(returnedState)
-      pendingAuths.delete(returnedState)
+    if (returnedState === pendingAuth.state) {
+      const p = pendingAuth
+      pendingAuth = null
       await p.cancel()
     }
     throw mapCallbackError(callbackError)
@@ -317,21 +357,43 @@ export async function completeToolAuth({ redirectUrl, cachePath = TokenCache.def
       'No `code` parameter found in the URL. The full URL should contain `?code=...&state=...`.',
     )
   }
-  if (!returnedState || !pendingAuths.has(returnedState)) {
+  if (returnedState !== pendingAuth.state) {
     throw makeError(
       'STATE_MISMATCH',
       'State mismatch. The URL is from a different sign-in attempt. Run the cep_auth tool with no arguments to start over.',
     )
   }
-  const pending = pendingAuths.get(returnedState)
-  const tokens = await exchangeAndCache({
-    oauth2: pending.oauth2,
-    code,
-    codeVerifier: pending.codeVerifier,
-    scopes: pending.scopes,
-    cachePath: pending.cachePath,
-  })
-  await clearAllPendingAuths()
+  const pending = pendingAuth
+  let tokens
+  try {
+    tokens = await exchangeAndCache({
+      oauth2: pending.oauth2,
+      code,
+      codeVerifier: pending.codeVerifier,
+      scopes: pending.scopes,
+      cachePath: pending.cachePath,
+    })
+  } catch (err) {
+    // If the exchange fails (e.g. invalid_grant), it's possible the background
+    // loopback process won the race and already cached the tokens. Perform one
+    // last check of the cache before giving up.
+    const retry = await isTokenLocallyValid({ cachePath })
+    if (retry.ok) {
+      if (pendingAuth === pending) {
+        pendingAuth = null
+        await pending.cancel()
+      }
+      return {
+        status: 'completed',
+        expiresAt: retry.expiresAt,
+      }
+    }
+    throw err
+  }
+  if (pendingAuth === pending) {
+    pendingAuth = null
+    await pending.cancel()
+  }
   return {
     status: 'completed',
     expiresAt: tokens.expiry_date ? new Date(tokens.expiry_date) : null,
@@ -343,17 +405,10 @@ export async function completeToolAuth({ redirectUrl, cachePath = TokenCache.def
  * @returns {Promise<void>} Resolves once any in-flight pending sign-in is cancelled.
  */
 export async function _resetPendingAuthForTests() {
-  await clearAllPendingAuths()
-}
-
-/**
- * Cancels all in-flight pending sign-in sessions and clears the map.
- * @returns {Promise<void>} Resolves once all loopback servers are stopped.
- */
-async function clearAllPendingAuths() {
-  const pendingList = Array.from(pendingAuths.values())
-  pendingAuths.clear()
-  await Promise.all(pendingList.map(p => p.cancel().catch(() => {})))
+  if (pendingAuth) {
+    await pendingAuth.cancel().catch(() => {})
+    pendingAuth = null
+  }
 }
 
 /**

--- a/lib/util/credential/auth_login.js
+++ b/lib/util/credential/auth_login.js
@@ -37,7 +37,7 @@ import { resolveOAuthClientConfig } from './oauth_client_config.js'
 import { defaultOpenBrowser } from './oauth_flow.js'
 import { SCOPES } from '../../constants.js'
 
-const PENDING_TTL_MS = 5 * 60 * 1000
+const PENDING_TTL_MS = 15 * 60 * 1000
 
 const pendingAuths = new Map()
 
@@ -251,7 +251,7 @@ export async function startToolAuth({
       }
     })
     .catch(() => {}) // catch top-level unhandled rejections
-  // Clean up after 5 minutes if unused
+  // Clean up after 15 minutes if unused
 
   setTimeout(() => {
     if (pendingAuths.has(state) && pendingAuths.get(state) === pending) {

--- a/lib/util/credential/auth_login.js
+++ b/lib/util/credential/auth_login.js
@@ -25,10 +25,8 @@ limitations under the License.
  * stdio mode cannot do (stdin is owned by the MCP transport).
  */
 
-/* eslint-disable require-atomic-updates */
-/* `pendingAuth` is intentionally single-flight: a fresh `startToolAuth` replaces
-   any in-flight pending state, and `completeToolAuth` consumes it. The reassign-
-   after-await pattern that triggers this rule is the intended behavior. */
+/* `pendingAuths` manages multi-flight authentication attempts in a Map keyed by OAuth state.
+   Any successful token exchange consumes all pending attempts. */
 
 import { randomBytes } from 'node:crypto'
 import fsSync from 'node:fs'
@@ -41,7 +39,7 @@ import { SCOPES } from '../../constants.js'
 
 const PENDING_TTL_MS = 5 * 60 * 1000
 
-let pendingAuth = null
+const pendingAuths = new Map()
 
 /**
  * @typedef {object} TokenValidity
@@ -175,10 +173,6 @@ export async function startToolAuth({
   authMethod = 'auto',
 } = {}) {
   const config = configResolver(env)
-  if (pendingAuth) {
-    await pendingAuth.cancel().catch(() => {})
-    pendingAuth = null
-  }
 
   const server = await startServer()
   const oauth2 = oauth2ClientFactory({
@@ -213,7 +207,7 @@ export async function startToolAuth({
       }
     },
   }
-  pendingAuth = pending
+  pendingAuths.set(state, pending)
 
   let browserAttempted = false
   if (authMethod === 'browser') {
@@ -234,27 +228,24 @@ export async function startToolAuth({
   server
     .waitForCode()
     .then(async r => {
-      if (pendingAuth !== pending) {
+      if (!pendingAuths.has(state) || pendingAuths.get(state) !== pending) {
         return
       }
       const isErr = r.error || r.state !== state || !r.code
       if (isErr) {
-        pendingAuth = null
+        pendingAuths.delete(state)
         await pending.cancel()
         return
       }
       try {
-        if (pendingAuth !== pending) {
+        if (!pendingAuths.has(state) || pendingAuths.get(state) !== pending) {
           return
         }
         await exchangeAndCache({ oauth2, code: r.code, codeVerifier, scopes, cachePath })
-        if (pendingAuth === pending) {
-          pendingAuth = null
-          await pending.cancel()
-        }
+        await clearAllPendingAuths()
       } catch (_err) {
-        if (pendingAuth === pending) {
-          pendingAuth = null
+        if (pendingAuths.has(state) && pendingAuths.get(state) === pending) {
+          pendingAuths.delete(state)
           await pending.cancel()
         }
       }
@@ -263,8 +254,8 @@ export async function startToolAuth({
   // Clean up after 5 minutes if unused
 
   setTimeout(() => {
-    if (pendingAuth === pending) {
-      pendingAuth = null
+    if (pendingAuths.has(state) && pendingAuths.get(state) === pending) {
+      pendingAuths.delete(state)
       pending.cancel()
     }
   }, PENDING_TTL_MS).unref?.()
@@ -297,7 +288,7 @@ export async function completeToolAuth({ redirectUrl, cachePath = TokenCache.def
     }
   }
 
-  if (!pendingAuth) {
+  if (pendingAuths.size === 0) {
     throw makeError('NO_PENDING_AUTH', 'No sign-in is in progress. Run the cep_auth tool with no arguments first.')
   }
   let parsed
@@ -313,6 +304,11 @@ export async function completeToolAuth({ redirectUrl, cachePath = TokenCache.def
   const returnedState = parsed.searchParams.get('state')
   const callbackError = parsed.searchParams.get('error')
   if (callbackError) {
+    if (returnedState && pendingAuths.has(returnedState)) {
+      const p = pendingAuths.get(returnedState)
+      pendingAuths.delete(returnedState)
+      await p.cancel()
+    }
     throw mapCallbackError(callbackError)
   }
   if (!code) {
@@ -321,13 +317,13 @@ export async function completeToolAuth({ redirectUrl, cachePath = TokenCache.def
       'No `code` parameter found in the URL. The full URL should contain `?code=...&state=...`.',
     )
   }
-  if (returnedState !== pendingAuth.state) {
+  if (!returnedState || !pendingAuths.has(returnedState)) {
     throw makeError(
       'STATE_MISMATCH',
       'State mismatch. The URL is from a different sign-in attempt. Run the cep_auth tool with no arguments to start over.',
     )
   }
-  const pending = pendingAuth
+  const pending = pendingAuths.get(returnedState)
   const tokens = await exchangeAndCache({
     oauth2: pending.oauth2,
     code,
@@ -335,8 +331,7 @@ export async function completeToolAuth({ redirectUrl, cachePath = TokenCache.def
     scopes: pending.scopes,
     cachePath: pending.cachePath,
   })
-  pendingAuth = null
-  await pending.cancel()
+  await clearAllPendingAuths()
   return {
     status: 'completed',
     expiresAt: tokens.expiry_date ? new Date(tokens.expiry_date) : null,
@@ -348,10 +343,17 @@ export async function completeToolAuth({ redirectUrl, cachePath = TokenCache.def
  * @returns {Promise<void>} Resolves once any in-flight pending sign-in is cancelled.
  */
 export async function _resetPendingAuthForTests() {
-  if (pendingAuth) {
-    await pendingAuth.cancel().catch(() => {})
-    pendingAuth = null
-  }
+  await clearAllPendingAuths()
+}
+
+/**
+ * Cancels all in-flight pending sign-in sessions and clears the map.
+ * @returns {Promise<void>} Resolves once all loopback servers are stopped.
+ */
+async function clearAllPendingAuths() {
+  const pendingList = Array.from(pendingAuths.values())
+  pendingAuths.clear()
+  await Promise.all(pendingList.map(p => p.cancel().catch(() => {})))
 }
 
 /**

--- a/prompts/definitions/auth.js
+++ b/prompts/definitions/auth.js
@@ -46,6 +46,7 @@ export const registerAuthPrompt = server => {
             text: `The user wants to sign in. Call the **cep_auth** tool with no arguments to start.
 
 - If the tool returns status="completed", the access token is cached and you're done.
+- If the tool returns status="awaiting" with nextAction="complete-in-browser", inform the user that a browser tab has opened automatically and they just need to complete sign-in there. No further tool call is needed.
 - If the tool returns status="awaiting" with nextAction="paste-redirect-url", show the user the authUrl from the response, ask them to open it in a browser and complete sign-in, then ask them to paste the full URL the browser is redirected to (it looks like \`http://127.0.0.1:PORT/?code=...&state=...\` and the page may show "connection refused" — that's expected). Call **cep_auth** again with that pasted URL as the redirectUrl argument.
 - If the tool returns status="error", relay the message to the user.`,
           },

--- a/test/local/auth-tool.test.js
+++ b/test/local/auth-tool.test.js
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import assert from 'node:assert/strict'
+process.env.NO_COLOR = '1'
 import { describe, test, mock, beforeEach } from 'node:test'
 import esmock from 'esmock'
 import { cliInvocation } from '../../lib/util/cli_invocation.js'

--- a/test/local/auth-tool.test.js
+++ b/test/local/auth-tool.test.js
@@ -217,6 +217,7 @@ describe('cep_auth Tool', () => {
     const result = await handler({}, {})
 
     assert.strictEqual(result.structuredContent.status, 'awaiting')
+    assert.strictEqual(result.structuredContent.nextAction, 'complete-in-browser')
     assert.strictEqual(result.structuredContent.browserOpened, true)
     assert.match(result.content[0].text, /A browser tab should have opened/)
     assert.match(result.content[0].text, /Once you sign in and see the "Signed in" success message/)

--- a/test/local/auth_login.test.js
+++ b/test/local/auth_login.test.js
@@ -356,6 +356,55 @@ describe('startToolAuth', () => {
     assert.ok(server.wasStopped())
   })
 
+  test('When startToolAuth is called twice, both attempts remain active until one completes and cancels both', async () => {
+    const { client, calls } = makeFakeOAuth2Client()
+    let resolve1
+    const server1 = makeFakeServer({
+      codePromise: new Promise(r => {
+        resolve1 = r
+      }),
+    })
+    const server2 = makeFakeServer({ codePromise: new Promise(() => {}) })
+    let count = 0
+    const startServer = async () => (count++ === 0 ? server1 : server2)
+
+    const res1 = await startToolAuth({
+      env: { SSH_CONNECTION: 'x' },
+      browserAvailable: () => false,
+      openBrowser: async () => false,
+      startServer,
+      oauth2ClientFactory: () => client,
+      configResolver: () => FAKE_CONFIG,
+      cachePath,
+      scopes: ['scope-a'],
+    })
+    await startToolAuth({
+      env: { SSH_CONNECTION: 'x' },
+      browserAvailable: () => false,
+      openBrowser: async () => false,
+      startServer,
+      oauth2ClientFactory: () => client,
+      configResolver: () => FAKE_CONFIG,
+      cachePath,
+      scopes: ['scope-a'],
+    })
+
+    assert.strictEqual(server1.wasStopped(), false)
+    assert.strictEqual(server2.wasStopped(), false)
+
+    const state1 = new URL(res1.authUrl).searchParams.get('state')
+    resolve1({ code: 'code1', state: state1 })
+
+    await new Promise(resolve => {
+      setTimeout(resolve, 50)
+    })
+
+    assert.strictEqual(calls.getToken.length, 1)
+    assert.strictEqual(calls.getToken[0].code, 'code1')
+    assert.strictEqual(server1.wasStopped(), true)
+    assert.strictEqual(server2.wasStopped(), true)
+  })
+
   test('When startToolAuth is called with authMethod="manual", then it does not check browserAvailable or attempt browser launch', async () => {
     const { client } = makeFakeOAuth2Client()
     const server = makeFakeServer()

--- a/test/local/auth_login.test.js
+++ b/test/local/auth_login.test.js
@@ -356,14 +356,9 @@ describe('startToolAuth', () => {
     assert.ok(server.wasStopped())
   })
 
-  test('When startToolAuth is called twice, both attempts remain active until one completes and cancels both', async () => {
-    const { client, calls } = makeFakeOAuth2Client()
-    let resolve1
-    const server1 = makeFakeServer({
-      codePromise: new Promise(r => {
-        resolve1 = r
-      }),
-    })
+  test('When startToolAuth is called twice, the second invocation reuses the active in-flight singleton session', async () => {
+    const { client } = makeFakeOAuth2Client()
+    const server1 = makeFakeServer({ codePromise: new Promise(() => {}) })
     const server2 = makeFakeServer({ codePromise: new Promise(() => {}) })
     let count = 0
     const startServer = async () => (count++ === 0 ? server1 : server2)
@@ -378,7 +373,7 @@ describe('startToolAuth', () => {
       cachePath,
       scopes: ['scope-a'],
     })
-    await startToolAuth({
+    const res2 = await startToolAuth({
       env: { SSH_CONNECTION: 'x' },
       browserAvailable: () => false,
       openBrowser: async () => false,
@@ -389,20 +384,21 @@ describe('startToolAuth', () => {
       scopes: ['scope-a'],
     })
 
+    assert.strictEqual(res1.authUrl, res2.authUrl)
+    assert.strictEqual(count, 1)
     assert.strictEqual(server1.wasStopped(), false)
-    assert.strictEqual(server2.wasStopped(), false)
+  })
 
-    const state1 = new URL(res1.authUrl).searchParams.get('state')
-    resolve1({ code: 'code1', state: state1 })
+  test('When startToolAuth is called with valid tokens already cached, it returns status=completed immediately', async () => {
+    const future = Date.now() + 3600 * 1000
+    await writeCache(cachePath, { access_token: 'existing-tok', expiry_date: future })
 
-    await new Promise(resolve => {
-      setTimeout(resolve, 50)
+    const result = await startToolAuth({
+      cachePath,
+      scopes: [],
     })
 
-    assert.strictEqual(calls.getToken.length, 1)
-    assert.strictEqual(calls.getToken[0].code, 'code1')
-    assert.strictEqual(server1.wasStopped(), true)
-    assert.strictEqual(server2.wasStopped(), true)
+    assert.strictEqual(result.status, 'completed')
   })
 
   test('When startToolAuth is called with authMethod="manual", then it does not check browserAvailable or attempt browser launch', async () => {
@@ -585,6 +581,46 @@ describe('completeToolAuth', () => {
       redirectUrl: 'http://127.0.0.1:1/?code=x&state=y',
       cachePath,
     })
+    assert.strictEqual(result.status, 'completed')
+    assert.strictEqual(result.expiresAt.getTime(), future)
+  })
+  test('When getToken fails but the background process already cached the tokens, then completeToolAuth succeeds', async () => {
+    const { client } = makeFakeOAuth2Client()
+    const server = makeFakeServer({ codePromise: new Promise(() => {}) })
+
+    // Stub getToken to fail
+    client.getToken = async () => {
+      throw new Error('invalid_grant')
+    }
+
+    let capturedState
+    const captureClient = {
+      ...client,
+      generateAuthUrl(opts) {
+        capturedState = opts.state
+        return client.generateAuthUrl(opts)
+      },
+    }
+
+    await startToolAuth({
+      browserAvailable: () => true,
+      openBrowser: async () => true,
+      startServer: async () => server,
+      oauth2ClientFactory: () => captureClient,
+      configResolver: () => FAKE_CONFIG,
+      cachePath,
+    })
+
+    // Manually write to the cache to simulate background process success
+    const future = Date.now() + 3600 * 1000
+    await writeCache(cachePath, { access_token: 'background-tok', expiry_date: future })
+
+    // This should now succeed because of the retry logic
+    const result = await completeToolAuth({
+      redirectUrl: `http://127.0.0.1:1/?code=x&state=${capturedState}`,
+      cachePath,
+    })
+
     assert.strictEqual(result.status, 'completed')
     assert.strictEqual(result.expiresAt.getTime(), future)
   })

--- a/tools/definitions/auth.js
+++ b/tools/definitions/auth.js
@@ -172,6 +172,7 @@ export function registerAuthTools(server, options, sessionState) {
         'Use this tool ONLY for the CEP MCP server. The Google Workspace MCP server has its own separate auth tool—do not use this one for that. ' +
         `Requests the CEP scope set: ${scopeSummary}. ` +
         'Call with no arguments to start the sign-in. ' +
+        'If the response sets `nextAction` to `complete-in-browser`, inform the user that a browser tab has opened automatically and they just need to complete sign-in there (no further tool call is needed). ' +
         'If the response sets `nextAction` to `paste-redirect-url`, ask the user to paste the URL the browser was redirected to, then call `cep_auth` again with that string as the `redirectUrl` argument.',
       inputSchema: {
         redirectUrl: z
@@ -362,7 +363,7 @@ function awaitingResponse(result) {
     structuredContent: {
       status: 'awaiting',
       authUrl: result.authUrl,
-      nextAction: 'paste-redirect-url',
+      nextAction: result.browserOpened ? 'complete-in-browser' : 'paste-redirect-url',
       browserAttempted: result.browserAttempted,
       browserOpened: result.browserOpened,
       expiresAt,

--- a/tools/definitions/auth.js
+++ b/tools/definitions/auth.js
@@ -304,7 +304,7 @@ export function registerAuthTools(server, options, sessionState) {
 
 /**
  * Builds the "you're signed in" response.
- * @param {{expiresAt?: Date|null, source?: string}} result The completed-auth result.
+ * @param {{expiresAt?: Date|null, source?: string, authMethod?: string}} result The completed-auth result.
  * @returns {object} MCP tool response with status=completed.
  */
 function successResponse(result) {
@@ -318,7 +318,7 @@ function successResponse(result) {
 
 /**
  * Builds the "waiting on the user to paste the URL back" response.
- * @param {{authUrl: string, browserOpened: boolean, browserAttempted: boolean, expiresAt?: Date|null, source?: string}} result The awaiting-auth result.
+ * @param {{authUrl: string, browserOpened: boolean, browserAttempted: boolean, expiresAt?: Date|null, source?: string, authMethod?: string}} result The awaiting-auth result.
  * @returns {object} MCP tool response with status=awaiting and nextAction=paste-redirect-url.
  */
 function awaitingResponse(result) {
@@ -336,7 +336,11 @@ function awaitingResponse(result) {
     if (result.browserAttempted) {
       lines.push('Failed to open browser automatically. Please complete sign-in manually:')
     } else {
-      lines.push('I cannot open a browser in this environment. Please complete sign-in manually:')
+      if (result.authMethod === 'manual') {
+        lines.push('Manual authentication requested. Please complete sign-in below:')
+      } else {
+        lines.push('I cannot open a browser in this environment. Please complete sign-in manually:')
+      }
     }
     lines.push('')
     lines.push('1. Open the URL below in your local browser:')
@@ -369,6 +373,7 @@ function awaitingResponse(result) {
       expiresAt,
       source: result.source,
       agentHint,
+      authMethod: result.authMethod,
     },
   }
 }


### PR DESCRIPTION
## Motivation

The cep_auth tool implementation previously handled only one pending sign-in attempt at a time (let pendingAuth = null). If the tool was invoked while a previous sign-in attempt was still awaiting user consent, the server explicitly terminated the first session (server.stop()) and regenerated state parameters. This caused the loopback redirect to fail with "Connection Refused" or throw STATE_MISMATCH errors when pasted manually.

## Main Changes

* Flow Singleton + Idempotency: Refactored lib/util/credential/auth_login.js to replace single-flight override logic with a Flow Singleton + Idempotency pattern.
  * Idempotent Pre-flight: startToolAuth checks isTokenLocallyValid() before initiating server listeners. If valid access tokens covering the requested scopes already exist in cache, it immediately returns { status: 'completed' } and halts redundant agent retry loops.
  * Active Session Reuse: If an unexpired sign-in is already awaiting user consent, subsequent tool invocations reuse and return existing session parameters rather than killing the listener or spawning duplicate local ports and browser tabs.
  * Race-Condition Retry: Added catch logic in completeToolAuth. If getToken() fails with invalid_grant due to concurrent callback handling, it checks isTokenLocallyValid() one last time before throwing.
* Dynamic nextAction: Modified cep_auth tool response generation (tools/definitions/auth.js) so that when browserOpened is true, nextAction is set to 'complete-in-browser' rather than 'paste-redirect-url'.
* Prose & Test Hyperlink Fixes: Updated manual auth prompt messages and configured NO_COLOR = '1' in unit tests to prevent OSC 8 escape codes from breaking assertions.
* TTL: Configured pending auth timeout to 15 minutes.

## Verified

Ran npm run presubmit (Prettier checks, ESLint, unit tests, fake integration tests, smoke tests) and verified 100% passing.

TAG=agy
CONV=9f3a3935-7a19-4e51-a566-8edd72c9f6c8