### PR TITLE
docs: add nvm troubleshooting tips and time-bound research rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,3 +75,4 @@ Don't reinvent; follow the recipes that already exist:
   `npm run format && git add -A` first; lint-staged will only touch what's
   already staged.
 - **Don't bypass hooks** with `--no-verify`. If one fails, fix the cause.
+- **Time-bound research for UI elements.** When searching for UI pages, links, or documentation (e.g., DataNexus tables, Admin Console URLs), do not spend extended time or tool calls. If a UI page or element cannot be found after 2-3 quick searches, give up and leave it blank.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ gemini extensions install https://github.com/google/chrome-enterprise-premium-mc
 }
 ```
 
+> [!TIP]
+> **Using NVM or version managers?** Graphical MCP clients (like Claude Desktop or Cursor) may not inherit your shell's environment. If you get a "command not found" error for `npx` or `node`, try using the absolute path to `npx` (e.g., `/usr/local/bin/npx` or your NVM path `/Users/username/.nvm/versions/node/vXX.XX.XX/bin/npx`), or see [Troubleshooting](docs/troubleshooting.md#nodejs) for how to resolve PATH issues.
+
 ### 3. Verify
 
 Restart your MCP client, then ask the agent:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -103,6 +103,15 @@ Try these in order.
 2. **Run the client's MCP-reload command.** Some clients pick up tool registrations only after an explicit reload, even after a restart. Consult your client's documentation for the reload command.
 3. **Use absolute paths.** The `args` path in your config must be absolute. Relative paths resolve from the client's working directory, which is unpredictable.
 4. **Check that the client can find `node`.** Graphical-interface clients might not inherit your shell PATH. Try the full path to node, for example `"command": "/usr/local/bin/node"`. Find yours with `which node`.
+
+   If you use NVM or another version manager, the cleanest fix is to install a system-wide Node fallback (e.g., `sudo apt install nodejs npm` on Linux or `brew install node` on macOS). This provides a stable fallback for GUI clients while allowing you to keep using NVM in your terminal.
+
+   Alternatively, you can symlink your active NVM Node version to your local `bin` directory (note that you will need to re-run this if you delete this Node version):
+
+   ```bash
+   mkdir -p ~/bin && ln -sf $(node -e 'console.log(process.execPath)') ~/bin/node
+   ```
+
 5. **Test the server manually.** Run `npx -y @google/chrome-enterprise-premium-mcp@latest` in a terminal. The server prints `[mcp] Chrome Enterprise Premium MCP server stdio transport connected` on standard error. If you see errors, fix those first.
 
 ### Server starts but immediately exits


### PR DESCRIPTION
## Motivation
Provides documentation and path resolution guidance for GUI MCP clients (e.g. Cursor, Claude Desktop) that don't inherit shell NVM environments. Additionally, adds a steering rule to AGENTS.md for time-bound UI element research.

## Stacked PR Architecture
Stacked on top of #343 (`fix/auth-multi-flight`).
- Bottom PR: #342 (`feat/prompt-next-steps`)
- Middle PR: #343 (`fix/auth-multi-flight`)
- Top PR: #344 (this PR)