### PR TITLE
feat(Crm): Add search_organizations tool to MCP server

### DIFF
--- a/.github/expected-tarball.txt
+++ b/.github/expected-tarball.txt
@@ -98,6 +98,7 @@ tools/definitions/list_customer_profiles.js
 tools/definitions/list_detectors.js
 tools/definitions/list_dlp_rules.js
 tools/definitions/list_org_units.js
+tools/definitions/search_organizations.js
 tools/definitions/security_insights.js
 tools/definitions/security_insights_data_tool.js
 tools/definitions/shared.js

--- a/lib/api/cloud_resource_manager_client.js
+++ b/lib/api/cloud_resource_manager_client.js
@@ -52,9 +52,10 @@ export class CloudResourceManagerClient {
   }
 
   /**
-   * Searches for organizations matching the specified query.
+   * Searches for organizations matching the specified query or filter.
    * @param {object} [options] Optional parameters.
-   * @param {string} [options.query] An organizational query.
+   * @param {string} [options.filter] An organizational filter (v1 API standard).
+   * @param {string} [options.query] Legacy alias for filter.
    * @param {number} [options.pageSize] Optional page size.
    * @param {string} [options.pageToken] Optional page token.
    * @param {string} [authToken] Optional OAuth 2.0 access token.
@@ -63,12 +64,17 @@ export class CloudResourceManagerClient {
    */
   async searchOrganizations(options = {}, authToken) {
     logger.debug(`${TAGS.API} searchOrganizations called with options:`, options)
+    const { query, filter, ...rest } = options
+    const requestBody = {
+      filter: filter || query,
+      ...rest,
+    }
     const client = await this.getClient(authToken)
     try {
       const response = await callWithRetry(
         () =>
           client.organizations.search({
-            requestBody: options,
+            requestBody,
           }),
         'organizations.search',
       )

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -100,7 +100,14 @@ async function probeOAuthFlow(requiredScopes) {
  * @returns {{customerId: null, cachedRootOrgUnitId: null, pendingRule: null, history: Array}} A new session-state object with all fields zeroed.
  */
 export function createSessionState() {
-  return { customerId: null, cachedRootOrgUnitId: null, pendingRule: null, history: [] }
+  return {
+    customerId: null,
+    cachedRootOrgUnitId: null,
+    pendingRule: null,
+    organizationId: null,
+    organizationName: null,
+    history: [],
+  }
 }
 
 /**

--- a/test/evals/cases/inspection/i17-search_organizations_found.eval.js
+++ b/test/evals/cases/inspection/i17-search_organizations_found.eval.js
@@ -1,0 +1,36 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export default {
+  id: 'i17',
+  priority: 'P1',
+  tags: ['inspection', 'discovery', 'crm'],
+  scenario: 'healthy',
+  expectedTools: ['get_customer_id', 'search_organizations'],
+  forbiddenPatterns: [],
+  requiredPatterns: ['123456789', 'Test Org'],
+  prompt:
+    'Find the GCP organization associated with our Workspace account. You will need to resolve our customer ID first.',
+  goldenResponse:
+    'The agent must first call `get_customer_id` to retrieve the Workspace customer ID. ' +
+    'It must then call `search_organizations` with that resolved customer ID to find the GCP organization. ' +
+    'Finally, it should report the organization ID (123456789) and display name (Test Org) cleanly to the user, ' +
+    'and mention that the ID has been cached in the session.',
+  judgeInstructions:
+    'Verify that the agent successfully resolved the customer ID, called `search_organizations`, and ' +
+    'reported the correct GCP Organization ID (123456789) and display name (Test Org) to the user. ' +
+    'The organization ID and display name must be explicitly shown in the final response.',
+}

--- a/test/evals/cases/inspection/i18-search_organizations_missing.eval.js
+++ b/test/evals/cases/inspection/i18-search_organizations_missing.eval.js
@@ -1,0 +1,39 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export default {
+  id: 'i18',
+  priority: 'P1',
+  tags: ['inspection', 'discovery', 'crm'],
+  scenario: 'no-gcp-organization',
+  expectedTools: ['get_customer_id', 'search_organizations'],
+  forbiddenPatterns: ['123456789'], // Should not find the default org!
+  requiredPatterns: ['console.cloud.google.com', 'accepting the terms of service'],
+  prompt:
+    'Find the GCP organization associated with our Workspace account. You will need to resolve our customer ID first.',
+  goldenResponse:
+    'The agent must first call `get_customer_id` to retrieve the Workspace customer ID. ' +
+    'It must then call `search_organizations` with that resolved customer ID. ' +
+    'Since no organization is found, the agent must explicitly warn the user and suggest creating a new GCP organization, ' +
+    'relaying the message that a GCP organization does not exist for their domain yet, and they can create one by ' +
+    'navigating to https://console.cloud.google.com/ and accepting the terms of service, which is required for ' +
+    'access to Chrome Enterprise Premium features like DLP with CAA conditions and Security Gateway.',
+  judgeInstructions:
+    'Verify that the agent successfully resolved the customer ID, called `search_organizations`, and ' +
+    'upon finding no organization, explicitly prompted the user to create a GCP organization by navigating to ' +
+    'https://console.cloud.google.com/ and accepting the terms of service. ' +
+    'The response must convey that a GCP organization is required for Chrome Enterprise Premium features.',
+}

--- a/test/evals/scenarios/base-state.js
+++ b/test/evals/scenarios/base-state.js
@@ -389,6 +389,15 @@ export function getBaseState() {
       },
     },
 
+    organizations: [
+      {
+        name: 'organizations/123456789',
+        displayName: 'Test Org',
+        directoryCustomerId: defaultCustomerId,
+        state: 'ACTIVE',
+      },
+    ],
+
     serviceUsage: Object.fromEntries(Object.values(SERVICE_NAMES).map(name => [name, 'ENABLED'])),
   }
 }

--- a/test/evals/scenarios/no-gcp-organization.js
+++ b/test/evals/scenarios/no-gcp-organization.js
@@ -1,0 +1,25 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @fileoverview Scenario: no GCP organization associated with the customer.
+ */
+
+/** @param {object} state - Cloned base state. */
+export function mutate(state) {
+  state.organizations = []
+  return state
+}

--- a/test/helpers/fake-api-server.js
+++ b/test/helpers/fake-api-server.js
@@ -269,7 +269,7 @@ function getInitialState() {
       {
         name: 'organizations/123456789',
         displayName: 'Test Org',
-        directoryCustomerId: 'C0123',
+        directoryCustomerId: 'C0123456',
         state: 'ACTIVE',
       },
     ],

--- a/test/helpers/fake-api-server.js
+++ b/test/helpers/fake-api-server.js
@@ -586,16 +586,17 @@ export function createFakeApp() {
     let results = state.organizations
 
     if (activeFilter) {
-      // Simple query parsing for testing, e.g. "domain:test.com" or "directoryCustomerId:C0123"
-      const match = activeFilter.match(/(domain|directoryCustomerId):(\S+)/)
+      // Simple query parsing for testing, e.g. "domain:test.com" or "owner.directorycustomerid:C0123"
+      const match = activeFilter.match(/(domain|owner\.directorycustomerid|directorycustomerid):(\S+)/i)
       if (match) {
         const [_, key, value] = match
-        if (key === 'domain') {
+        const normalizedKey = key.toLowerCase()
+        if (normalizedKey === 'domain') {
           results = results.filter(
             org => org.displayName.toLowerCase().includes(value.toLowerCase()) || value === 'test.com',
           )
-        } else if (key === 'directoryCustomerId') {
-          results = results.filter(org => org.directoryCustomerId === value)
+        } else if (normalizedKey.includes('directorycustomerid')) {
+          results = results.filter(org => org.directoryCustomerId.toLowerCase() === value.toLowerCase())
         }
       }
     }

--- a/test/helpers/fake-api-server.js
+++ b/test/helpers/fake-api-server.js
@@ -581,12 +581,13 @@ export function createFakeApp() {
 
   // Cloud Resource Manager: Search Organizations
   app.post('/v1/organizations\\:search', (req, res) => {
-    const { query } = req.body
+    const { filter, query } = req.body
+    const activeFilter = filter || query
     let results = state.organizations
 
-    if (query) {
+    if (activeFilter) {
       // Simple query parsing for testing, e.g. "domain:test.com" or "directoryCustomerId:C0123"
-      const match = query.match(/(domain|directoryCustomerId):(\S+)/)
+      const match = activeFilter.match(/(domain|directoryCustomerId):(\S+)/)
       if (match) {
         const [_, key, value] = match
         if (key === 'domain') {

--- a/test/integration/server/mcp-server.test.js
+++ b/test/integration/server/mcp-server.test.js
@@ -103,6 +103,7 @@ describe('MCP Server in stdio mode', () => {
         'search_content',
         'list_documents',
         'get_document',
+        'search_organizations',
       ].sort(),
     )
   })

--- a/test/integration/tools/search_organizations.test.js
+++ b/test/integration/tools/search_organizations.test.js
@@ -48,9 +48,9 @@ describe('Search Organizations Tool Integration', () => {
     assert.ok(text.includes('Test Org'), `Output text: ${text}`)
     assert.ok(text.includes('123456789'), `Output text: ${text}`)
 
-    // Verify raw details in structured content
-    assert.strictEqual(details.organizations[0].displayName, 'Test Org')
-    assert.strictEqual(details.organizations[0].name, 'organizations/123456789')
+    // Verify structured content details
+    assert.strictEqual(details.organizationId, '123456789')
+    assert.strictEqual(details.organizationName, 'organizations/123456789')
 
     // Verify sessionState was updated
     assert.strictEqual(sessionState.organizationId, '123456789')

--- a/test/integration/tools/search_organizations.test.js
+++ b/test/integration/tools/search_organizations.test.js
@@ -56,22 +56,4 @@ describe('Search Organizations Tool Integration', () => {
     assert.strictEqual(sessionState.organizationId, '123456789')
     assert.strictEqual(sessionState.organizationName, 'organizations/123456789')
   })
-
-  test('When search_organizations is called without customerId, then it auto-resolves and succeeds', async () => {
-    const { client, sessionState } = harness
-
-    // Reset session state to verify auto-resolution writes to it again
-    sessionState.organizationId = null
-    sessionState.organizationName = null
-
-    const result = await client.callTool({
-      name: 'search_organizations',
-      arguments: {}, // Omit customerId
-    })
-
-    const { text } = parseToolOutput(result)
-
-    assert.ok(text.includes('Associated GCP Organization Found'), `Output text: ${text}`)
-    assert.strictEqual(sessionState.organizationId, '123456789')
-  })
 })

--- a/test/integration/tools/search_organizations.test.js
+++ b/test/integration/tools/search_organizations.test.js
@@ -1,0 +1,77 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { createIntegrationHarness, teardownIntegrationHarness } from '../../helpers/integration/tools/harness.js'
+import { parseToolOutput } from '../../helpers/integration/tools/tool_utils.js'
+
+describe('Search Organizations Tool Integration', () => {
+  let harness
+  const createdResources = []
+
+  before(async () => {
+    harness = await createIntegrationHarness()
+  })
+
+  after(async () => {
+    await teardownIntegrationHarness(harness, createdResources)
+  })
+
+  test('When search_organizations is called, then it returns the associated organization and caches it in sessionState', async () => {
+    const { client, testContext, sessionState } = harness
+
+    const result = await client.callTool({
+      name: 'search_organizations',
+      arguments: {
+        customerId: testContext.customerId,
+      },
+    })
+
+    const { text, details } = parseToolOutput(result)
+
+    // Verify output text contains key details
+    assert.ok(text.includes('Associated GCP Organization Found'), `Output text: ${text}`)
+    assert.ok(text.includes('Test Org'), `Output text: ${text}`)
+    assert.ok(text.includes('123456789'), `Output text: ${text}`)
+
+    // Verify raw details in structured content
+    assert.strictEqual(details.organizations[0].displayName, 'Test Org')
+    assert.strictEqual(details.organizations[0].name, 'organizations/123456789')
+
+    // Verify sessionState was updated
+    assert.strictEqual(sessionState.organizationId, '123456789')
+    assert.strictEqual(sessionState.organizationName, 'organizations/123456789')
+  })
+
+  test('When search_organizations is called without customerId, then it auto-resolves and succeeds', async () => {
+    const { client, sessionState } = harness
+
+    // Reset session state to verify auto-resolution writes to it again
+    sessionState.organizationId = null
+    sessionState.organizationName = null
+
+    const result = await client.callTool({
+      name: 'search_organizations',
+      arguments: {}, // Omit customerId
+    })
+
+    const { text } = parseToolOutput(result)
+
+    assert.ok(text.includes('Associated GCP Organization Found'), `Output text: ${text}`)
+    assert.strictEqual(sessionState.organizationId, '123456789')
+  })
+})

--- a/test/local/cloud_resource_manager.test.js
+++ b/test/local/cloud_resource_manager.test.js
@@ -19,7 +19,7 @@ import assert from 'node:assert/strict'
 import esmock from 'esmock'
 
 describe('CloudResourceManagerClient', () => {
-  test('When searchOrganizations is called, then it calls the googleapi search method', async () => {
+  test('When searchOrganizations is called with legacy query option, then it maps it to filter in the request body', async () => {
     const mockSearch = mock.fn(async () => ({ data: { organizations: [] } }))
     const mockCloudresourcemanager = {
       organizations: {
@@ -45,7 +45,37 @@ describe('CloudResourceManagerClient', () => {
 
     assert.strictEqual(mockSearch.mock.callCount(), 1)
     const callArgs = mockSearch.mock.calls[0].arguments[0]
-    assert.deepStrictEqual(callArgs.requestBody, options)
+    assert.deepStrictEqual(callArgs.requestBody, { filter: 'domain:test.com', pageSize: 10 })
+    assert.deepStrictEqual(result, { organizations: [] })
+  })
+
+  test('When searchOrganizations is called with filter option, then it passes it directly in the request body', async () => {
+    const mockSearch = mock.fn(async () => ({ data: { organizations: [] } }))
+    const mockCloudresourcemanager = {
+      organizations: {
+        search: mockSearch,
+      },
+    }
+
+    const { CloudResourceManagerClient } = await esmock('../../lib/api/cloud_resource_manager_client.js', {
+      '../../lib/util/api-client.js': {
+        createApiClient: async () => mockCloudresourcemanager,
+      },
+      '../../lib/util/helpers.js': {
+        callWithRetry: async fn => fn(),
+        handleApiError: err => {
+          throw err
+        },
+      },
+    })
+
+    const client = new CloudResourceManagerClient()
+    const options = { filter: 'domain:test.com', pageSize: 10 }
+    const result = await client.searchOrganizations(options, 'mock-token')
+
+    assert.strictEqual(mockSearch.mock.callCount(), 1)
+    const callArgs = mockSearch.mock.calls[0].arguments[0]
+    assert.deepStrictEqual(callArgs.requestBody, { filter: 'domain:test.com', pageSize: 10 })
     assert.deepStrictEqual(result, { organizations: [] })
   })
 })

--- a/test/local/search_organizations.test.js
+++ b/test/local/search_organizations.test.js
@@ -77,10 +77,10 @@ describe('search_organizations Tool', () => {
       { requestInfo: { headers: { authorization: 'Bearer mock-token' } } },
     )
 
-    // Verify CRM client was called with correct query
+    // Verify CRM client was called with correct filter
     assert.strictEqual(mockCrmClient.searchOrganizations.mock.callCount(), 1)
     const callArgs = mockCrmClient.searchOrganizations.mock.calls[0].arguments
-    assert.deepStrictEqual(callArgs[0], { query: 'directoryCustomerId:C012345' })
+    assert.deepStrictEqual(callArgs[0], { filter: 'owner.directorycustomerid:C012345' })
     assert.strictEqual(callArgs[1], 'mock-token')
 
     // Verify sessionState was updated
@@ -119,6 +119,6 @@ describe('search_organizations Tool', () => {
     assert.strictEqual(mockAdminSdk.getCustomerId.mock.callCount(), 1)
     assert.strictEqual(mockCrmClient.searchOrganizations.mock.callCount(), 1)
     const callArgs = mockCrmClient.searchOrganizations.mock.calls[0].arguments
-    assert.deepStrictEqual(callArgs[0], { query: 'directoryCustomerId:C012345' })
+    assert.deepStrictEqual(callArgs[0], { filter: 'owner.directorycustomerid:C012345' })
   })
 })

--- a/test/local/search_organizations.test.js
+++ b/test/local/search_organizations.test.js
@@ -1,0 +1,124 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import assert from 'node:assert/strict'
+import { describe, test, mock, beforeEach } from 'node:test'
+import { registerSearchOrganizationsTool } from '../../tools/definitions/search_organizations.js'
+
+describe('search_organizations Tool', () => {
+  let server
+  let mockCrmClient
+  let mockAdminSdk
+  let handler
+  let sessionState
+
+  beforeEach(() => {
+    server = {
+      registerTool: mock.fn(),
+    }
+
+    mockCrmClient = {
+      searchOrganizations: mock.fn(async () => ({
+        organizations: [
+          {
+            name: 'organizations/123456789',
+            displayName: 'Test Org',
+            directoryCustomerId: 'C012345',
+            state: 'ACTIVE',
+          },
+        ],
+      })),
+    }
+
+    mockAdminSdk = {
+      getCustomerId: mock.fn(async () => ({ id: 'C012345' })),
+    }
+
+    sessionState = {
+      customerId: null,
+      organizationId: null,
+      organizationName: null,
+    }
+
+    const options = {
+      cloudResourceManagerClient: mockCrmClient,
+      adminSdkClient: mockAdminSdk,
+      apiClients: {
+        adminSdk: mockAdminSdk,
+      },
+    }
+
+    registerSearchOrganizationsTool(server, options, sessionState)
+    // The handler is the 3rd argument to registerTool
+    handler = server.registerTool.mock.calls[0].arguments[2]
+  })
+
+  test('registers the search_organizations tool', () => {
+    assert.strictEqual(server.registerTool.mock.callCount(), 1)
+    assert.strictEqual(server.registerTool.mock.calls[0].arguments[0], 'search_organizations')
+  })
+
+  test('handler calls searchOrganizations and caches organization details', async () => {
+    const result = await handler(
+      { customerId: 'C012345' },
+      { requestInfo: { headers: { authorization: 'Bearer mock-token' } } },
+    )
+
+    // Verify CRM client was called with correct query
+    assert.strictEqual(mockCrmClient.searchOrganizations.mock.callCount(), 1)
+    const callArgs = mockCrmClient.searchOrganizations.mock.calls[0].arguments
+    assert.deepStrictEqual(callArgs[0], { query: 'directoryCustomerId:C012345' })
+    assert.strictEqual(callArgs[1], 'mock-token')
+
+    // Verify sessionState was updated
+    assert.strictEqual(sessionState.organizationId, '123456789')
+    assert.strictEqual(sessionState.organizationName, 'organizations/123456789')
+
+    // Verify output content
+    assert.ok(result.content[0].text.includes('Associated GCP Organization Found'))
+    assert.ok(result.content[0].text.includes('Test Org'))
+    assert.ok(result.content[0].text.includes('123456789'))
+  })
+
+  test('handler handles no organizations found gracefully', async () => {
+    // Override mock to return empty list
+    mockCrmClient.searchOrganizations = mock.fn(async () => ({
+      organizations: [],
+    }))
+
+    const result = await handler(
+      { customerId: 'C012345' },
+      { requestInfo: { headers: { authorization: 'Bearer mock-token' } } },
+    )
+
+    // Verify sessionState was NOT updated
+    assert.strictEqual(sessionState.organizationId, null)
+    assert.strictEqual(sessionState.organizationName, null)
+
+    // Verify output content
+    assert.ok(result.content[0].text.includes('No GCP organization found'))
+  })
+
+  test('handler auto-resolves customerId if omitted', async () => {
+    // If customerId is omitted, guardedToolCall should resolve it via adminSdk
+    await handler({}, { requestInfo: { headers: { authorization: 'Bearer mock-token' } } })
+
+    assert.strictEqual(mockAdminSdk.getCustomerId.mock.callCount(), 1)
+    assert.strictEqual(mockCrmClient.searchOrganizations.mock.callCount(), 1)
+    const callArgs = mockCrmClient.searchOrganizations.mock.calls[0].arguments
+    assert.deepStrictEqual(callArgs[0], { query: 'directoryCustomerId:C012345' })
+  })
+})

--- a/test/local/search_organizations.test.js
+++ b/test/local/search_organizations.test.js
@@ -111,14 +111,4 @@ describe('search_organizations Tool', () => {
     // Verify output content
     assert.ok(result.content[0].text.includes('No GCP organization found'))
   })
-
-  test('handler auto-resolves customerId if omitted', async () => {
-    // If customerId is omitted, guardedToolCall should resolve it via adminSdk
-    await handler({}, { requestInfo: { headers: { authorization: 'Bearer mock-token' } } })
-
-    assert.strictEqual(mockAdminSdk.getCustomerId.mock.callCount(), 1)
-    assert.strictEqual(mockCrmClient.searchOrganizations.mock.callCount(), 1)
-    const callArgs = mockCrmClient.searchOrganizations.mock.calls[0].arguments
-    assert.deepStrictEqual(callArgs[0], { filter: 'owner.directorycustomerid:C012345' })
-  })
 })

--- a/test/local/search_organizations.test.js
+++ b/test/local/search_organizations.test.js
@@ -91,6 +91,12 @@ describe('search_organizations Tool', () => {
     assert.ok(result.content[0].text.includes('Associated GCP Organization Found'))
     assert.ok(result.content[0].text.includes('Test Org'))
     assert.ok(result.content[0].text.includes('123456789'))
+
+    // Verify structured output content
+    assert.deepStrictEqual(result.structuredContent, {
+      organizationId: '123456789',
+      organizationName: 'organizations/123456789',
+    })
   })
 
   test('handler handles no organizations found gracefully', async () => {
@@ -109,6 +115,13 @@ describe('search_organizations Tool', () => {
     assert.strictEqual(sessionState.organizationName, null)
 
     // Verify output content
-    assert.ok(result.content[0].text.includes('No GCP organization found'))
+    assert.ok(result.content[0].text.includes('GCP Organization Not Found'))
+    assert.ok(result.content[0].text.includes('A GCP organization does not exist for your domain yet'))
+
+    // Verify structured output content
+    assert.deepStrictEqual(result.structuredContent, {
+      organizationId: null,
+      organizationName: null,
+    })
   })
 })

--- a/test/local/tool-registration.test.js
+++ b/test/local/tool-registration.test.js
@@ -49,6 +49,7 @@ const CORE_TOOLS = [
   'list_detectors',
   'list_dlp_rules',
   'list_org_units',
+  'search_organizations',
   'security_insights',
 ]
 

--- a/test/unit/mcp-server-state-isolation.test.js
+++ b/test/unit/mcp-server-state-isolation.test.js
@@ -50,6 +50,8 @@ describe('HTTP per-request session state isolation', () => {
       customerId: null,
       cachedRootOrgUnitId: null,
       pendingRule: null,
+      organizationId: null,
+      organizationName: null,
       history: [],
     })
     a.customerId = 'C0AAAAAAA'

--- a/tools/definitions/search_organizations.js
+++ b/tools/definitions/search_organizations.js
@@ -56,7 +56,7 @@ export function registerSearchOrganizationsTool(server, options, sessionState) {
 
           const result = await cloudResourceManagerClient.searchOrganizations(
             {
-              query: `directoryCustomerId:${customerId}`,
+              filter: `owner.directorycustomerid:${customerId}`,
             },
             authToken,
           )

--- a/tools/definitions/search_organizations.js
+++ b/tools/definitions/search_organizations.js
@@ -44,8 +44,11 @@ export function registerSearchOrganizationsTool(server, options, sessionState) {
       inputSchema: z.object({
         customerId: z
           .string()
-          .optional()
-          .describe('The Workspace customer ID (e.g. C012345). Defaults to "my_customer".'),
+          .describe(
+            'The Workspace customer ID (e.g. C012345) retrieved from get_customer_id. ' +
+              'Note that the literal value "my_customer" is NOT supported by the GCP CRM API; ' +
+              'you must retrieve the real customer ID first and provide it here.',
+          ),
       }),
       outputSchema: z.looseObject({}),
     },

--- a/tools/definitions/search_organizations.js
+++ b/tools/definitions/search_organizations.js
@@ -50,7 +50,23 @@ export function registerSearchOrganizationsTool(server, options, sessionState) {
               'you must retrieve the real customer ID first and provide it here.',
           ),
       }),
-      outputSchema: z.looseObject({}),
+      outputSchema: z.looseObject({
+        organizationId: z
+          .string()
+          .nullable()
+          .describe(
+            'The unique GCP Organization ID (e.g. 123456789) associated with the customer. ' +
+              'If this is empty/null, a GCP organization does not exist for this domain. ' +
+              'In this case, you MUST prompt the user with this exact message to consider creating one: ' +
+              '"A GCP organization does not exist for your domain yet, you can create one by navigating to ' +
+              'https://console.cloud.google.com/ and accepting the terms of service. Having a GCP organization ' +
+              'is required for access to Chrome Enterprise Premium features like DLP with CAA conditions and Security Gateway"',
+          ),
+        organizationName: z
+          .string()
+          .nullable()
+          .describe('The full resource name of the organization (e.g. organizations/123456789).'),
+      }),
     },
     guardedToolCall(
       {
@@ -70,10 +86,19 @@ export function registerSearchOrganizationsTool(server, options, sessionState) {
             formatFn: raw => {
               const orgs = raw?.organizations || []
               if (orgs.length === 0) {
+                const sc = {
+                  organizationId: null,
+                  organizationName: null,
+                }
+                const summary =
+                  '## GCP Organization Not Found\n\n' +
+                  'A GCP organization does not exist for your domain yet, you can create one by navigating to ' +
+                  'https://console.cloud.google.com/ and accepting the terms of service. Having a GCP organization ' +
+                  'is required for access to Chrome Enterprise Premium features like DLP with CAA conditions and Security Gateway'
                 return formatToolResponse({
-                  summary: `No GCP organization found associated with customer ID ${customerId}.`,
-                  data: raw,
-                  structuredContent: raw,
+                  summary,
+                  data: sc,
+                  structuredContent: sc,
                 })
               }
 
@@ -87,6 +112,11 @@ export function registerSearchOrganizationsTool(server, options, sessionState) {
                 logger.info(`${TAGS.MCP} Cached organizationId: ${orgId} in sessionState.`)
               }
 
+              const sc = {
+                organizationId: orgId,
+                organizationName: org.name,
+              }
+
               const summary =
                 `## Associated GCP Organization Found\n\n` +
                 `- **Display Name:** ${org.displayName}\n` +
@@ -97,8 +127,8 @@ export function registerSearchOrganizationsTool(server, options, sessionState) {
 
               return formatToolResponse({
                 summary,
-                data: raw,
-                structuredContent: raw,
+                data: sc,
+                structuredContent: sc,
               })
             },
           })

--- a/tools/definitions/search_organizations.js
+++ b/tools/definitions/search_organizations.js
@@ -1,0 +1,108 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file Tool definition for searching GCP organizations.
+ */
+
+import { z } from 'zod'
+import { guardedToolCall, formatToolResponse, safeFormatResponse } from '../utils/wrapper.js'
+import { TAGS } from '../../lib/constants.js'
+import { logger } from '../../lib/util/logger.js'
+
+/**
+ * Registers the 'search_organizations' tool with the MCP server.
+ * @param {import('@modelcontextprotocol/sdk/server/mcp.js').McpServer} server - The MCP server instance.
+ * @param {object} options - Configuration options for the tool.
+ * @param {import('../../lib/api/cloud_resource_manager_client.js').CloudResourceManagerClient} options.cloudResourceManagerClient - The CRM client instance.
+ * @param {object} sessionState - The session state object for caching.
+ * @returns {void}
+ */
+export function registerSearchOrganizationsTool(server, options, sessionState) {
+  const { cloudResourceManagerClient } = options
+  logger.debug(`${TAGS.MCP} Registering 'search_organizations' tool...`)
+
+  server.registerTool(
+    'search_organizations',
+    {
+      description:
+        'Searches for the GCP organization associated with the Workspace customer. ' +
+        'Resolves and caches the Organization ID in the session for subsequent Context-Aware Access (CAA) operations.',
+      inputSchema: z.object({
+        customerId: z
+          .string()
+          .optional()
+          .describe('The Workspace customer ID (e.g. C012345). Defaults to "my_customer".'),
+      }),
+      outputSchema: z.looseObject({}),
+    },
+    guardedToolCall(
+      {
+        handler: async ({ customerId }, { authToken }) => {
+          logger.debug(`${TAGS.MCP} Calling 'search_organizations' with customerId: ${customerId}`)
+
+          const result = await cloudResourceManagerClient.searchOrganizations(
+            {
+              query: `directoryCustomerId:${customerId}`,
+            },
+            authToken,
+          )
+
+          return safeFormatResponse({
+            rawData: result,
+            toolName: 'search_organizations',
+            formatFn: raw => {
+              const orgs = raw?.organizations || []
+              if (orgs.length === 0) {
+                return formatToolResponse({
+                  summary: `No GCP organization found associated with customer ID ${customerId}.`,
+                  data: raw,
+                  structuredContent: raw,
+                })
+              }
+
+              const org = orgs[0]
+              const orgId = org.name.split('/').pop()
+
+              // Cache in sessionState for subsequent CAA tools (e.g. creating access levels)
+              if (sessionState) {
+                sessionState.organizationId = orgId
+                sessionState.organizationName = org.name
+                logger.info(`${TAGS.MCP} Cached organizationId: ${orgId} in sessionState.`)
+              }
+
+              const summary =
+                `## Associated GCP Organization Found\n\n` +
+                `- **Display Name:** ${org.displayName}\n` +
+                `- **Resource Name:** \`${org.name}\` (ID: \`${orgId}\`)\n` +
+                `- **Customer ID:** ${org.directoryCustomerId}\n` +
+                `- **State:** ${org.state}\n\n` +
+                `The Organization ID has been cached in the session for subsequent operations.`
+
+              return formatToolResponse({
+                summary,
+                data: raw,
+                structuredContent: raw,
+              })
+            },
+          })
+        },
+      },
+      options,
+      sessionState,
+    ),
+  )
+}

--- a/tools/index.js
+++ b/tools/index.js
@@ -48,6 +48,7 @@ import { registerKnowledgeTools } from './definitions/knowledge.js'
 import { registerAuthTools } from './definitions/auth.js'
 import { registerSecurityInsightsTool } from './definitions/security_insights.js'
 import { registerSecurityInsightsDataTool } from './definitions/security_insights_data_tool.js'
+import { registerSearchOrganizationsTool } from './definitions/search_organizations.js'
 import { featureFlags, FLAGS } from '../lib/util/feature_flags.js'
 
 /**
@@ -79,6 +80,7 @@ export function registerTools(server, options = {}, sessionState) {
     chromePolicy: chromePolicyClient,
     cloudIdentity: cloudIdentityClient,
     serviceUsage: serviceUsageClient,
+    cloudResourceManager: cloudResourceManagerClient,
   } = apiClients
 
   const apiOptions = options.apiOptions || {}
@@ -124,6 +126,7 @@ export function registerTools(server, options = {}, sessionState) {
     registerCheckAndEnableCepApiTool(server, { ...commonOpts, serviceUsageClient }, state)
   }
   registerEnableChromeEnterpriseConnectorsTool(server, { ...commonOpts, chromePolicyClient }, state)
+  registerSearchOrganizationsTool(server, { ...commonOpts, cloudResourceManagerClient }, state)
 
   if (flags.isEnabled(FLAGS.DIAGNOSE_TOOL_ENABLED)) {
     logger.debug(`${TAGS.MCP} Registering diagnose tool (EXPERIMENT_DIAGNOSE_TOOL_ENABLED is active)`)


### PR DESCRIPTION
This PR adds a new tool called search_organizations which finds the GCP org for a given customer. This is then stored in the session state for tools that will require a GCP organization. If no organization is found then that member of sessionState is left empty. The output of this tool is the organization ID and name. If it is empty MCP clients are instructed to suggest to the user to create a GCP organization ID. 

## Manual test

I created a custom OAuth client as the default one does not have the cloud platform scope added yet. With the custom client I was able to get the call to work with Gemini CLI by using the prompt "can you search my organization using cep-dev?"
<img width="1918" height="895" alt="SearchOrganizationResult" src="https://github.com/user-attachments/assets/84cf5a36-4661-44d6-a9f4-749981828b5b" />
