### PR TITLE
test: hermetically sanitize custom OAuth client env vars in runners

### DIFF
--- a/test/integration/server/mcp-server.test.js
+++ b/test/integration/server/mcp-server.test.js
@@ -25,6 +25,7 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { spawnSync } from 'node:child_process'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { sanitizeOauthClientEnv } from '../../run-utils.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -39,10 +40,8 @@ describe('MCP Server in stdio mode', () => {
     transport = new StdioClientTransport({
       command: 'node',
       args: ['mcp-server.js'],
-      env: {
+      env: sanitizeOauthClientEnv({
         ...process.env,
-        CEP_OAUTH_CLIENT_ID: '',
-        CEP_OAUTH_CLIENT_SECRET: '',
         GCP_STDIO: 'true',
         EXPERIMENT_KNOWLEDGE_SEARCH_ENABLED: 'true',
         // The integration runner sets EXPERIMENT_DELETE_TOOL_ENABLED=true, but
@@ -50,7 +49,7 @@ describe('MCP Server in stdio mode', () => {
         // delete_* tools; opt this child process out so the expected list
         // matches what the parent suite registers.
         EXPERIMENT_DELETE_TOOL_ENABLED: 'false',
-      },
+      }),
     })
     client = new Client({
       name: 'test-client',

--- a/test/integration/server/mcp-server.test.js
+++ b/test/integration/server/mcp-server.test.js
@@ -41,6 +41,8 @@ describe('MCP Server in stdio mode', () => {
       args: ['mcp-server.js'],
       env: {
         ...process.env,
+        CEP_OAUTH_CLIENT_ID: '',
+        CEP_OAUTH_CLIENT_SECRET: '',
         GCP_STDIO: 'true',
         EXPERIMENT_KNOWLEDGE_SEARCH_ENABLED: 'true',
         // The integration runner sets EXPERIMENT_DELETE_TOOL_ENABLED=true, but

--- a/test/run-integration.js
+++ b/test/run-integration.js
@@ -34,7 +34,7 @@ limitations under the License.
 import { join, resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { execFileSync } from 'node:child_process'
-import { findTestFiles } from './run-utils.js'
+import { findTestFiles, sanitizeOauthClientEnv } from './run-utils.js'
 import { setupSyntheticTokenCache } from './helpers/synthetic_token_cache.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -56,8 +56,7 @@ if (backend !== 'fake' && backend !== 'real') {
 
 process.env.CEP_BACKEND = backend
 if (backend !== 'real') {
-  process.env.CEP_OAUTH_CLIENT_ID = ''
-  process.env.CEP_OAUTH_CLIENT_SECRET = ''
+  sanitizeOauthClientEnv()
 }
 
 const integrationDirs = [join(root, 'test', 'integration', 'tools'), join(root, 'test', 'integration', 'server')]

--- a/test/run-integration.js
+++ b/test/run-integration.js
@@ -55,6 +55,10 @@ if (backend !== 'fake' && backend !== 'real') {
 }
 
 process.env.CEP_BACKEND = backend
+if (backend !== 'real') {
+  process.env.CEP_OAUTH_CLIENT_ID = ''
+  process.env.CEP_OAUTH_CLIENT_SECRET = ''
+}
 
 const integrationDirs = [join(root, 'test', 'integration', 'tools'), join(root, 'test', 'integration', 'server')]
 const testFiles = integrationDirs.flatMap(dir => findTestFiles(dir)).sort()

--- a/test/run-unit.js
+++ b/test/run-unit.js
@@ -40,6 +40,8 @@ if (!process.env.CEP_LOG_LEVEL) {
 }
 
 process.env.CEP_BACKEND = 'fake'
+process.env.CEP_OAUTH_CLIENT_ID = ''
+process.env.CEP_OAUTH_CLIENT_SECRET = ''
 
 setupSyntheticTokenCache('cep-mcp-unit-home-')
 

--- a/test/run-unit.js
+++ b/test/run-unit.js
@@ -28,7 +28,7 @@ limitations under the License.
 import { join, resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { execFileSync } from 'node:child_process'
-import { findTestFiles } from './run-utils.js'
+import { findTestFiles, sanitizeOauthClientEnv } from './run-utils.js'
 import { setupSyntheticTokenCache } from './helpers/synthetic_token_cache.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -40,8 +40,7 @@ if (!process.env.CEP_LOG_LEVEL) {
 }
 
 process.env.CEP_BACKEND = 'fake'
-process.env.CEP_OAUTH_CLIENT_ID = ''
-process.env.CEP_OAUTH_CLIENT_SECRET = ''
+sanitizeOauthClientEnv()
 
 setupSyntheticTokenCache('cep-mcp-unit-home-')
 

--- a/test/run-utils.js
+++ b/test/run-utils.js
@@ -29,3 +29,15 @@ export function findTestFiles(dir) {
   }
   return results
 }
+
+/**
+ * Defensively blanks out custom OAuth client credentials to empty strings (rather than
+ * deleting them) so spawned subprocesses ignore developer .env files and host creds.
+ * @param {object} [env] - The environment object to sanitize.
+ * @returns {object} The sanitized environment object.
+ */
+export function sanitizeOauthClientEnv(env = process.env) {
+  env.CEP_OAUTH_CLIENT_ID = ''
+  env.CEP_OAUTH_CLIENT_SECRET = ''
+  return env
+}


### PR DESCRIPTION
Stops developers from seeing false test failures caused by local environment variables or `.env` files on their machine.

### Motivation
- If an engineer has `CEP_OAUTH_CLIENT_ID` and `CEP_OAUTH_CLIENT_SECRET` set in their terminal or in a local `.env` file, test server subprocesses inherit those credentials.
- This causes the server to boot in custom OAuth mode and unexpectedly register the `check_and_enable_cep_api` tool, failing stdio tool-listing test assertions.
- Blanking out these variables before running tests guarantees hermetic, consistent test results for everyone regardless of local machine configuration.

### Main Changes
- `test/run-unit.js`: Blank out custom OAuth client environment variables before running unit tests.
- `test/run-integration.js`: Blank out custom OAuth client variables before running fake integration tests (preserved for live `real` runs so engineers can still test against their BYO OAuth client projects).
- `test/integration/server/mcp-server.test.js`: Restored explicit blanking inside the `before()` hook so direct IDE test runs (`node --test ...`) remain isolated.

### Verification
- Simulated leaking `CEP_OAUTH_CLIENT_ID=leak-test` into `npm test`; confirmed all 39 integration tests pass cleanly.
- Ran full `npm run presubmit` suite (all checks pass).