### PR TITLE
feat: support test file argument forwarding in integration runner

### DIFF
--- a/test/run-integration.js
+++ b/test/run-integration.js
@@ -60,7 +60,15 @@ if (backend !== 'real') {
 }
 
 const integrationDirs = [join(root, 'test', 'integration', 'tools'), join(root, 'test', 'integration', 'server')]
-const testFiles = integrationDirs.flatMap(dir => findTestFiles(dir)).sort()
+let testFiles = []
+
+// Support running specific files passed as arguments
+const args = process.argv.slice(3)
+if (args.length > 0) {
+  testFiles = args.map(arg => resolve(root, arg))
+} else {
+  testFiles = integrationDirs.flatMap(dir => findTestFiles(dir)).sort()
+}
 
 if (testFiles.length === 0) {
   console.error('No test files found under test/integration/tools/ or test/integration/server/')


### PR DESCRIPTION
Stacked on top of #347.

Engineers debugging integration test failures can now run a single test file through the official test harness instead of running the entire integration test suite.

### Example Invocation

```bash
npm run test:integration:fake -- test/integration/server/mcp-server.test.js
```

### Motivation
- **Why running via the test runner is necessary**: Running raw `node --test path/to/file.test.js` directly in the terminal bypasses the suite bootstrap. This causes tests to fail unexpectedly due to local machine state—such as real OAuth tokens in `~/.config` or ambient developer environment variables / `.env` files leaking into child processes.
- **Why file forwarding is needed**: Previously, `npm run test:integration:fake` hardcoded running all 9 integration test files (~32s). Engineers needed a fast way to get the hermetic protection of the test runner for a single test file (~2s).

### Main Changes
- `test/run-integration.js`: Inspect `process.argv.slice(3)` for file path arguments. If provided, execute only the specified test files.

### Verification
- Ran `npm run test:integration:fake -- test/integration/tools/security_insights.test.js` (executed 1 file in 2s).
- Ran full `npm run presubmit` suite (all checks pass).