### PR TITLE
fix(eval): derive golden run comparison baseline from latest run version (#353)

### DIFF
--- a/test/evals/reporter.js
+++ b/test/evals/reporter.js
@@ -125,13 +125,12 @@ function run() {
     console.log()
   }
 
-  // 2. Golden Run Comparison
-  const goldenRunInfo = runFiles.find(runInfo => runInfo.version && runInfo.version !== currentVersion)
   const latestRunInfo = runFiles[0]
+  const goldenRunInfo = runFiles.find(runInfo => runInfo.version && runInfo.version !== latestRunInfo.version)
 
   if (latestRunInfo && goldenRunInfo) {
     console.log(`## 🏆 Golden Run Comparison`)
-    console.log(`- **Latest Run (Current Version ${currentVersion}):** ${latestRunInfo.file}`)
+    console.log(`- **Latest Run (Current Version ${latestRunInfo.version || currentVersion}):** ${latestRunInfo.file}`)
     console.log(`- **Golden Run (Previous Version ${goldenRunInfo.version}):** ${goldenRunInfo.file}\n`)
 
     try {


### PR DESCRIPTION
Fixes #353

### Summary of Changes
- In `test/evals/reporter.js`, updated `goldenRunInfo` to select a baseline relative to `latestRunInfo.version` (`runInfo.version !== latestRunInfo.version`) instead of `packageJson.version`.
- Prevents false regressions or test failures during release version bumps when evaluation artifacts for the new version do not exist yet.