### PR TITLE
fix(eval): enable security insights by default in healthy and no-detectors scenarios (b/527496693)

### DIFF
--- a/test/evals/scenarios/healthy.js
+++ b/test/evals/scenarios/healthy.js
@@ -21,7 +21,8 @@ limitations under the License.
  * the agent's behavior in a fully configured environment.
  */
 
-/** @param {object} state - Cloned base state (returned as-is). */
+/** @param {object} state - Cloned base state. */
 export function mutate(state) {
+  state.insightsState = 'INSIGHTS_ENABLED'
   return state
 }

--- a/test/evals/scenarios/no-detectors.js
+++ b/test/evals/scenarios/no-detectors.js
@@ -25,6 +25,7 @@ limitations under the License.
 
 /** @param {object} state - Cloned base state. */
 export function mutate(state) {
+  state.insightsState = 'INSIGHTS_ENABLED'
   const detectorTypes = new Set([
     'settings/detector',
     'settings/detector.regex',


### PR DESCRIPTION
Fixes b/527496693

### Summary of Changes
- In `test/evals/scenarios/healthy.js` and `test/evals/scenarios/no-detectors.js`, explicitly set `state.insightsState = 'INSIGHTS_ENABLED'`.
- Prevents `diagnose_environment` from reporting a critical finding regarding disabled Security Insights during `pr01` and `pr17` prompt evaluation runs, allowing the agent to focus on environment health baselines and detector configurations.