### PR TITLE
fix(eval): add explicit permission to m04 prompt to trigger connector enablement tool (b/527582280)

### DIFF
--- a/test/evals/cases/mutation/m04-enable_upload_connector.eval.js
+++ b/test/evals/cases/mutation/m04-enable_upload_connector.eval.js
@@ -22,7 +22,8 @@ export default {
   expectedTools: ['list_org_units', 'enable_chrome_enterprise_connectors'],
   forbiddenPatterns: [],
   requiredPatterns: [],
-  prompt: 'Enable the file-upload connector for the root organizational unit using sensible defaults.',
+  prompt:
+    'Enable the file-upload connector for the root organizational unit using sensible defaults. You have my permission to apply this change immediately.',
   goldenResponse:
     'The agent identified the root organizational unit, then called the connector enablement tool to configure the file-upload connector. It confirmed the connector is now active and briefly described what it does — scanning files users attempt to upload for policy violations — so the admin understands the change that was applied.',
   judgeInstructions: `Verify the agent actually performed the action (tool was called), not just


### PR DESCRIPTION
Fixes b/527582280

### Summary of Changes
- In `test/evals/cases/mutation/m04-enable_upload_connector.eval.js`, updated the prompt to include explicit permission (*"You have my permission to apply this change immediately."*).
- Allows the agent to execute `enable_chrome_enterprise_connectors` in single-turn benchmark evaluations without hesitating to ask for user confirmation.