### PR TITLE
feat(eval): track and report newly added evals separately in daily trend reporter (b/527926026)

### DIFF
--- a/.github/workflows/agent-evals.yml
+++ b/.github/workflows/agent-evals.yml
@@ -25,6 +25,8 @@ jobs:
       CEP_BACKEND: fake
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 24

--- a/test/evals/reporter.js
+++ b/test/evals/reporter.js
@@ -20,10 +20,53 @@ limitations under the License.
 
 import fs from 'node:fs'
 import path from 'node:path'
+import { execSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const RUNS_DIR = path.resolve(__dirname, 'runs')
+
+/**
+ * Retrieves the IDs of evaluations added in the last N days.
+ * @param {string} casesDir - Path to evals cases directory.
+ * @param {string} projectRoot - Path to git project root.
+ * @param {number} daysLimit - Number of days to look back.
+ * @returns {Set<string>} Set of new evaluation IDs.
+ */
+function getNewEvalIds(casesDir, projectRoot, daysLimit = 14) {
+  const newIds = new Set()
+  try {
+    const gitCmd = `git log --name-only --diff-filter=A --since="${daysLimit} days ago" --format="" -- "${casesDir}"`
+    const output = execSync(gitCmd, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      cwd: projectRoot,
+    }).trim()
+
+    if (!output) {
+      return newIds
+    }
+
+    const files = output.split('\n').filter(Boolean)
+    files.forEach(file => {
+      const fullPath = path.resolve(projectRoot, file)
+      if (fs.existsSync(fullPath) && fs.statSync(fullPath).isFile()) {
+        try {
+          const content = fs.readFileSync(fullPath, 'utf8')
+          const match = content.match(/id:\s*['"]([A-Za-z0-9_]+)['"]/)
+          if (match) {
+            newIds.add(match[1])
+          }
+        } catch (_err) {
+          // Ignore
+        }
+      }
+    })
+  } catch (err) {
+    console.error('Failed to check git logs for new evals:', err.message)
+  }
+  return newIds
+}
 
 // Read package.json to get version
 const packageJsonPath = path.resolve(__dirname, '../../package.json')
@@ -78,6 +121,10 @@ function run() {
   const lastRuns = runFiles.slice(0, 7)
   console.log(`Analyzing last ${lastRuns.length} run(s) from history...\n`)
 
+  const projectRoot = path.resolve(__dirname, '../..')
+  const CASES_DIR = path.resolve(__dirname, 'cases')
+  const newEvalIds = getNewEvalIds(CASES_DIR, projectRoot, 14)
+
   const failCounts = {}
   const totalCounts = {}
   const evalCategories = {}
@@ -101,7 +148,7 @@ function run() {
     }
   })
 
-  // Filter evals that failed more than 3 times
+  // Filter evals that failed more than 3 times and are not newly added
   const persistentFailures = Object.keys(failCounts)
     .map(id => ({
       id,
@@ -109,7 +156,7 @@ function run() {
       failures: failCounts[id],
       totalRuns: totalCounts[id],
     }))
-    .filter(item => item.failures > 3)
+    .filter(item => !newEvalIds.has(item.id) && item.failures > 3)
     .sort((a, b) => b.failures - a.failures)
 
   // Print persistent failures
@@ -121,6 +168,37 @@ function run() {
     console.log('| :--- | :--- | :--- | :--- |')
     persistentFailures.forEach(item => {
       console.log(`| **${item.id}** | ${item.category} | ${item.failures} | ${item.totalRuns} |`)
+    })
+    console.log()
+  }
+
+  // Print newly added evals tracking
+  console.log('## 🆕 Newly Added Evals (Last 14 days)')
+  if (newEvalIds.size === 0) {
+    console.log('No new evaluations added in the last 14 days.\n')
+  } else {
+    console.log('| Eval ID | Category | Status | Failures / Runs |')
+    console.log('| :--- | :--- | :--- | :--- |')
+
+    const sortedNewIds = Array.from(newEvalIds).sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+
+    sortedNewIds.forEach(id => {
+      const category = evalCategories[id] || 'Unknown'
+      const failures = failCounts[id] || 0
+      const totalRuns = totalCounts[id] || 0
+
+      let status = '⚪ NO RUNS'
+      if (totalRuns > 0) {
+        if (failures === 0) {
+          status = '🟢 PASS'
+        } else if (failures === totalRuns) {
+          status = '🔴 FAIL'
+        } else {
+          status = '🟡 FLAKY'
+        }
+      }
+
+      console.log(`| **${id}** | ${category} | ${status} | ${failures} / ${totalRuns} |`)
     })
     console.log()
   }

--- a/test/integration/server/eval-reporter.test.js
+++ b/test/integration/server/eval-reporter.test.js
@@ -78,6 +78,7 @@ test('Daily Trend Reporter', async t => {
     // Check golden comparison outputs
     assert.match(stdout, /Golden Run Comparison/)
     assert.match(stdout, /Golden Run \(Previous Version 1.8.0-beta\)/)
+    assert.match(stdout, /Newly Added Evals/)
 
     // Cleanup fake runs
     const files = fs.readdirSync(RUNS_DIR).filter(f => f.startsWith('run-') && f.endsWith('.json'))
@@ -119,6 +120,9 @@ test('Daily Trend Reporter', async t => {
     // Check persistent failure alert on m03
     assert.match(stdout, /Persistent Failures Alert/)
     assert.match(stdout, /m03/)
+
+    // Check newly added evals tracking
+    assert.match(stdout, /Newly Added Evals/)
 
     // Check golden comparison
     assert.match(stdout, /Golden Run Comparison/)


### PR DESCRIPTION
Fixes b/527926026

### Summary of Changes
- Updated `test/evals/reporter.js` to identify evaluations added in the last 14 days by executing `git log` to retrieve creation timestamps.
- Added a dedicated section `## 🆕 Newly Added Evals (Last 14 days)` listing all new evals with a status:
  - **PASS** (🟢): 0 failures.
  - **FAIL** (🔴): Fails in all checked runs (failures === totalRuns).
  - **FLAKY** (🟡): Fails in some runs, passes in others.
  - **NO RUNS** (⚪): Has not run in any of the checked runs.
- Excluded newly added evals from the `## ⚠️ Persistent Failures Alert` section.
- Configured checkout step in `.github/workflows/agent-evals.yml` to fetch full history (`fetch-depth: 0`) so `git log` has access to creation metadata.
- Updated `test/integration/server/eval-reporter.test.js` to assert presence of the new section.