### PR TITLE
ci: add PR eval presubmit check with 80% pass rate threshold

### DIFF
--- a/.github/workflows/pr-evals.yml
+++ b/.github/workflows/pr-evals.yml
@@ -1,12 +1,6 @@
 name: PR Eval Check
 
 on:
-  push:
-    branches:
-      - 'ci/**'
-    paths:
-      - 'test/evals/cases/**/*.eval.js'
-      - '.github/workflows/pr-evals.yml'
   pull_request:
     branches: [main]
     paths:

--- a/.github/workflows/pr-evals.yml
+++ b/.github/workflows/pr-evals.yml
@@ -1,6 +1,12 @@
 name: PR Eval Check
 
 on:
+  push:
+    branches:
+      - 'ci/**'
+    paths:
+      - 'test/evals/cases/**/*.eval.js'
+      - '.github/workflows/pr-evals.yml'
   pull_request:
     branches: [main]
     paths:
@@ -31,8 +37,12 @@ jobs:
       - name: Identify changed eval cases
         id: changed
         run: |
-          git fetch origin "${{ github.base_ref }}" --depth=1 || true
-          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- "test/evals/cases/**/*.eval.js" || true)
+          BASE_BRANCH="${{ github.base_ref }}"
+          if [ -z "$BASE_BRANCH" ]; then
+            BASE_BRANCH="main"
+          fi
+          git fetch origin "$BASE_BRANCH" --depth=1 || true
+          CHANGED_FILES=$(git diff --name-only origin/$BASE_BRANCH...HEAD -- "test/evals/cases/**/*.eval.js" || true)
           if [ -z "$CHANGED_FILES" ]; then
             echo "No eval cases added or modified in this PR."
             echo "ids=" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-evals.yml
+++ b/.github/workflows/pr-evals.yml
@@ -1,0 +1,79 @@
+name: PR Eval Check
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'test/evals/cases/**/*.eval.js'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pr-evals:
+    name: 🤖 PR Eval Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+
+      - name: Identify changed eval cases
+        id: changed
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=1 || true
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- "test/evals/cases/**/*.eval.js" || true)
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No eval cases added or modified in this PR."
+            echo "ids=" >> "$GITHUB_OUTPUT"
+          else
+            EVAL_IDS=$(echo "$CHANGED_FILES" | sed -E 's/.*\/([a-zA-Z0-9_]+)-.*/\1/' | sort -u | paste -sd, -)
+            echo "Changed eval IDs: $EVAL_IDS"
+            echo "ids=$EVAL_IDS" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run changed evals (Dry-run / syntax check)
+        if: steps.changed.outputs.ids != '' && env.GEMINI_API_KEY == ''
+        env:
+          CEP_BACKEND: fake
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          echo "GEMINI_API_KEY is not set (likely an external fork PR)."
+          echo "Running deterministic dry-run check against golden responses..."
+          node test/evals/run.js --id "${{ steps.changed.outputs.ids }}" --dry-run
+
+      - name: Run changed evals (Full agent + judge)
+        if: steps.changed.outputs.ids != '' && env.GEMINI_API_KEY != ''
+        env:
+          CEP_BACKEND: fake
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          echo "Running 5 runs per changed eval case..."
+          node test/evals/run.js --id "${{ steps.changed.outputs.ids }}" --runs 5 --output pr-evals.json || true
+          node -e '
+            const fs = require("node:fs");
+            if (!fs.existsSync("pr-evals.json")) {
+              console.error("::error::pr-evals.json was not generated!");
+              process.exit(1);
+            }
+            const res = JSON.parse(fs.readFileSync("pr-evals.json", "utf8"));
+            let failed = false;
+            for (const e of res.evaluations) {
+              console.log(`Eval ${e.id} pass rate: ${e.passRate}% (${e.passed}/${e.total})`);
+              if (e.passRate < 80) {
+                console.error(`::error::Eval ${e.id} pass rate (${e.passRate}%) is below required 80% threshold!`);
+                failed = true;
+              }
+            }
+            if (failed) process.exit(1);
+          '


### PR DESCRIPTION
### Motivation
Currently, agent evals only run on a daily scheduled cron job. When a contributor adds or modifies an eval case, there is no automated presubmit verification on the pull request, creating a risk that broken or flaky evals land in `main`.

### Main Changes
* Added `.github/workflows/pr-evals.yml` to automatically trigger when files under `test/evals/cases/` change in a Pull Request targeting `main`.
* Uses `git diff --name-only` against the PR base branch to dynamically identify only the specific `.eval.js` files modified or added by the PR.
* Executes 5 evaluation runs (`--runs 5`) per changed eval case and parses the generated `pr-evals.json` report to enforce an **80% pass rate threshold** (at least 4 out of 5 runs passing).

### Testing
Verified live in GitHub Actions using a stacked test branch containing a deliberately broken eval case (`i19` with an impossible required string pattern). The workflow correctly identified the changed eval file, executed 5 runs, detected the 0% pass rate, and failed the status check with exit code 1 as required:
* Live verification run: https://github.com/google/chrome-enterprise-premium-mcp/actions/runs/28467964537

### Design Decisions
* **Fork vs. Internal PR Handling**: GitHub Actions strips repository secrets (like `GEMINI_API_KEY`) from `pull_request` workflows originating from external forks. The workflow checks for secret availability: if `GEMINI_API_KEY` is present (internal PRs), it runs the full 5-run agent+judge suite; if missing (external forks), it automatically falls back to `--dry-run` mode to validate config syntax and deterministic checks without failing on auth.
* **Inline Threshold Parsing**: Because `test/evals/run.js` natively exits with code 1 if *any* single run fails, we execute it with `|| true` and use a short inline Node script to verify `e.passRate < 80`, allowing minor transient LLM flakiness without failing the CI check.

TAG=agy
CONV=a699777c-978b-40ae-a24d-9847b07c0ae4
