### PR TITLE
test(evals): add broken i19 eval to test PR presubmit threshold

### DIFF
--- a/.github/workflows/pr-evals.yml
+++ b/.github/workflows/pr-evals.yml
@@ -1,6 +1,12 @@
 name: PR Eval Check
 
 on:
+  push:
+    branches:
+      - 'ci/**'
+    paths:
+      - 'test/evals/cases/**/*.eval.js'
+      - '.github/workflows/pr-evals.yml'
   pull_request:
     branches: [main]
     paths:
@@ -31,8 +37,12 @@ jobs:
       - name: Identify changed eval cases
         id: changed
         run: |
-          git fetch origin "${{ github.base_ref }}" --depth=1 || true
-          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- "test/evals/cases/**/*.eval.js" || true)
+          BASE_BRANCH="${{ github.base_ref }}"
+          if [ -z "$BASE_BRANCH" ]; then
+            BASE_BRANCH="main"
+          fi
+          git fetch origin "$BASE_BRANCH" --depth=1 || true
+          CHANGED_FILES=$(git diff --name-only origin/$BASE_BRANCH...HEAD -- "test/evals/cases/**/*.eval.js" || true)
           if [ -z "$CHANGED_FILES" ]; then
             echo "No eval cases added or modified in this PR."
             echo "ids=" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-evals.yml
+++ b/.github/workflows/pr-evals.yml
@@ -1,0 +1,79 @@
+name: PR Eval Check
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'test/evals/cases/**/*.eval.js'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pr-evals:
+    name: 🤖 PR Eval Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+
+      - name: Identify changed eval cases
+        id: changed
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=1 || true
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- "test/evals/cases/**/*.eval.js" || true)
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No eval cases added or modified in this PR."
+            echo "ids=" >> "$GITHUB_OUTPUT"
+          else
+            EVAL_IDS=$(echo "$CHANGED_FILES" | sed -E 's/.*\/([a-zA-Z0-9_]+)-.*/\1/' | sort -u | paste -sd, -)
+            echo "Changed eval IDs: $EVAL_IDS"
+            echo "ids=$EVAL_IDS" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run changed evals (Dry-run / syntax check)
+        if: steps.changed.outputs.ids != '' && env.GEMINI_API_KEY == ''
+        env:
+          CEP_BACKEND: fake
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          echo "GEMINI_API_KEY is not set (likely an external fork PR)."
+          echo "Running deterministic dry-run check against golden responses..."
+          node test/evals/run.js --id "${{ steps.changed.outputs.ids }}" --dry-run
+
+      - name: Run changed evals (Full agent + judge)
+        if: steps.changed.outputs.ids != '' && env.GEMINI_API_KEY != ''
+        env:
+          CEP_BACKEND: fake
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          echo "Running 5 runs per changed eval case..."
+          node test/evals/run.js --id "${{ steps.changed.outputs.ids }}" --runs 5 --output pr-evals.json || true
+          node -e '
+            const fs = require("node:fs");
+            if (!fs.existsSync("pr-evals.json")) {
+              console.error("::error::pr-evals.json was not generated!");
+              process.exit(1);
+            }
+            const res = JSON.parse(fs.readFileSync("pr-evals.json", "utf8"));
+            let failed = false;
+            for (const e of res.evaluations) {
+              console.log(`Eval ${e.id} pass rate: ${e.passRate}% (${e.passed}/${e.total})`);
+              if (e.passRate < 80) {
+                console.error(`::error::Eval ${e.id} pass rate (${e.passRate}%) is below required 80% threshold!`);
+                failed = true;
+              }
+            }
+            if (failed) process.exit(1);
+          '

--- a/test/evals/cases/inspection/i19-search_organizations_verify.eval.js
+++ b/test/evals/cases/inspection/i19-search_organizations_verify.eval.js
@@ -1,0 +1,35 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export default {
+  id: 'i19',
+  priority: 'P1',
+  tags: ['inspection', 'discovery', 'crm'],
+  scenario: 'healthy',
+  expectedTools: ['get_customer_id', 'search_organizations'],
+  forbiddenPatterns: [],
+  requiredPatterns: ['123456789', 'Test Org', 'IMPOSSIBLE_STRING_THAT_WILL_NEVER_APPEAR_9999'],
+  prompt:
+    'Find the Google Cloud organization associated with our Workspace account and show its display name and ID. You will need to resolve our customer ID first.',
+  goldenResponse:
+    'The agent must first call `get_customer_id` to retrieve the Workspace customer ID. ' +
+    'It must then call `search_organizations` with that resolved customer ID to find the GCP organization. ' +
+    'Finally, it should report the organization ID (123456789) and display name (Test Org) cleanly to the user.',
+  judgeInstructions:
+    'Verify that the agent successfully resolved the customer ID, called `search_organizations`, and ' +
+    'reported the correct GCP Organization ID (123456789) and display name (Test Org) to the user. ' +
+    'Both pieces of information must be clearly presented in the response.',
+}


### PR DESCRIPTION
Stacked on top of #363 (`ci/pr-eval-presubmit`).

### Motivation
Demonstrate and verify that our new PR eval presubmit workflow (`.github/workflows/pr-evals.yml`) correctly detects modified eval cases, executes 5 evaluation runs, and blocks merging when an eval fails to achieve the required 80% pass rate threshold.

### Main Changes
* Added `test/evals/cases/inspection/i19-search_organizations_verify.eval.js` with an impossible required string pattern (`IMPOSSIBLE_STRING_THAT_WILL_NEVER_APPEAR_9999`).

### Non-Trivial Design Decisions
* **Deterministic Failure Verification**: By including an impossible string pattern in `requiredPatterns`, we guarantee that `i19` fails deterministically across all 5 runs (0% pass rate), confirming that our inline GitHub Actions script catches pass rates below 80% and exits with status 1.

TAG=agy
CONV=a699777c-978b-40ae-a24d-9847b07c0ae4
