### PR TITLE
fix(eval): resolve connector validation issues in healthy base scenario (b/527496693)

### DIFF
--- a/test/evals/scenarios/base-state.js
+++ b/test/evals/scenarios/base-state.js
@@ -229,7 +229,7 @@ export function getBaseState() {
               onBulkTextEntryAnalysisConnectorConfiguration: {
                 bulkTextEntryConfiguration: {
                   serviceProvider: 'SERVICE_PROVIDER_CHROME_ENTERPRISE_PREMIUM',
-                  delayDeliveryUntilVerdict: false,
+                  delayDeliveryUntilVerdict: true,
                 },
               },
             },
@@ -280,6 +280,8 @@ export function getBaseState() {
                     'sensitiveDataEvent',
                     'urlFilteringInterstitialEvent',
                     'suspiciousUrlEvent',
+                    'unscannedFileEvent',
+                    'interstitialEvent',
                   ],
                 },
               },


### PR DESCRIPTION
Sets delayDeliveryUntilVerdict to true for the bulk text entry connector and adds the missing core reporting events (unscannedFileEvent and interstitialEvent) to the default base state in base-state.js. This ensures that the healthy scenario does not report false-positive High severity issues, preventing failures in pr01 and pr17.