### PR TITLE
feat(tools): add total browser count to count_browser_versions tool

### DIFF
--- a/test/evals/cases/inspection/i17-browser_and_profile_counts.eval.js
+++ b/test/evals/cases/inspection/i17-browser_and_profile_counts.eval.js
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export default {
+  id: 'i17',
+  priority: 'P1',
+  tags: ['inspection', 'browsers', 'profiles'],
+  scenario: 'healthy',
+  expectedTools: ['count_browser_versions', 'list_customer_profiles'],
+  prompt:
+    'Please report two metrics for my organization: 1) How many total Chrome browsers are deployed (check browser versions), and 2) How many total Chrome browser profiles are managed?',
+  goldenResponse:
+    'Agent should invoke count_browser_versions and list_customer_profiles and clearly report 89 total managed browsers (across 3 version buckets) and 3 managed browser profiles.',
+  judgeInstructions:
+    'The agent must explicitly report the total number of managed browsers (89) AND the total number of managed profiles (3). If the agent confuses the number of version buckets (3) with the total browser count, or fails to report the profile count, grade as FAIL.',
+}

--- a/test/evals/cases/inspection/i19-browser_and_profile_counts.eval.js
+++ b/test/evals/cases/inspection/i19-browser_and_profile_counts.eval.js
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 export default {
-  id: 'i17',
+  id: 'i19',
   priority: 'P1',
   tags: ['inspection', 'browsers', 'profiles'],
   scenario: 'healthy',

--- a/test/evals/scenarios/base-state.js
+++ b/test/evals/scenarios/base-state.js
@@ -362,7 +362,29 @@ export function getBaseState() {
       { version: '136.0.7100.3', count: '2', channel: 'CANARY' },
     ],
 
-    profiles: [],
+    profiles: [
+      {
+        name: `customers/${defaultCustomerId}/profiles/p1`,
+        displayName: 'Engineering Profile 1',
+        userEmail: 'alice@example.com',
+        osPlatformType: 'MAC',
+        osVersion: '14.2',
+      },
+      {
+        name: `customers/${defaultCustomerId}/profiles/p2`,
+        displayName: 'Engineering Profile 2',
+        userEmail: 'bob@example.com',
+        osPlatformType: 'LINUX',
+        osVersion: '6.5',
+      },
+      {
+        name: `customers/${defaultCustomerId}/profiles/p3`,
+        displayName: 'Sales Profile 1',
+        userEmail: 'carol@example.com',
+        osPlatformType: 'WINDOWS',
+        osVersion: '11',
+      },
+    ],
 
     licenses: {
       [defaultCustomerId]: {

--- a/test/local/chromemanagement.test.js
+++ b/test/local/chromemanagement.test.js
@@ -61,9 +61,39 @@ describe('Chrome Management API', () => {
       )
 
       assert.strictEqual(mockCountBrowserVersions.mock.callCount(), 1)
-      assert.ok(result.content[0].text.includes('## Browser Versions (2)'))
+      assert.ok(result.content[0].text.includes('Total Browsers: 15 across 2 version buckets'))
       assert.ok(result.content[0].text.includes('**120.0.6099.71**'))
       assert.ok(result.content[1].text.includes('```json'))
+      assert.ok(result.content[1].text.includes('"totalCount": 15'))
+    })
+
+    test('When no versions found, then it returns 0 totalCount', async () => {
+      const mockCountBrowserVersions = mock.fn(async () => [])
+      const MockChromeManagementClient = class {
+        constructor() {
+          this.countBrowserVersions = mockCountBrowserVersions
+        }
+      }
+
+      const { registerTools } = await esmock(
+        '../../tools/index.js',
+        {},
+        {
+          '../../lib/api/chrome_management_client.js': {
+            ChromeManagementClient: MockChromeManagementClient,
+          },
+        },
+      )
+      registerTools(server, {
+        apiClients: { chromeManagement: new MockChromeManagementClient() },
+      })
+
+      const handler = server.registerTool.mock.calls.find(call => call.arguments[0] === 'count_browser_versions')
+        .arguments[2]
+
+      const result = await handler({ project: 'test-project', customerId: 'C0123' }, {})
+      assert.ok(result.content[0].text.includes('No browser versions found'))
+      assert.ok(result.content[1].text.includes('"totalCount": 0'))
     })
 
     // Test error handling when the API call fails.

--- a/tools/definitions/count_browser_versions.js
+++ b/tools/definitions/count_browser_versions.js
@@ -47,6 +47,7 @@ Use this for auditing and reporting on the distribution of browser versions acro
       },
       outputSchema: z.looseObject({
         versions: z.array(commonOutputSchemas.browserVersion),
+        totalCount: z.number(),
       }),
     },
     guardedToolCall(
@@ -62,7 +63,7 @@ Use this for auditing and reporting on the distribution of browser versions acro
             toolName: 'count_browser_versions',
             formatFn: raw => {
               if (!raw || raw.length === 0) {
-                const sc = { versions: [] }
+                const sc = { versions: [], totalCount: 0 }
                 return formatToolResponse({
                   summary: `No browser versions found for customer ${customerId}.`,
                   data: sc,
@@ -76,13 +77,15 @@ Use this for auditing and reporting on the distribution of browser versions acro
                 count: v.count ? Number(v.count) : 0,
               }))
 
+              const totalCount = coerced.reduce((sum, v) => sum + v.count, 0)
+
               const versionList = coerced
                 .map(v => `- **${v.version}** — count: ${v.count}, channel: ${v.channel || 'UNKNOWN'}`)
                 .join('\n')
 
-              const sc = { versions: coerced }
+              const sc = { versions: coerced, totalCount }
               return formatToolResponse({
-                summary: `## Browser Versions (${coerced.length})\n\n${versionList}`,
+                summary: `## Browser Versions (Total Browsers: ${totalCount} across ${coerced.length} version buckets)\n\n${versionList}`,
                 data: sc,
                 structuredContent: sc,
               })


### PR DESCRIPTION
feat(tools): add total browser count to count_browser_versions tool

Motivation:

When listing profiles (list_customer_profiles), the tool automatically calculates and returns `totalCount: data.length`. However, when counting browser versions (count_browser_versions), the tool previously only returned the individual version distribution buckets without calculating the sum. This forced agents to perform arithmetic in text, which can lead to calculation errors across large numbers of version buckets.

Main Changes:
- Updated `tools/definitions/count_browser_versions.js` to sum `.count` across all returned version buckets to compute `totalCount`.
- Formatted the summary header to clearly display the total managed browser count (e.g., `## Browser Versions (Total Browsers: X across Y version buckets)`).

TAG=agy
CONV=56e2c392-e9ca-4124-bc4c-cc60615bd657
