### PR TITLE
docs: update knowledge article to cite security_insights_data tool 

### DIFF
--- a/lib/knowledge/31-security-insights-data.md
+++ b/lib/knowledge/31-security-insights-data.md
@@ -6,16 +6,18 @@ summary: 'Guide to querying Chrome Enterprise Security Insights data. Covers met
 
 # Querying Security Insights Data
 
-The `SecurityInsightsService` `Query*` methods provide aggregated data about user activities related to content movement and website visits. The agent can analyze this data to identify potential security risks and areas where Data Loss Prevention (DLP) rules could be effectively applied to enhance data protection.
+To query Chrome Enterprise Security Insights data, call the `security_insights_data` tool with the corresponding query name as the `action` parameter. The agent can analyze this data to identify potential security risks and areas where Data Loss Prevention (DLP) rules could be effectively applied to enhance data protection.
 
-## 1. QueryContentTransfers
+## 1. queryContentTransfers
 
+- **Action**: `queryContentTransfers`
 - **Insight for DLP**: Provides the agent with a high-level, organization-wide summary of content transfer volumes (uploads, downloads, prints), distinguishing between total and sensitive data.
 - **Use Case**: The agent can use this data to baseline data movement and flag significant increases in sensitive data transfers, indicating a potential need for broader DLP controls.
 - **DLP Suggestion**: If the agent observes high sensitive data transfer volumes, it can suggest implementing foundational DLP rules, such as auditing or warning on the transfer of data matching common sensitive information types.
 
-## 2. QueryContentTransfersBreakdowns
+## 2. queryContentTransfersBreakdowns
 
+- **Action**: `queryContentTransfersBreakdowns`
 - **Insight for DLP**: Allows the agent to perform a granular analysis of content transfers, broken down by User, Event Domain, or Content Category for a specific metric.
 - **Use Case**: The agent can pinpoint specific sources of risk:
   - **USER**: The agent can identify individuals or roles with high-volume sensitive data transfers.
@@ -26,15 +28,17 @@ The `SecurityInsightsService` `Query*` methods provide aggregated data about use
   - For risky domains: The agent can recommend DLP rules to block or warn on transfers to these specific domains.
   - For common content categories: The agent can suggest enabling and configuring relevant DLP detectors.
 
-## 3. QueryUrlVisits
+## 3. queryUrlVisits
 
+- **Action**: `queryUrlVisits`
 - **Subscription**: Requires Chrome Enterprise Premium.
 - **Insight for Security Posture**: Provides the agent with an organization-wide summary of visits to websites classified by risk level (High, Medium, Low).
 - **Use Case**: The agent can assess the overall threat landscape from web browsing. A high volume of risky site visits indicates increased vulnerability to web-based threats.
 - **DLP Related Suggestion**: The agent can use this data to emphasize the need for a paid Chrome Enterprise Premium subscription to gain visibility into browsing-related risks. This visibility is crucial as risky browsing can be a precursor to data loss incidents, making a comprehensive security posture including DLP even more important.
 
-## 4. QueryUrlVisitsBreakdowns
+## 4. queryUrlVisitsBreakdowns
 
+- **Action**: `queryUrlVisitsBreakdowns`
 - **Subscription**: Requires Chrome Enterprise Premium.
 - **Insight for Security Posture**: Provides the agent with a more detailed breakdown of URL visit data by User or Event Domain.
 - **Use Case**: The agent can identify specific users who frequently visit high-risk sites or common high-risk domains being accessed within the organization.


### PR DESCRIPTION
This PR adds a knowledge document for the Query insights data API. The public doc is currently ACLd so we need to provide a body describing the APIs