### PR TITLE
fix: clear cached session state when OAuth credentials are cleared

### DIFF
--- a/test/local/auth.test.js
+++ b/test/local/auth.test.js
@@ -203,4 +203,44 @@ describe('Auth', () => {
       assert.match(message, /cep_auth/)
     })
   })
+
+  test('When cep_auth_clear is called, then it clears the token cache and resets sessionState', async () => {
+    let cacheCleared = false
+    const { registerAuthTools } = await esmock('../../tools/definitions/auth.js', {
+      '../../lib/util/credential/token_cache.js': {
+        TokenCache: class {
+          static defaultPath() {
+            return '/tmp/fake-path'
+          }
+          constructor() {}
+          async clear() {
+            cacheCleared = true
+          }
+        },
+      },
+    })
+
+    const handlers = {}
+    const mockServer = {
+      registerTool: (name, schema, handler) => {
+        handlers[name] = handler
+      },
+    }
+
+    const sessionState = {
+      customerId: 'C0123456',
+      cachedRootOrgUnitId: 'id:fakeOUId1',
+    }
+
+    registerAuthTools(mockServer, {}, sessionState)
+
+    const clearHandler = handlers['cep_auth_clear']
+    assert.ok(clearHandler)
+
+    await clearHandler({}, { requestInfo: { headers: { authorization: 'Bearer token' } } })
+
+    assert.ok(cacheCleared)
+    assert.strictEqual(sessionState.customerId, null)
+    assert.strictEqual(sessionState.cachedRootOrgUnitId, null)
+  })
 })

--- a/tools/definitions/auth.js
+++ b/tools/definitions/auth.js
@@ -287,6 +287,10 @@ export function registerAuthTools(server, options, sessionState) {
         handler: async () => {
           const cache = new TokenCache(TokenCache.defaultPath())
           await cache.clear()
+          if (sessionState) {
+            sessionState.customerId = null
+            sessionState.cachedRootOrgUnitId = null
+          }
           return formatToolResponse({
             summary: 'OAuth credentials cleared.',
             data: { cleared: true },


### PR DESCRIPTION
Fixes an issue where session state (such as cached customerId and cachedRootOrgUnitId) persisted after authentication credentials were removed. Now, invoking cep_auth_clear resets both the stored OAuth token cache and the active MCP session state.