### PR TITLE
test(eval): remove domain name requirement from i15/i16 judge instructions

### DIFF
--- a/test/evals/cases/inspection/i15-security_insights_data.eval.js
+++ b/test/evals/cases/inspection/i15-security_insights_data.eval.js
@@ -36,9 +36,8 @@ export default {
     '   * protegotollamadummyurl.com: 2,709 visits',
   judgeInstructions:
     'Verify that the agent successfully retrieves and reports the following key details:\n' +
-    '1. The domain name: securityinsights-e2e-readonly-prod.apollo-df.dev\n' +
-    '2. The total count of 8,627 suspicious URL visits.\n' +
-    '3. The top 3 suspicious domains with their exact visit counts:\n' +
+    '1. The total count of 8,627 suspicious URL visits.\n' +
+    '2. The top 3 suspicious domains with their exact visit counts:\n' +
     '   - protegotollamadummyurl-higher.com (2,713 visits)\n' +
     '   - protegotollamadummyurl-high.com (2,713 visits)\n' +
     '   - protegotollamadummyurl.com (2,709 visits)\n' +

--- a/test/evals/cases/inspection/i16-security_insights_content_transfers.eval.js
+++ b/test/evals/cases/inspection/i16-security_insights_content_transfers.eval.js
@@ -34,9 +34,8 @@ export default {
     ' - bob@securityinsights-e2e-readonly-prod.apollo-df.dev (92 transfers)',
   judgeInstructions:
     'Verify that the agent successfully retrieves and reports the following key details:\n' +
-    '1. The domain name: securityinsights-e2e-readonly-prod.apollo-df.dev\n' +
-    '2. The total count of 12,500 content transfers.\n' +
-    '3. The sensitive transfers count of 450.\n' +
-    '4. The top users contributing to these transfers: alice (150) and bob (92).\n' +
+    '1. The total count of 12,500 content transfers.\n' +
+    '2. The sensitive transfers count of 450.\n' +
+    '3. The top users contributing to these transfers: alice (150) and bob (92).\n' +
     'The agent must use the security_insights_data tool to retrieve this information.',
 }


### PR DESCRIPTION
This improves the pass rate for for evals i15 and i16 from 75% to 91% across 6 runs

### Testing

Done manually on the CLI using

```
node test/evals/run.js --id i15,i16 --runs 6
```
