### PR TITLE
docs: add additional secure gateway troubleshooting knowledge and evals

### DIFF
--- a/lib/knowledge/98-agent-knowledge-addendum.md
+++ b/lib/knowledge/98-agent-knowledge-addendum.md
@@ -1,5 +1,5 @@
 ---
-summary: 'Mandatory Technical "Golden Facts" and operational memory for Chrome Enterprise Premium. Covers Extension IDs for EV and SEB, Windows Certificate Store requirements for CBA, URL filtering syntax rules, and troubleshooting "Something went wrong" errors for Security Insights using specific privileges. Keywords: callobklhcbilhphinckomhgkigmfocg, ekajlcmdfcigmdbphhifahdfjbkciflj, Windows Store requirements, Security Insights Error, Chrome DLP insight setting management, SafeBrowsingAllowlistDomains.'
+summary: 'Mandatory Technical "Golden Facts" and operational memory for Chrome Enterprise Premium. Covers Extension IDs for EV and SEB, Windows Certificate Store requirements for CBA, URL filtering syntax rules, troubleshooting "Something went wrong" errors for Security Insights, Secure Gateway HTTPS requirements, and SEB extension log locations. Keywords: callobklhcbilhphinckomhgkigmfocg, ekajlcmdfcigmdbphhifahdfjbkciflj, Windows Store requirements, Security Insights Error, Chrome DLP insight setting management, SafeBrowsingAllowlistDomains, Secure Gateway HTTPS, 401 Unauthorized, SEB extension logs.'
 title: 'CEP Technical Addendum (Agent Memory)'
 articleId: 98
 ---
@@ -55,3 +55,8 @@ To successfully implement CBA, you **MUST** complete all three steps:
 - **Server-Side:** Use the **Investigation Tool** with the **Rule log events** data source.
 - **Client-Side:** Direct users to `chrome://policy` to verify rule receipt.
 - **SIEM:** Streaming events require the **Chrome Reporting Connector** and OU-level **Event Reporting** policy enablement.
+
+## 8. Secure Gateway Requirements & Troubleshooting
+
+- **HTTPS Required for Browser Access:** While the Security Gateway API allows configuring arbitrary ports for non-browser ZTNA TCP clients, **Google Chrome and the SEB Extension require access over HTTPS (`https://`) on any configured TLS port (such as `443`, `8443`, etc.)**. Accessing an internal app over unencrypted HTTP (e.g. port 80) in Chrome causes the extension to send direct `GET` requests instead of establishing a `CONNECT` tunnel, resulting in a **`401 Unauthorized` error**. Terminate TLS in your VPC (e.g., via an Internal Load Balancer) if the web app only supports plain HTTP on port 80.
+- **SEB Extension Logs Location:** SEB extension logs are **NOT** part of Chrome Reporting Connector or Chrome log events. Client-side extension logs are accessed via the extension options page at `chrome://extensions/?options=ekajlcmdfcigmdbphhifahdfjbkciflj` by navigating to the **Troubleshooting** section and clicking **Show Log**.

--- a/test/evals/cases/knowledge/k37-security-gateway-http-401.eval.js
+++ b/test/evals/cases/knowledge/k37-security-gateway-http-401.eval.js
@@ -1,0 +1,26 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export default {
+  id: 'k37',
+  priority: 'P1',
+  tags: ['gateway', 'troubleshooting', 'knowledge'],
+  requiredPatterns: ['401', 're:https|443|tls'],
+  prompt:
+    'Users are getting a 401 Unauthorized error in Google Chrome when attempting to access an internal web application (configured on port 80) via the BeyondCorp Secure Gateway. Why is this happening and how can we resolve it?',
+  goldenResponse:
+    'Google Chrome and the SEB Extension require access over HTTPS on a configured TLS port (such as 443, 8443, etc.) for browser-based Secure Gateway routing. When accessing an internal application over unencrypted HTTP (such as port 80), Chrome sends direct GET requests instead of establishing a CONNECT tunnel, which results in a 401 Unauthorized error from the gateway. To resolve this, you must terminate TLS in your VPC (e.g., using an Internal Load Balancer or local server certificate) so that browser traffic is routed over HTTPS.',
+}

--- a/test/evals/cases/knowledge/k38-seb-extension-logs.eval.js
+++ b/test/evals/cases/knowledge/k38-seb-extension-logs.eval.js
@@ -1,0 +1,26 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export default {
+  id: 'k38',
+  priority: 'P1',
+  tags: ['gateway', 'troubleshooting', 'knowledge', 'seb'],
+  requiredPatterns: ['re:ekajlcmdfcigmdbphhifahdfjbkciflj|options'],
+  prompt:
+    "Where can I find the Secure Enterprise Browser (SEB) extension logs on a user's machine to troubleshoot Secure Gateway routing issues? Are they available in Chrome Reporting Connector or Workspace log events?",
+  goldenResponse:
+    'SEB extension logs are NOT part of Chrome Reporting Connector or Chrome log events. Instead, client-side extension logs are located on the user\'s machine in the SEB extension options page at chrome://extensions/?options=ekajlcmdfcigmdbphhifahdfjbkciflj by navigating to the Troubleshooting section and clicking "Show Log".',
+}


### PR DESCRIPTION
## Summary
This PR documents known gaps in current public documentation for **BeyondCorp Secure Gateway** (HTTPS/TLS requirement for browser routing and client-side SEB extension log location) and adds corresponding evaluation cases (`k37` and `k38`) with a **100% pass rate**.

## Key Changes
1. **Secure Gateway Knowledge Addendum (`lib/knowledge/98-agent-knowledge-addendum.md`):**
   * Added Section 8 (**Secure Gateway Requirements & Troubleshooting**) documenting that Google Chrome and the SEB Extension require access over HTTPS (`https://`) / port 443, and that unencrypted HTTP / port 80 causes direct `GET` requests resulting in `401 Unauthorized` errors.
   * Documented client-side SEB extension log location (`chrome://extensions/?options=ekajlcmdfcigmdbphhifahdfjbkciflj` -> **Troubleshooting** -> **Show Log**) and explicitly clarified that SEB logs are **NOT** streamable via Chrome Reporting Connector or Chrome log events.
   * Updated YAML frontmatter `summary` and `keywords` for optimal RAG/retrieval by the `get_document` and `search_content` tools.
2. **Knowledge Agent Evaluations (`test/evals/cases/knowledge/`):**
   * **`k37` (`k37-security-gateway-http-401.eval.js`):** Added a P1 evaluation verifying that when users report `401 Unauthorized` errors on port 80 HTTP web apps, the agent accurately identifies the missing CONNECT tunnel / HTTPS requirement and recommends VPC TLS termination.
   * **`k38` (`k38-seb-extension-logs.eval.js`):** Added a P1 evaluation verifying that the agent provides the exact client-side extension options path for SEB logs without hallucinating server-side reporting connector tools.

---

## Verification

### Automated Tests
- **Presubmit Checks:** Verified all formatting, linting, unit, and fake integration tests pass:
  ```bash
  npm run presubmit
  ```

### Evaluation Validation
Verified both new evaluations (k37 and k38) pass reliably after 10 consecutive runs (100.0% pass rate):
```bash
$ CEP_BACKEND=fake node test/evals/run.js --id k37,k38 --runs 10
Running 2 eval(s) [full (agent + judge)] concurrency=5, runs=10...

  k37   PASS  Users are getting a 401 Unauthorized error in G...   3.9s/run  (10 of 10 runs passed)
  k38   PASS  Where can I find the Secure Enterprise Browser ...   2.5s/run  (10 of 10 runs passed)

Results: 20 of 20 runs passed (100.0% pass rate)
  knowledge            20 of 20 passed (100.0%)
```

### Interactive Testing (Jetski CLI)
* Manually verified using the Jetski CLI agent that when asked about 401 errors on port 80 or SEB log locations, the agent retrieves article 98 via get_document and provides the exact HTTPS / TLS termination guidance and chrome://extensions/?options=ekajlcmdfcigmdbphhifahdfjbkciflj troubleshooting path without hallucinating server-side log tools.