### PR TITLE
feat: implement check_ev_extension_status tool and tests

### DIFF
--- a/.github/expected-tarball.txt
+++ b/.github/expected-tarball.txt
@@ -82,6 +82,7 @@ tools/README.md
 tools/definitions/auth.js
 tools/definitions/check_and_enable_cep_api.js
 tools/definitions/check_cep_subscription.js
+tools/definitions/check_ev_extension_status.js
 tools/definitions/check_seb_extension_status.js
 tools/definitions/check_user_cep_license.js
 tools/definitions/count_browser_versions.js

--- a/test/integration/server/mcp-server.test.js
+++ b/test/integration/server/mcp-server.test.js
@@ -81,6 +81,7 @@ describe('MCP Server in stdio mode', () => {
         'cep_auth_clear',
         'cep_auth_status',
         'check_cep_subscription',
+        'check_ev_extension_status',
         'check_seb_extension_status',
         'check_user_cep_license',
         'count_browser_versions',

--- a/test/local/extension_tools.test.js
+++ b/test/local/extension_tools.test.js
@@ -19,6 +19,7 @@ import { describe, test, mock, beforeEach } from 'node:test'
 import esmock from 'esmock'
 
 const SEB_EXTENSION_ID = 'ekajlcmdfcigmdbphhifahdfjbkciflj'
+const EV_EXTENSION_ID = 'callobklhcbilhphinckomhgkigmfocg'
 const INSTALL_TYPE_SCHEMA = 'chrome.users.apps.InstallType'
 
 describe('Extension Tools', () => {
@@ -186,5 +187,87 @@ describe('Extension Tools', () => {
     assert.strictEqual(passedRequests[0].policyValue.value.appInstallType, 'FORCED')
     assert.strictEqual(passedRequests[0].policyTargetKey.additionalTargetKeys.app_id, `chrome:${SEB_EXTENSION_ID}`)
     assert.ok(result.content[0].text.includes('Successfully force-installed SEB extension on this OU.'))
+  })
+
+  test('When check_ev_extension_status is called and extension is installed, then it returns success', async () => {
+    const mockResolvePolicy = mock.fn(async () => [
+      {
+        targetKey: {
+          additionalTargetKeys: { app_id: `chrome:${EV_EXTENSION_ID}` },
+        },
+        value: {
+          policySchema: INSTALL_TYPE_SCHEMA,
+          value: {
+            appInstallType: 'FORCED',
+          },
+        },
+      },
+    ])
+
+    const MockChromePolicyClient = class {
+      constructor() {
+        this.resolvePolicy = mockResolvePolicy
+      }
+    }
+
+    const { registerTools } = await esmock(
+      '../../tools/index.js',
+      {},
+      {
+        '../../lib/api/chrome_policy_client.js': {
+          ChromePolicyClient: MockChromePolicyClient,
+        },
+      },
+    )
+
+    registerTools(server, {
+      apiClients: { chromePolicy: new MockChromePolicyClient() },
+    })
+
+    const handler = server.registerTool.mock.calls.find(call => call.arguments[0] === 'check_ev_extension_status')
+      .arguments[2]
+
+    const result = await handler({ customerId: 'C123', orgUnitId: 'ou1' }, { requestInfo: {} })
+
+    assert.strictEqual(mockResolvePolicy.mock.callCount(), 1)
+    assert.ok(
+      result.content[0].text.includes(
+        `Endpoint Verification extension (\`${EV_EXTENSION_ID}\`) is force-installed on this OU.`,
+      ),
+    )
+  })
+
+  test('When check_ev_extension_status is called and extension is missing, then it returns an error indicator', async () => {
+    const mockResolvePolicy = mock.fn(async () => [])
+
+    const MockChromePolicyClient = class {
+      constructor() {
+        this.resolvePolicy = mockResolvePolicy
+      }
+    }
+
+    const { registerTools } = await esmock(
+      '../../tools/index.js',
+      {},
+      {
+        '../../lib/api/chrome_policy_client.js': {
+          ChromePolicyClient: MockChromePolicyClient,
+        },
+      },
+    )
+
+    registerTools(server, {
+      apiClients: { chromePolicy: new MockChromePolicyClient() },
+    })
+
+    const handler = server.registerTool.mock.calls.find(call => call.arguments[0] === 'check_ev_extension_status')
+      .arguments[2]
+
+    const result = await handler({ customerId: 'C123', orgUnitId: 'ou1' }, { requestInfo: {} })
+
+    assert.ok(
+      result.content[0].text.includes('Endpoint Verification extension') &&
+        result.content[0].text.includes('NOT force-installed'),
+    )
   })
 })

--- a/test/local/tool-registration.test.js
+++ b/test/local/tool-registration.test.js
@@ -30,6 +30,7 @@ const CORE_TOOLS = [
   'cep_auth_status',
   'check_and_enable_cep_api',
   'check_cep_subscription',
+  'check_ev_extension_status',
   'check_seb_extension_status',
   'check_user_cep_license',
   'count_browser_versions',

--- a/tools/definitions/check_ev_extension_status.js
+++ b/tools/definitions/check_ev_extension_status.js
@@ -1,0 +1,83 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file Tool definition for checking the status of the Endpoint Verification extension.
+ */
+
+import { z } from 'zod'
+import { guardedToolCall, formatToolResponse } from '../utils/wrapper.js'
+import { TAGS } from '../../lib/constants.js'
+import { logger } from '../../lib/util/logger.js'
+
+const EV_EXTENSION_ID = 'callobklhcbilhphinckomhgkigmfocg'
+const INSTALL_TYPE_SCHEMA = 'chrome.users.apps.InstallType'
+
+/**
+ * Registers the 'check_ev_extension_status' tool with the MCP server.
+ * @param {import('@modelcontextprotocol/sdk/server/mcp.js').McpServer} server - The MCP server instance.
+ * @param {object} options - Configuration options for the tool.
+ * @param {import('../../lib/api/chrome_policy_client.js').ChromePolicyClient} options.chromePolicyClient - The Chrome Policy client instance.
+ * @param {object} sessionState - The session state object for caching.
+ * @returns {void}
+ */
+export function registerCheckEvExtensionStatusTool(server, options, sessionState) {
+  const { chromePolicyClient } = options
+  logger.debug(`${TAGS.MCP} Registering 'check_ev_extension_status' tool...`)
+
+  server.registerTool(
+    'check_ev_extension_status',
+    {
+      description: `Checks if the Endpoint Verification (EV) extension is force-installed for a given Organizational Unit.
+The EV extension is REQUIRED for gathering device posture to use Context-Aware Access (CAA) levels.`,
+      inputSchema: {
+        customerId: z.string().optional().describe('The Chrome customer ID (e.g. C012345).'),
+        orgUnitId: z.string().describe('The ID of the organizational unit to check.'),
+      },
+      outputSchema: z.looseObject({
+        isInstalled: z.boolean(),
+        extensionId: z.string(),
+        policies: z.array(z.looseObject({})),
+      }),
+    },
+    guardedToolCall(
+      {
+        handler: async ({ customerId, orgUnitId }, { _requestInfo, authToken }) => {
+          logger.debug(
+            `${TAGS.MCP} Calling 'check_ev_extension_status' with customerId: ${customerId}, orgUnitId: ${orgUnitId}`,
+          )
+
+          const policies = await chromePolicyClient.resolvePolicy(customerId, orgUnitId, INSTALL_TYPE_SCHEMA, authToken)
+
+          const evPolicy = policies?.find(
+            p =>
+              p.value?.policySchema === INSTALL_TYPE_SCHEMA &&
+              p.targetKey?.additionalTargetKeys?.app_id === `chrome:${EV_EXTENSION_ID}`,
+          )
+          const isInstalled = evPolicy?.value?.value?.appInstallType === 'FORCED'
+
+          const sc = { isInstalled, extensionId: EV_EXTENSION_ID, policies: policies || [] }
+          const summary = isInstalled
+            ? `Endpoint Verification extension (\`${EV_EXTENSION_ID}\`) is force-installed on this OU.`
+            : `Endpoint Verification extension (\`${EV_EXTENSION_ID}\`) is NOT force-installed on this OU. Device posture sync may not work.`
+          return formatToolResponse({ summary, data: sc, structuredContent: sc })
+        },
+      },
+      options,
+      sessionState,
+    ),
+  )
+}

--- a/tools/index.js
+++ b/tools/index.js
@@ -40,6 +40,7 @@ import { registerCreateUrlListDetectorTool } from './definitions/create_url_list
 import { registerCreateWordListDetectorTool } from './definitions/create_word_list_detector.js'
 import { registerCreateDefaultDlpRulesTool } from './definitions/create_default_dlp_rules.js'
 import { registerCheckSebExtensionStatusTool } from './definitions/check_seb_extension_status.js'
+import { registerCheckEvExtensionStatusTool } from './definitions/check_ev_extension_status.js'
 import { registerInstallSebExtensionTool } from './definitions/install_seb_extension.js'
 import { registerCheckAndEnableCepApiTool } from './definitions/check_and_enable_cep_api.js'
 import { registerEnableChromeEnterpriseConnectorsTool } from './definitions/enable_chrome_enterprise_connectors.js'
@@ -122,6 +123,7 @@ export function registerTools(server, options = {}, sessionState) {
   registerCreateWordListDetectorTool(server, { ...commonOpts, cloudIdentityClient }, state)
   registerCreateDefaultDlpRulesTool(server, { ...commonOpts, cloudIdentityClient }, state)
   registerCheckSebExtensionStatusTool(server, { ...commonOpts, chromePolicyClient }, state)
+  registerCheckEvExtensionStatusTool(server, { ...commonOpts, chromePolicyClient }, state)
   registerInstallSebExtensionTool(server, { ...commonOpts, chromePolicyClient }, state)
   if (registerEnableApi) {
     registerCheckAndEnableCepApiTool(server, { ...commonOpts, serviceUsageClient }, state)


### PR DESCRIPTION
# Feat: Implement `check_ev_extension_status` Tool

This change introduces the `check_ev_extension_status` tool to check if the Endpoint Verification (EV) extension is force-installed on a given Organizational Unit (OU). This aligns with the existing `check_seb_extension_status` tool pattern.

## Changes

### 1. New Tool Definition
* **File**: [tools/definitions/check_ev_extension_status.js](file:///usr/local/google/home/sahilmadeka/.gemini/jetski/worktrees/cep-mcp-clone/tools/definitions/check_ev_extension_status.js)
* **Implementation**:
  * Calls `chromePolicyClient.resolvePolicy` to resolve the `chrome.users.apps.InstallType` policy schema for the requested `orgUnitId`.
  * Verifies if the policy value for the app `chrome:callobklhcbilhphinckomhgkigmfocg` (Endpoint Verification ID) is set to `FORCED`.
  * Returns a structured response containing:
    * `isInstalled`: boolean indicating forced status.
    * `extensionId`: `callobklhcbilhphinckomhgkigmfocg`
    * `policies`: The list of resolved policies.

### 2. Tool Registration
* **File**: [tools/index.js](file:///usr/local/google/home/sahilmadeka/.gemini/jetski/worktrees/cep-mcp-clone/tools/index.js)
* **Implementation**: Imported `registerCheckEvExtensionStatusTool` and registered it in `registerTools`.

### 3. Tests
* **File**: [test/local/extension_tools.test.js](file:///usr/local/google/home/sahilmadeka/.gemini/jetski/worktrees/cep-mcp-clone/test/local/extension_tools.test.js)
  * Added test: `When check_ev_extension_status is called and extension is installed, then it returns success`
  * Added test: `When check_ev_extension_status is called and extension is missing, then it returns an error indicator`
* **File**: [test/local/tool-registration.test.js](file:///usr/local/google/home/sahilmadeka/.gemini/jetski/worktrees/cep-mcp-clone/test/local/tool-registration.test.js)
  * Added `check_ev_extension_status` to `CORE_TOOLS` to verify registration under default experiments state.
* **File**: [test/integration/server/mcp-server.test.js](file:///usr/local/google/home/sahilmadeka/.gemini/jetski/worktrees/cep-mcp-clone/test/integration/server/mcp-server.test.js)
  * Added `check_ev_extension_status` to the list of expected tools in the `listTools` integration test.

### 4. Build Configuration
* **File**: [.github/expected-tarball.txt](file:///usr/local/google/home/sahilmadeka/.gemini/jetski/worktrees/cep-mcp-clone/.github/expected-tarball.txt)
  * Added `tools/definitions/check_ev_extension_status.js` to the release package expected files.


## Manual testing
Prompted agent to check if endpoint verification is installed for my domain
<img width="1893" height="781" alt="EVManualTest" src="https://github.com/user-attachments/assets/56ca7f12-49cf-4b97-aa29-ce26bbabfd55" />
