### PR TITLE
fix: bypass OAuth token check when service account is configured

### DIFF
--- a/lib/util/auth_messages.js
+++ b/lib/util/auth_messages.js
@@ -44,6 +44,10 @@ function labelFor(source) {
  * @returns {string} The banner field text.
  */
 export function buildScopesField(probe, requiredScopes) {
+  if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+    return `🟢 Service Account configured`
+  }
+
   if (probe.scopesKnown && probe.missingScopes.length > 0) {
     return `🔴 ${probe.missingScopes.length} of ${requiredScopes.length} missing`
   }
@@ -76,6 +80,10 @@ export function buildScopesField(probe, requiredScopes) {
  * @returns {?string[]} Array of lines (no trailing newline), or null.
  */
 export function buildAuthRemediationLines(probe, requiredScopes) {
+  if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+    return null
+  }
+
   if (probe.ok) {
     return null
   }
@@ -126,6 +134,13 @@ function oauthClientLabel(config) {
  * @returns {string[]} A [head, parens] tuple suitable for the banner's fmtField.
  */
 export function buildApiCredsField(probe, clientConfig) {
+  if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+    const impersonated = process.env.CEP_IMPERSONATE_SUBJECT
+      ? `, impersonating ${process.env.CEP_IMPERSONATE_SUBJECT}`
+      : ''
+    return ['Service Account', `(GOOGLE_APPLICATION_CREDENTIALS${impersonated})`]
+  }
+
   const client = oauthClientLabel(clientConfig)
   if (!probe.ok) {
     return ['OAuth', `(not configured, ${client})`]

--- a/test/local/utils.test.js
+++ b/test/local/utils.test.js
@@ -83,7 +83,7 @@ describe('Tool Utils', () => {
       const failHandler = mock.fn(async () => {
         throw err
       })
-      const tool = guardedToolCall({ handler: failHandler })
+      const tool = guardedToolCall({ handler: failHandler, skipAuthCheck: true })
       const result = await tool({}, {})
       assert.strictEqual(result.isError, true)
       assert.match(result.content[0].text, /cep_auth/)
@@ -96,7 +96,7 @@ describe('Tool Utils', () => {
       const failHandler = mock.fn(async () => {
         throw err
       })
-      const tool = guardedToolCall({ handler: failHandler })
+      const tool = guardedToolCall({ handler: failHandler, skipAuthCheck: true })
       const result = await tool({}, {})
       assert.strictEqual(result.isError, true)
       assert.match(result.content[0].text, /cep_auth/)
@@ -109,7 +109,7 @@ describe('Tool Utils', () => {
       const failHandler = mock.fn(async () => {
         throw err
       })
-      const tool = guardedToolCall({ handler: failHandler })
+      const tool = guardedToolCall({ handler: failHandler, skipAuthCheck: true })
       const result = await tool({}, {})
       assert.strictEqual(result.isError, true)
       assert.match(result.content[0].text, /auth login/)
@@ -309,6 +309,43 @@ describe('Tool Utils', () => {
           delete process.env[homeKey]
         } else {
           process.env[homeKey] = saved
+        }
+
+        await fs.rm(emptyHome, { recursive: true, force: true })
+      }
+    })
+
+    test('When guardedToolCall runs with GOOGLE_APPLICATION_CREDENTIALS set and no cached token, then it bypasses pre-flight and invokes the handler', async () => {
+      const handler = mock.fn(async () => ({ content: [{ type: 'text', text: 'ok' }] }))
+      const homeKey = process.platform === 'win32' ? 'APPDATA' : 'HOME'
+      const saved = process.env[homeKey]
+      const emptyHome = path.join(
+        os.tmpdir(),
+        `cep-mcp-empty-home-sa-${process.pid}-${Math.random().toString(16).slice(2)}`,
+      )
+
+      await fs.mkdir(emptyHome, { recursive: true })
+      process.env[homeKey] = emptyHome
+
+      const previousCreds = process.env.GOOGLE_APPLICATION_CREDENTIALS
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = '/nonexistent-sa.json'
+
+      try {
+        const tool = guardedToolCall({ handler })
+        const result = await tool({}, {})
+        assert.strictEqual(result.content[0].text, 'ok')
+        assert.strictEqual(handler.mock.callCount(), 1)
+      } finally {
+        if (saved === undefined) {
+          delete process.env[homeKey]
+        } else {
+          process.env[homeKey] = saved
+        }
+
+        if (previousCreds === undefined) {
+          delete process.env.GOOGLE_APPLICATION_CREDENTIALS
+        } else {
+          process.env.GOOGLE_APPLICATION_CREDENTIALS = previousCreds
         }
 
         await fs.rm(emptyHome, { recursive: true, force: true })

--- a/test/run-utils.js
+++ b/test/run-utils.js
@@ -39,5 +39,7 @@ export function findTestFiles(dir) {
 export function sanitizeOauthClientEnv(env = process.env) {
   env.CEP_OAUTH_CLIENT_ID = ''
   env.CEP_OAUTH_CLIENT_SECRET = ''
+  delete env.GOOGLE_APPLICATION_CREDENTIALS
+  delete env.CEP_IMPERSONATE_SUBJECT
   return env
 }

--- a/tools/utils/wrapper.js
+++ b/tools/utils/wrapper.js
@@ -169,7 +169,7 @@ export function guardedToolCall(
 ) {
   const wrapped = async (params, context) => {
     const authToken = getAuthToken(context?.requestInfo)
-    if (!authToken && !skipAuthCheck) {
+    if (!authToken && !skipAuthCheck && !process.env.GOOGLE_APPLICATION_CREDENTIALS) {
       const validity = await isTokenLocallyValid({ scopes })
       if (!validity.ok) {
         return buildAuthRequiredResponse(validity)


### PR DESCRIPTION
If a service account is configured via GOOGLE_APPLICATION_CREDENTIALS, the local OAuth pre-flight verification in guardedToolCall should be bypassed. Otherwise, users are incorrectly blocked with a 'Sign-in is needed' error if they have an expired or missing OAuth access token, even though the service account credentials are valid and would be successfully utilized by the API clients.

Also refactors auth_messages.js to appropriately report and display Service Account status in the console banner UI.
