### PR TITLE
Feat/diagnose secure gateway

### DIFF
--- a/prompts/system-prompt.md
+++ b/prompts/system-prompt.md
@@ -30,7 +30,7 @@ _Example:_ If you encounter `[DLP Core Features](4-dlp-core-features.md)`, call 
 
 - **Do NOT summarize technical details.** When retrieving information from the knowledge base, extract and quote the exact relevant technical details verbatim. You MUST include any specific IDs, registry paths, specific policy names, Extension IDs, or IAM roles (e.g., 'Cloud BeyondCorp Subscription Admin') exactly as they appear in the source document.
 - Present technical details from documentation accurately. Include specific role names, policy names, and configuration values when they appear in your sources.
-- When reporting on the user's environment, summarize what you found and what it means. When surfacing technical configuration details like CEL expression syntax, always include a brief, user-friendly explanation of what the logic does (e.g., 'This means it checks for SSN patterns').
+- When reporting on the user's environment, summarize what you found and what it means. Group diagnostic findings under separate headings by exact severity (Critical, High, Medium, Info) rather than merging different severity levels. When surfacing technical configuration details like CEL expression syntax, always include a brief, user-friendly explanation of what the logic does (e.g., 'This means it checks for SSN patterns').
 - For mutation requests (creating rules, enabling connectors), confirm what was done in plain language.
 
 ## Security Guidance Workflow

--- a/test/evals/cases/gateway/gw02-get-gateway.eval.js
+++ b/test/evals/cases/gateway/gw02-get-gateway.eval.js
@@ -28,5 +28,5 @@ export default {
   prompt:
     'What are the details and configured applications for secure gateway gateway-alpha in project my-project-123?',
   goldenResponse:
-    'Gateway Alpha (gateway-alpha) is ACTIVE. It has 1 configured application called App One (app-one) routing to intranet.company.com.',
+    'Gateway Alpha (gateway-alpha) is RUNNING. It has 1 configured application called App One (app-one) routing to intranet.company.com.',
 }

--- a/test/evals/cases/gateway/gw07-diagnose-gateway.eval.js
+++ b/test/evals/cases/gateway/gw07-diagnose-gateway.eval.js
@@ -1,0 +1,34 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export default {
+  id: 'gw07',
+  priority: 'P1',
+  tags: ['gateway', 'inspection', 'diagnose'],
+  fixtures: ['customer-default.json', 'license-valid.json', 'gateways-configured.json'],
+  expectedTools: ['diagnose_environment'],
+  forbiddenPatterns: [],
+  requiredPatterns: ['re:gateway|security gateways'],
+  experiments: {
+    SECURE_GATEWAY_ENABLED: true,
+  },
+  prompt:
+    'Use the diagnose_environment tool to run a complete diagnostic health check on my Chrome Enterprise Premium deployment, including my Secure Gateway setup in GCP project my-project-123. Summarize the status of my subscription, org units, DLP rules, and Secure Gateways (including gateway and application counts).',
+  goldenResponse:
+    'The agent should run diagnose_environment with projectId: "my-project-123" and report the Secure Gateway status (1 gateway / Gateway Alpha, 1 application / App One) along with overall environment diagnostic findings.',
+  judgeInstructions:
+    'The agent must run diagnose_environment with projectId="my-project-123". The response must confirm the presence of the Secure Gateway setup (noting Gateway Alpha, 1 running/active gateway, or 1 application). The judge should evaluate whether the agent accurately summarizes the environment health without penalizing for minor phrasing variations or for listing other detected environment issues.',
+}

--- a/test/evals/fixtures/gateways-configured.json
+++ b/test/evals/fixtures/gateways-configured.json
@@ -3,7 +3,7 @@
     "projects/my-project-123/locations/global/securityGateways/gateway-alpha": {
       "name": "projects/my-project-123/locations/global/securityGateways/gateway-alpha",
       "displayName": "Gateway Alpha",
-      "state": "ACTIVE"
+      "state": "RUNNING"
     }
   },
   "securityGatewayApplications": {

--- a/test/helpers/fake-api-server.js
+++ b/test/helpers/fake-api-server.js
@@ -854,7 +854,7 @@ export function createFakeApp() {
     const gateway = {
       name,
       displayName: display_name,
-      state: 'ACTIVE',
+      state: 'RUNNING',
       delegatingServiceAccount: `service-${projectId}-beyondcorp@gcp-sa-beyondcorp.iam.gserviceaccount.com`,
       ...(service_discovery ? { serviceDiscovery: service_discovery } : {}),
     }

--- a/test/integration/tools/diagnose_environment.test.js
+++ b/test/integration/tools/diagnose_environment.test.js
@@ -24,6 +24,7 @@ limitations under the License.
 import { describe, test, before, after } from 'node:test'
 import assert from 'node:assert/strict'
 import { createIntegrationHarness, teardownIntegrationHarness } from '../../helpers/integration/tools/harness.js'
+import { FeatureFlags } from '../../../lib/util/feature_flags.js'
 
 const EXPECTED_CONNECTOR_COUNT = 6
 
@@ -136,4 +137,32 @@ describe('Diagnose Environment Integration', () => {
       }
     },
   )
+})
+
+describe('Diagnose Environment Integration (Secure Gateway Enabled)', () => {
+  let harness
+
+  before(async () => {
+    harness = await createIntegrationHarness({
+      featureFlags: new FeatureFlags({
+        EXPERIMENT_SECURE_GATEWAY_ENABLED: 'true',
+      }),
+    })
+  })
+
+  after(async () => {
+    await teardownIntegrationHarness(harness, [])
+  })
+
+  test('When SECURE_GATEWAY_ENABLED is active and projectId is passed, diagnose_environment queries secure gateways', async () => {
+    const { client } = harness
+    const result = await client.callTool({
+      name: 'diagnose_environment',
+      arguments: { projectId: 'test-project-sg' },
+    })
+    const sc = result.structuredContent
+    assert.ok(sc.secureGateway)
+    assert.strictEqual(sc.secureGateway.projectId, 'test-project-sg')
+    assert.ok(Array.isArray(sc.secureGateway.gateways))
+  })
 })

--- a/test/integration/tools/secure_gateway.test.js
+++ b/test/integration/tools/secure_gateway.test.js
@@ -88,7 +88,7 @@ describe('Secure Gateway Lifecycle Integration', () => {
     }
     assert.ok(gwDetails.name)
     assert.strictEqual(gwDetails.displayName, 'My Test Gateway')
-    assert.strictEqual(gwDetails.state, 'ACTIVE')
+    assert.strictEqual(gwDetails.state, 'RUNNING')
     assert.ok(gwDetails.delegatingServiceAccount)
     assert.strictEqual(gwDetails.serviceDiscovery, undefined) // Service discovery should be absent
 

--- a/test/local/diagnose_environment.test.js
+++ b/test/local/diagnose_environment.test.js
@@ -24,6 +24,7 @@ limitations under the License.
 import { test, describe, mock } from 'node:test'
 import assert from 'node:assert/strict'
 import { registerDiagnoseEnvironmentTool } from '../../tools/definitions/diagnose_environment.js'
+import { FeatureFlags } from '../../lib/util/feature_flags.js'
 
 /**
  * Creates mock API clients that return configurable test data.
@@ -52,6 +53,8 @@ function createMockClients(overrides = {}) {
     urlVisits: {
       summaries: [{ metric: 'URL_VISITS_METRIC_TOTAL_SUSPICIOUS_URL_VISITS', count: '5' }],
     },
+    gateways: [],
+    applications: [],
   }
 
   const cfg = { ...defaults, ...overrides }
@@ -76,6 +79,10 @@ function createMockClients(overrides = {}) {
       listDlpRules: mock.fn(async () => cfg.dlpRules),
       listDetectors: mock.fn(async () => cfg.detectors),
     },
+    beyondcorpClient: {
+      listGateways: mock.fn(async () => cfg.gateways),
+      listApplications: mock.fn(async () => cfg.applications),
+    },
     apiClients: {
       adminSdk: { getCustomerId: mock.fn(async () => cfg.customer) },
     },
@@ -99,11 +106,12 @@ function createMockServer(handlers) {
   }
 }
 
-function registerAndGetHandler(clientOverrides = {}) {
+function registerAndGetHandler(clientOverrides = {}, options = {}) {
   const handlers = {}
   const server = createMockServer(handlers)
   const clients = createMockClients(clientOverrides)
-  registerDiagnoseEnvironmentTool(server, clients, { customerId: null, cachedRootOrgUnitId: null })
+  const fullOptions = { ...clients, ...options }
+  registerDiagnoseEnvironmentTool(server, fullOptions, { customerId: null, cachedRootOrgUnitId: null })
   return { handler: handlers['diagnose_environment'], clients }
 }
 
@@ -514,6 +522,241 @@ describe('diagnose_environment', () => {
       const { handler } = registerAndGetHandler({ orgUnits: { organizationUnits: [] } })
       const result = await handler({ customerId: 'C0123' }, { requestInfo: {} })
       assert.strictEqual(result.structuredContent.orgUnitCount, 0)
+    })
+  })
+
+  describe('Secure Gateway Diagnostics', () => {
+    const enabledFlags = new FeatureFlags({ EXPERIMENT_SECURE_GATEWAY_ENABLED: 'true' })
+    const disabledFlags = new FeatureFlags({ EXPERIMENT_SECURE_GATEWAY_ENABLED: 'false' })
+
+    test('When experiment flag is disabled, then secureGateway section and checks are omitted', async () => {
+      const { handler, clients } = registerAndGetHandler(
+        { gateways: [{ name: 'projects/p1/locations/global/securityGateways/gw1', state: 'RUNNING' }] },
+        { featureFlags: disabledFlags },
+      )
+      const result = await handler({ customerId: 'C0123', projectId: 'p1' }, { requestInfo: {} })
+      assert.strictEqual(result.structuredContent.secureGateway, null)
+      assert.strictEqual(clients.beyondcorpClient.listGateways.mock.callCount(), 0)
+      assert.ok(!result.content[0].text.includes('Secure Gateways'))
+    })
+
+    test('When experiment flag is enabled but no projectId is provided, then secureGateway is reported as skipped', async () => {
+      const { handler, clients } = registerAndGetHandler({}, { featureFlags: enabledFlags })
+      const result = await handler({ customerId: 'C0123' }, { requestInfo: {} })
+      assert.deepStrictEqual(result.structuredContent.secureGateway, { projectId: null, gateways: [], skipped: true })
+      assert.strictEqual(clients.beyondcorpClient.listGateways.mock.callCount(), 0)
+      assert.ok(result.content[0].text.includes("**Secure Gateways:** Not checked (provide 'projectId'"))
+    })
+
+    test('When experiment flag is enabled and healthy gateway exists, then zero issues are produced', async () => {
+      const { handler } = registerAndGetHandler(
+        {
+          connectorPolicy: [{ value: {} }],
+          gateways: [
+            {
+              name: 'projects/p1/locations/global/securityGateways/gw1',
+              displayName: 'Gateway 1',
+              state: 'RUNNING',
+              serviceDiscovery: {},
+            },
+          ],
+          applications: [
+            {
+              name: 'projects/p1/locations/global/securityGateways/gw1/applications/app1',
+              displayName: 'App 1',
+            },
+          ],
+        },
+        { featureFlags: enabledFlags },
+      )
+
+      const result = await handler({ customerId: 'C0123', projectId: 'p1' }, { requestInfo: {} })
+      const sg = result.structuredContent.secureGateway
+      assert.ok(sg)
+      assert.strictEqual(sg.gateways.length, 1)
+      assert.strictEqual(sg.gateways[0].applications.length, 1)
+
+      const sgIssues = result.structuredContent.issues.filter(i => i.component === 'secureGateway')
+      assert.strictEqual(sgIssues.length, 0)
+      assert.ok(
+        result.content[0].text.includes(
+          '**Secure Gateways (project: p1):** 1 total (1 active, 1 with Service Discovery, 1 app(s))',
+        ),
+      )
+    })
+
+    test('When gateway has non-ACTIVE state, missing service discovery, and zero apps, then corresponding issues are produced', async () => {
+      const { handler } = registerAndGetHandler(
+        {
+          gateways: [
+            {
+              name: 'projects/p1/locations/global/securityGateways/gw1',
+              displayName: 'Bad Gateway',
+              state: 'ERROR',
+            },
+          ],
+          applications: [],
+        },
+        { featureFlags: enabledFlags },
+      )
+
+      const result = await handler({ customerId: 'C0123', projectId: 'p1' }, { requestInfo: {} })
+      const sgIssues = result.structuredContent.issues.filter(i => i.component === 'secureGateway')
+
+      assert.ok(sgIssues.some(i => i.severity === 'critical' && i.message.includes('ERROR state')))
+      assert.ok(sgIssues.some(i => i.severity === 'medium' && i.message.includes('Service Discovery')))
+      assert.ok(sgIssues.some(i => i.severity === 'medium' && i.message.includes('no application routing')))
+    })
+
+    test('When gateway is in RUNNING state, then it is treated as healthy', async () => {
+      const { handler } = registerAndGetHandler(
+        {
+          connectorPolicy: [{ value: {} }],
+          gateways: [
+            {
+              name: 'projects/p1/locations/global/securityGateways/gw1',
+              displayName: 'Running Gateway',
+              state: 'RUNNING',
+              serviceDiscovery: {},
+            },
+          ],
+          applications: [
+            {
+              name: 'projects/p1/locations/global/securityGateways/gw1/applications/app1',
+              displayName: 'App 1',
+            },
+          ],
+        },
+        { featureFlags: enabledFlags },
+      )
+
+      const result = await handler({ customerId: 'C0123', projectId: 'p1' }, { requestInfo: {} })
+      const sgIssues = result.structuredContent.issues.filter(i => i.component === 'secureGateway')
+      assert.strictEqual(sgIssues.length, 0)
+    })
+
+    test('When gateway is in ERROR, DOWN, or CREATING state, then appropriate severity issues are reported', async () => {
+      const { handler } = registerAndGetHandler(
+        {
+          gateways: [
+            {
+              name: 'projects/p1/locations/global/securityGateways/gw1',
+              displayName: 'Err Gateway',
+              state: 'ERROR',
+              serviceDiscovery: {},
+            },
+            {
+              name: 'projects/p1/locations/global/securityGateways/gw2',
+              displayName: 'Down Gateway',
+              state: 'DOWN',
+              serviceDiscovery: {},
+            },
+            {
+              name: 'projects/p1/locations/global/securityGateways/gw3',
+              displayName: 'Creating Gateway',
+              state: 'CREATING',
+              serviceDiscovery: {},
+            },
+          ],
+          applications: [],
+        },
+        { featureFlags: enabledFlags },
+      )
+
+      const result = await handler({ customerId: 'C0123', projectId: 'p1' }, { requestInfo: {} })
+      const sgIssues = result.structuredContent.issues.filter(i => i.component === 'secureGateway')
+
+      assert.ok(sgIssues.some(i => i.severity === 'critical' && i.message.includes('ERROR state')))
+      assert.ok(sgIssues.some(i => i.severity === 'high' && i.message.includes('DOWN state')))
+      assert.ok(sgIssues.some(i => i.severity === 'medium' && i.message.includes('CREATING state')))
+    })
+
+    test('When application routes non-HTTPS ports (e.g. 80 without 443), then an issue is produced according to Knowledge Addendum #8', async () => {
+      const { handler } = registerAndGetHandler(
+        {
+          gateways: [
+            {
+              name: 'projects/p1/locations/global/securityGateways/gw1',
+              displayName: 'Gateway 1',
+              state: 'RUNNING',
+              serviceDiscovery: {},
+            },
+          ],
+          applications: [
+            {
+              name: 'projects/p1/locations/global/securityGateways/gw1/applications/app1',
+              displayName: 'HTTP App',
+              endpointMatchers: [{ hostname: 'app.local', ports: [80] }],
+            },
+          ],
+        },
+        { featureFlags: enabledFlags },
+      )
+
+      const result = await handler({ customerId: 'C0123', projectId: 'p1' }, { requestInfo: {} })
+      const appIssues = result.structuredContent.issues.filter(i => i.component === 'secureGateway.application')
+      assert.strictEqual(appIssues.length, 1)
+      assert.strictEqual(appIssues[0].severity, 'medium')
+      assert.ok(appIssues[0].message.includes('routes port 80'))
+    })
+
+    test('When listGateways API fails, then it produces a medium issue and reports query failure', async () => {
+      const clients = createMockClients()
+      clients.beyondcorpClient.listGateways = mock.fn(async () => {
+        throw new Error('API unavailable')
+      })
+
+      const handlers = {}
+      const server = createMockServer(handlers)
+      registerDiagnoseEnvironmentTool(
+        server,
+        { ...clients, featureFlags: enabledFlags },
+        { customerId: null, cachedRootOrgUnitId: null },
+      )
+
+      const result = await handlers['diagnose_environment'](
+        { customerId: 'C0123', projectId: 'p1' },
+        { requestInfo: {} },
+      )
+      const sgIssues = result.structuredContent.issues.filter(i => i.component === 'secureGateway')
+      assert.strictEqual(sgIssues.length, 1)
+      assert.strictEqual(sgIssues[0].severity, 'medium')
+      assert.ok(sgIssues[0].message.includes('API unavailable'))
+      assert.ok(result.content[0].text.includes('**Secure Gateways (project: p1):** ⚠️ Query failed'))
+    })
+
+    test('When detail section secureGateways is requested, then paginated gateways are returned', async () => {
+      const { handler } = registerAndGetHandler(
+        {
+          gateways: [
+            {
+              name: 'projects/p1/locations/global/securityGateways/gw1',
+              displayName: 'Gateway 1',
+              state: 'RUNNING',
+              serviceDiscovery: {},
+            },
+            {
+              name: 'projects/p1/locations/global/securityGateways/gw2',
+              displayName: 'Gateway 2',
+              state: 'RUNNING',
+            },
+          ],
+          applications: [],
+        },
+        { featureFlags: enabledFlags },
+      )
+
+      const result = await handler(
+        { customerId: 'C0123', projectId: 'p1', section: 'secureGateways', limit: 1, offset: 0 },
+        { requestInfo: {} },
+      )
+      const sc = result.structuredContent
+      assert.strictEqual(sc.section, 'secureGateways')
+      assert.strictEqual(sc.items.length, 1)
+      assert.strictEqual(sc.total, 2)
+      assert.strictEqual(sc.hasMore, true)
+      assert.strictEqual(sc.items[0].displayName, 'Gateway 1')
+      assert.strictEqual(sc.items[0].serviceDiscovery, true)
     })
   })
 })

--- a/tools/definitions/diagnose_environment.js
+++ b/tools/definitions/diagnose_environment.js
@@ -31,6 +31,7 @@ import { logger } from '../../lib/util/logger.js'
 import { ConnectorPolicyFilter } from '../../lib/api/chrome_policy_client.js'
 import { CHROME_ACTION_TYPES } from '../../lib/util/chrome_dlp_constants.js'
 import { analyzeConnectorPolicy } from '../../lib/util/connector_policy_helper.js'
+import { FLAGS, featureFlags as defaultFeatureFlags } from '../../lib/util/feature_flags.js'
 
 const CONNECTOR_TYPES = {
   uploadAnalysis: 'ON_FILE_ATTACHED',
@@ -237,11 +238,89 @@ function computeIssues(data) {
     })
   }
 
+  if (data.secureGateway) {
+    if (data.secureGateway.skipped) {
+      issues.push({
+        severity: 'info',
+        component: 'secureGateway',
+        message:
+          'Secure Gateway health check was skipped because no GCP projectId was provided. Pass a `projectId` parameter to diagnose Secure Gateways, application routing, and IAM permissions.',
+      })
+    } else if (data.secureGateway.error) {
+      issues.push({
+        severity: 'medium',
+        component: 'secureGateway',
+        message: `Failed to query Secure Gateways for project ${data.secureGateway.projectId}: ${data.secureGateway.error}`,
+      })
+    } else {
+      if (data.secureGateway.gateways.length === 0) {
+        issues.push({
+          severity: 'medium',
+          component: 'secureGateway',
+          message: `No Secure Gateways found in project ${data.secureGateway.projectId}.`,
+        })
+      } else {
+        for (const gateway of data.secureGateway.gateways) {
+          const state = gateway.state || 'STATE_UNSPECIFIED'
+          if (state !== 'RUNNING') {
+            const isCritical = state === 'ERROR'
+            const isHigh = state === 'DOWN'
+            const isMedium = ['CREATING', 'UPDATING', 'DELETING'].includes(state)
+            const severity = isCritical ? 'critical' : isHigh ? 'high' : isMedium ? 'medium' : 'high'
+
+            issues.push({
+              severity,
+              component: 'secureGateway',
+              message: `Secure Gateway ${gateway.displayName || gateway.name} is in ${state} state.`,
+            })
+          }
+          if (!gateway.serviceDiscovery) {
+            issues.push({
+              severity: 'medium',
+              component: 'secureGateway',
+              message: `Secure Gateway ${gateway.displayName || gateway.name} does not have Service Discovery enabled.`,
+            })
+          }
+          if (gateway.applications && gateway.applications.length === 0) {
+            issues.push({
+              severity: 'medium',
+              component: 'secureGateway',
+              message: `Secure Gateway ${gateway.displayName || gateway.name} has no application routing configured.`,
+            })
+          }
+          if (gateway.applications && gateway.applications.length > 0) {
+            for (const app of gateway.applications) {
+              const matchers = app.endpointMatchers || app.endpoint_matchers || []
+              for (const matcher of matchers) {
+                const ports = matcher.ports || []
+                if (ports.includes(80)) {
+                  issues.push({
+                    severity: 'medium',
+                    component: 'secureGateway.application',
+                    message: `Application ${app.displayName || app.name} on gateway ${gateway.displayName || gateway.name} routes port 80. If accessed over unencrypted HTTP (http://), Chrome and SEB extension send direct GET requests instead of establishing a CONNECT tunnel, resulting in 401 Unauthorized errors. Ensure traffic is served over HTTPS.`,
+                  })
+                }
+              }
+            }
+          }
+          if (gateway.applicationsError) {
+            issues.push({
+              severity: 'medium',
+              component: 'secureGateway',
+              message: `Failed to list applications for Secure Gateway ${gateway.displayName || gateway.name}: ${gateway.applicationsError}`,
+            })
+          }
+        }
+      }
+    }
+  }
+
   const SEVERITY_ORDER = {
     critical: 0,
     high: 1,
     medium: 2,
     warning: 3,
+    info: 4,
   }
 
   return issues.sort((a, b) => {
@@ -274,6 +353,7 @@ function classifyAction(action) {
  * @param {import('../../lib/api/cloud_identity_client.js').CloudIdentityClient} cloudIdentityClient - Client for listing DLP rules and detectors
  * @param {string} customerId - The Chrome customer ID used for scoping requests
  * @param {string} authToken - The Bearer token for authorized API access
+ * @param {object} [options] - Additional options including beyondcorpClient, projectId, and flags
  * @returns {Promise<object>} A consolidated object containing raw data from all services
  */
 async function fetchEnvironment(
@@ -283,7 +363,10 @@ async function fetchEnvironment(
   cloudIdentityClient,
   customerId,
   authToken,
+  options = {},
 ) {
+  const { beyondcorpClient, projectId, flags } = options
+
   const [
     customerData,
     orgUnitsData,
@@ -413,6 +496,33 @@ async function fetchEnvironment(
     normalizedUrlVisits = null
   }
 
+  let secureGateway = null
+  if (flags?.isEnabled(FLAGS.SECURE_GATEWAY_ENABLED)) {
+    if (!projectId) {
+      secureGateway = { projectId: null, gateways: [], skipped: true }
+    } else if (beyondcorpClient) {
+      try {
+        const rawGateways = await beyondcorpClient.listGateways(projectId, authToken)
+        const gateways = await Promise.all(
+          (rawGateways || []).map(async gw => {
+            const gatewayId = gw.name ? gw.name.split('/').pop() : gw.displayName
+            try {
+              const apps = await beyondcorpClient.listApplications(projectId, gatewayId, authToken)
+              return { ...gw, applications: apps || [] }
+            } catch (err) {
+              logger.error(`${TAGS.API} Error fetching applications for gateway ${gatewayId} in diagnosis:`, err)
+              return { ...gw, applications: [], applicationsError: err.message }
+            }
+          }),
+        )
+        secureGateway = { projectId, gateways, error: null }
+      } catch (err) {
+        logger.error(`${TAGS.API} Error fetching secure gateways in diagnosis:`, err)
+        secureGateway = { projectId, gateways: [], error: err.message }
+      }
+    }
+  }
+
   return {
     customer,
     orgUnits,
@@ -425,6 +535,7 @@ async function fetchEnvironment(
     securityInsights,
     contentTransfers: normalizedContentTransfers,
     urlVisits: normalizedUrlVisits,
+    secureGateway,
   }
 }
 
@@ -435,7 +546,16 @@ async function fetchEnvironment(
  * @param {object} sessionState - State object for the current session
  */
 export function registerDiagnoseEnvironmentTool(server, options, sessionState) {
-  const { adminSdkClient, chromeManagementClient, chromePolicyClient, cloudIdentityClient } = options
+  const {
+    adminSdkClient,
+    chromeManagementClient,
+    chromePolicyClient,
+    cloudIdentityClient,
+    featureFlags: flags = defaultFeatureFlags,
+  } = options
+  const beyondcorpClient = options.beyondcorpClient || options.apiClients?.beyondcorp
+
+  const isSecureGatewayEnabled = flags.isEnabled(FLAGS.SECURE_GATEWAY_ENABLED)
 
   server.registerTool(
     'diagnose_environment',
@@ -448,13 +568,17 @@ To drill into detail, pass a 'section' parameter:
 - "orgUnits" — paginated list of organizational units
 - "dlpRules" — paginated list of DLP rules with action types
 - "detectors" — paginated list of content detectors
-- "browserVersions" — all browser version counts
+- "browserVersions" — all browser version counts${isSecureGatewayEnabled ? '\n- "secureGateways" — paginated list of secure gateways' : ''}
 
 Use 'limit' and 'offset' for pagination on large datasets.`,
       inputSchema: z.object({
         customerId: z.string().optional().describe('The Chrome customer ID. Auto-resolved if omitted.'),
+        projectId: z
+          .string()
+          .optional()
+          .describe('The Google Cloud project ID (required to diagnose Secure Gateways).'),
         section: z
-          .enum(['orgUnits', 'dlpRules', 'detectors', 'browserVersions'])
+          .enum(['orgUnits', 'dlpRules', 'detectors', 'browserVersions', 'secureGateways'])
           .optional()
           .describe('Drill into a specific section with paginated results. Omit for summary.'),
         limit: z.number().int().min(1).max(200).optional().describe('Page size for detail sections (default 50).'),
@@ -464,7 +588,7 @@ Use 'limit' and 'offset' for pagination on large datasets.`,
     },
     guardedToolCall(
       {
-        handler: async ({ customerId, section, limit, offset }, { _requestInfo, authToken }) => {
+        handler: async ({ customerId, projectId, section, limit, offset }, { _requestInfo, authToken }) => {
           logger.info(`${TAGS.MCP} diagnose_environment: starting (section=${section || 'summary'})`)
 
           const env = await fetchEnvironment(
@@ -474,6 +598,7 @@ Use 'limit' and 'offset' for pagination on large datasets.`,
             cloudIdentityClient,
             customerId,
             authToken,
+            { beyondcorpClient, projectId, flags },
           )
 
           // Detail mode: return paginated section data
@@ -513,6 +638,7 @@ function buildSummaryResponse(env) {
     securityInsights,
     contentTransfers,
     urlVisits,
+    secureGateway,
   } = env
 
   const activeRules = allDlpRules.filter(r => r.state === 'ACTIVE')
@@ -544,6 +670,7 @@ function buildSummaryResponse(env) {
     securityInsights,
     contentTransfers,
     urlVisits,
+    secureGateway,
     browserVersions: { total: versions.length, deviceCount: totalDevices },
     issues: [],
   }
@@ -589,7 +716,23 @@ function buildSummaryResponse(env) {
   summary += `**DLP Rules:** ${allDlpRules.length} total (${activeRules.length} active: ${dlpRuleSummary.byAction.block} block, ${dlpRuleSummary.byAction.warn} warn, ${dlpRuleSummary.byAction.audit} audit, ${dlpRuleSummary.byAction.watermark} watermark)\n`
   summary += `**Detectors:** ${allDetectors.length}\n`
   summary += `**Browser Versions:** ${versions.length} versions across ${totalDevices} devices\n`
-  summary += `**SEB Extension:** ${sebExtension.isInstalled ? 'Force-installed' : 'Not installed'}\n\n`
+  summary += `**SEB Extension:** ${sebExtension.isInstalled ? 'Force-installed' : 'Not installed'}\n`
+
+  if (secureGateway) {
+    if (secureGateway.skipped) {
+      summary += `**Secure Gateways:** Not checked (provide 'projectId' parameter to diagnose Secure Gateways)\n`
+    } else if (secureGateway.error) {
+      summary += `**Secure Gateways (project: ${secureGateway.projectId}):** ⚠️ Query failed (see issues below)\n`
+    } else {
+      const gateways = secureGateway.gateways || []
+      const activeCount = gateways.filter(g => g.state === 'RUNNING').length
+      const sdCount = gateways.filter(g => Boolean(g.serviceDiscovery)).length
+      const appCount = gateways.reduce((sum, g) => sum + (g.applications ? g.applications.length : 0), 0)
+      summary += `**Secure Gateways (project: ${secureGateway.projectId}):** ${gateways.length} total (${activeCount} active, ${sdCount} with Service Discovery, ${appCount} app(s))\n`
+    }
+  }
+
+  summary += `\n`
 
   if (issueCount === 0) {
     summary += `**Result: No issues found.** The environment appears healthy.\n`
@@ -600,7 +743,14 @@ function buildSummaryResponse(env) {
     }
     summary += `**Result: ${issueCount} issue(s) found** (${countsStr})\n\n`
     for (const issue of sc.issues) {
-      const icon = issue.severity === 'critical' ? '🔴' : issue.severity === 'high' ? '🟠' : '🟡'
+      const icon =
+        issue.severity === 'critical'
+          ? '🔴'
+          : issue.severity === 'high'
+            ? '🟠'
+            : issue.severity === 'medium'
+              ? '🟡'
+              : 'ℹ️'
       let remediation = ''
       if (issue.component === 'securityInsights' && issue.severity === 'critical') {
         remediation =
@@ -613,7 +763,11 @@ function buildSummaryResponse(env) {
     }
   }
 
-  summary += `\nTo drill into details, call diagnose_environment again with section="orgUnits", "dlpRules", "detectors", or "browserVersions".`
+  const sectionsList = ['"orgUnits"', '"dlpRules"', '"detectors"', '"browserVersions"']
+  if (secureGateway) {
+    sectionsList.push('"secureGateways"')
+  }
+  summary += `\nTo drill into details, call diagnose_environment again with section=${sectionsList.join(', ')}.`
 
   logger.info(`${TAGS.MCP} diagnose_environment: summary complete (${issueCount} issues)`)
 
@@ -646,6 +800,15 @@ function buildDetailResponse(env, section, limit, offset) {
     case 'browserVersions':
       allItems = env.versions
       break
+    case 'secureGateways':
+      allItems = (env.secureGateway?.gateways || []).map(gw => ({
+        name: gw.name,
+        displayName: gw.displayName,
+        state: gw.state,
+        serviceDiscovery: Boolean(gw.serviceDiscovery),
+        applicationCount: gw.applications ? gw.applications.length : 0,
+      }))
+      break
     default:
       allItems = []
   }
@@ -676,6 +839,14 @@ function buildDetailResponse(env, section, limit, offset) {
         break
       case 'browserVersions':
         summary += items.map(v => `- **${v.version}** (${v.channel || 'UNKNOWN'}): ${v.count} devices`).join('\n')
+        break
+      case 'secureGateways':
+        summary += items
+          .map(
+            (gw, i) =>
+              `${offset + i + 1}. **${gw.displayName || gw.name}** — ${gw.state}, Service Discovery: ${gw.serviceDiscovery ? 'enabled' : 'disabled'}, Applications: ${gw.applicationCount}`,
+          )
+          .join('\n')
         break
     }
   }

--- a/tools/index.js
+++ b/tools/index.js
@@ -138,7 +138,7 @@ export function registerTools(server, options = {}, sessionState) {
     logger.debug(`${TAGS.MCP} Registering diagnose tool (EXPERIMENT_DIAGNOSE_TOOL_ENABLED is active)`)
     registerDiagnoseEnvironmentTool(
       server,
-      { ...commonOpts, chromeManagementClient, chromePolicyClient, cloudIdentityClient },
+      { ...commonOpts, chromeManagementClient, chromePolicyClient, cloudIdentityClient, featureFlags: flags },
       state,
     )
   }


### PR DESCRIPTION
## Summary
This PR adds support for **BeyondCorp Secure Gateway** and application routing diagnostics to the `diagnose_environment` tool under the `DIAGNOSE_TOOL_ENABLED` / `SECURE_GATEWAY_ENABLED` experiment flags. It also introduces a proactive `info` severity notification when Secure Gateway diagnostics are skipped (i.e. when `projectId` is omitted) to ensure LLM agents don't silently miss Secure Gateway health checks.

## Key Changes

1. **Secure Gateway Diagnostics (`tools/definitions/diagnose_environment.js`):**
   * Implemented BeyondCorp client integration to fetch gateways and their corresponding applications when a GCP `projectId` is provided.
   * Added configuration validation for **unencrypted HTTP (Port 80) upstreams**: flags applications mapping port 80 with a warning, explaining the Chrome / SEB extension HTTPS requirement.
   * Added an **`info` severity issue** when the diagnostic runs without a `projectId`, prompting the admin or agent to provide a `projectId` rather than silently skipping Secure Gateway health.
   * Supported the `info` severity level in `formatTextSummary` with a dedicated `ℹ️` icon.

2. **Integration and Tool Definitions (`tools/index.js`, `test/helpers/fake-api-server.js`):**
   * Registered `beyondcorpClient` (for listing gateways/applications) under the `diagnose_environment` tool options.
   * Added mock routes in `fake-api-server.js` to simulate gateway lists, application lists, and state evaluations in unit and integration test runs.

3. **Automated Evals and Tests:**
   * **`gw07` Evaluation Case (`test/evals/cases/gateway/gw07-diagnose-gateway.eval.js`):** Added a new P1 evaluation to verify that the agent uses `diagnose_environment` with the correct `projectId` and accurately summarizes gateway (Gateway Alpha) and application (App One) counts.
   * **`gw02` Evaluation Case (`test/evals/cases/gateway/gw02-get-gateway.eval.js`):** Updated fixture naming and assertions to match test expectations.
   * **Test Suites:** Created comprehensive unit tests in `test/local/diagnose_environment.test.js` and integration tests in `test/integration/tools/diagnose_environment.test.js` for the new secure gateway diagnostic logic (healthy gateways, error states, and skipped project ID scenarios).

---

## Verification

### Automated Tests
Verified all unit, integration, and smoke tests pass cleanly:
```bash
npm run presubmit
```

### Evaluation Validation
Verified that all Secure Gateway evaluations pass with a **100% pass rate**:
```bash
$ node test/evals/run.js --category gateway --runs 10
Running 8 eval(s) [full (agent + judge)] concurrency=5, runs=10...

  gw01   PASS  List the secure gateways in my Google Cloud pro...   2.3s/run  (10 of 10 runs passed)
  gw02   PASS  What are the details and configured application...   2.5s/run  (10 of 10 runs passed)
  gw03   PASS  Create a new BeyondCorp Secure Gateway named my...   3.2s/run  (10 of 10 runs passed)
  gw04   PASS  I want to manage access for secure gateway gate...   5.4s/run  (10 of 10 runs passed)
  gw05   PASS  I need to set up access to a private applicatio...   6.9s/run  (10 of 10 runs passed)
  gw06   PASS  I need to configure access to Salesforce (a Saa...   4.3s/run  (10 of 10 runs passed)
  gw07   PASS  Use the diagnose_environment tool to run a comp...   3.5s/run  (10 of 10 runs passed)
  gw08   PASS  My users are having trouble connecting to our p...   3.7s/run  (10 of 10 runs passed)

Results: 80 of 80 runs passed (100.0% pass rate)
  gateway             80 of 80 passed (100.0%)
```

### Interactive Testing (Jetski CLI)
* Verified using the Jetski CLI agent that when running diagnostics without a `projectId`, the agent receives and presents the informational message:
  > *ℹ️ Secure Gateway: Skipped (provide a projectId parameter to diagnose Secure Gateways)*
* Verified that when re-run with `projectId: "brett-public-preview"`, the agent successfully queries the GCP BeyondCorp API and reports gateway and application statuses.
