### PR TITLE
test(eval): add evals for check_ev_extension_status and update tool description

### DIFF
--- a/test/evals/cases/inspection/i19-ev_extension_installed.eval.js
+++ b/test/evals/cases/inspection/i19-ev_extension_installed.eval.js
@@ -1,0 +1,28 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export default {
+  id: 'i19',
+  priority: 'P1',
+  tags: ['inspection', 'extension'],
+  scenario: 'ev-extension-installed',
+  expectedTools: ['check_ev_extension_status'],
+  prompt: 'Check if the Endpoint Verification extension is force-installed for the root OU.',
+  goldenResponse:
+    'The agent should call the `check_ev_extension_status` tool for the root OU. It should report that the Endpoint Verification extension (ID `callobklhcbilhphinckomhgkigmfocg`) is force-installed.',
+  judgeInstructions:
+    'Verify that the agent called `check_ev_extension_status` for the root OU and reported that the Endpoint Verification extension is force-installed.',
+}

--- a/test/evals/cases/inspection/i20-ev_extension_missing.eval.js
+++ b/test/evals/cases/inspection/i20-ev_extension_missing.eval.js
@@ -1,0 +1,28 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export default {
+  id: 'i20',
+  priority: 'P1',
+  tags: ['inspection', 'extension'],
+  scenario: 'healthy',
+  expectedTools: ['check_ev_extension_status'],
+  prompt: 'Check if the Endpoint Verification extension is force-installed for the root OU.',
+  goldenResponse:
+    'The agent should call the `check_ev_extension_status` tool for the root OU. It should report that the Endpoint Verification extension (ID `callobklhcbilhphinckomhgkigmfocg`) is NOT force-installed. It should recommend force-installing the extension and explain that it is required for Context-Aware Access (CAA) levels to be enforced.',
+  judgeInstructions:
+    'Verify that the agent called `check_ev_extension_status` for the root OU and reported that the Endpoint Verification extension is NOT force-installed. The agent MUST recommend force-installing the extension and explain that it is required for Context-Aware Access (CAA) levels to be enforced.',
+}

--- a/test/evals/scenarios/ev-extension-installed.js
+++ b/test/evals/scenarios/ev-extension-installed.js
@@ -1,0 +1,47 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @fileoverview Scenario: Endpoint Verification extension force-installed.
+ */
+
+const EV_EXTENSION_ID = 'chrome:callobklhcbilhphinckomhgkigmfocg'
+
+/** @param {object} state - Cloned base state. */
+export function mutate(state) {
+  state.globalConnectorPolicies['chrome.users.apps.InstallType'] = [
+    ...(state.globalConnectorPolicies['chrome.users.apps.InstallType'] || []),
+    {
+      targetKey: {
+        targetResource: 'orgunits/ouRoot',
+        additionalTargetKeys: {
+          app_id: EV_EXTENSION_ID,
+        },
+      },
+      sourceKey: {
+        targetResource: 'orgunits/ouRoot',
+        additionalTargetKeys: {
+          app_id: EV_EXTENSION_ID,
+        },
+      },
+      value: {
+        policySchema: 'chrome.users.apps.InstallType',
+        value: { appInstallType: 'FORCED' },
+      },
+    },
+  ]
+  return state
+}

--- a/tools/definitions/check_ev_extension_status.js
+++ b/tools/definitions/check_ev_extension_status.js
@@ -42,7 +42,8 @@ export function registerCheckEvExtensionStatusTool(server, options, sessionState
     'check_ev_extension_status',
     {
       description: `Checks if the Endpoint Verification (EV) extension is force-installed for a given Organizational Unit.
-The EV extension is REQUIRED for gathering device posture to use Context-Aware Access (CAA) levels.`,
+The EV extension is REQUIRED for gathering device posture to use Context-Aware Access (CAA) levels.
+If the extension is NOT force-installed, you MUST recommend that the administrator force-installs it and explain that it is required for Context-Aware Access (CAA) levels to be enforced.`,
       inputSchema: {
         customerId: z.string().optional().describe('The Chrome customer ID (e.g. C012345).'),
         orgUnitId: z.string().describe('The ID of the organizational unit to check.'),


### PR DESCRIPTION
# Summary of Changes: Evals for `check_ev_extension_status`

Added new evaluation cases to verify the behavior of the `check_ev_extension_status` tool and updated the tool's description to include instructions on recommending installation when the extension is missing.

### 1. Evals & Scenarios Created
*   **`test/evals/scenarios/ev-extension-installed.js`**:
    *   Defines a scenario that mutates the base state to force-install the Endpoint Verification extension (`chrome:callobklhcbilhphinckomhgkigmfocg`) on the root OU (`ouRoot`).
*   **`test/evals/cases/inspection/i19-ev_extension_installed.eval.js`**:
    *   Tests the case where the EV extension **is** force-installed.
    *   Expects the agent to call `check_ev_extension_status` and report that the extension is force-installed.
*   **`test/evals/cases/inspection/i20-ev_extension_missing.eval.js`**:
    *   Tests the case where the EV extension **is NOT** force-installed (using the default `healthy` scenario).
    *   Expects the agent to call `check_ev_extension_status`, report it missing, recommend force-installing it, and explain that it is required for Context-Aware Access (CAA) levels to be enforced (per user comments).

### 2. Tool Definition Updated
*   **`tools/definitions/check_ev_extension_status.js`**:
    *   Updated the tool's `description` to instruct the agent to recommend force-installing the extension when it is missing and explain that it is required for CAA. This aligns the agent's behavior with the new evaluation expectations in `i20`.

## Testing

Ran the following command

```
node test/evals/run.js --id i19,i20 --runs 6
```

and the pass rate was 100%