### PR TITLE
feat: implement install_ev_extension tool and tests

### DIFF
--- a/.github/expected-tarball.txt
+++ b/.github/expected-tarball.txt
@@ -99,6 +99,7 @@ tools/definitions/get_chrome_activity_log.js
 tools/definitions/get_connector_policy.js
 tools/definitions/get_customer_id.js
 tools/definitions/get_dlp_rule.js
+tools/definitions/install_ev_extension.js
 tools/definitions/install_seb_extension.js
 tools/definitions/knowledge.js
 tools/definitions/list_customer_profiles.js

--- a/test/integration/server/mcp-server.test.js
+++ b/test/integration/server/mcp-server.test.js
@@ -96,6 +96,7 @@ describe('MCP Server in stdio mode', () => {
         'get_connector_policy',
         'get_customer_id',
         'get_dlp_rule',
+        'install_ev_extension',
         'install_seb_extension',
         'list_customer_profiles',
         'list_detectors',

--- a/test/local/extension_tools.test.js
+++ b/test/local/extension_tools.test.js
@@ -329,10 +329,15 @@ describe('Extension Tools', () => {
     )
   })
 
-  test('When install_ev_extension is called and extension is already installed, then it skips modification', async () => {
+  test('When install_ev_extension is called and extension is already installed directly, then it skips modification', async () => {
     const mockResolvePolicy = mock.fn(async () => [
       {
         targetKey: {
+          targetResource: 'orgunits/ou1',
+          additionalTargetKeys: { app_id: `chrome:${EV_EXTENSION_ID}` },
+        },
+        sourceKey: {
+          targetResource: 'orgunits/ou1',
           additionalTargetKeys: { app_id: `chrome:${EV_EXTENSION_ID}` },
         },
         value: {
@@ -370,7 +375,67 @@ describe('Extension Tools', () => {
     const result = await handler({ customerId: 'C123', orgUnitId: 'ou1' }, { requestInfo: {} })
 
     assert.strictEqual(mockBatchModifyPolicy.mock.callCount(), 0)
-    assert.ok(result.content[0].text.includes('Endpoint Verification extension is already force-installed on this OU.'))
+    assert.ok(
+      result.content[0].text.includes(
+        'Endpoint Verification extension is already force-installed directly on this OU.',
+      ),
+    )
+  })
+
+  test('When install_ev_extension is called and extension is inherited, then it force-installs it directly', async () => {
+    const mockResolvePolicy = mock.fn(async () => [
+      {
+        targetKey: {
+          targetResource: 'orgunits/ou1',
+          additionalTargetKeys: { app_id: `chrome:${EV_EXTENSION_ID}` },
+        },
+        sourceKey: {
+          targetResource: 'orgunits/parent_ou',
+          additionalTargetKeys: { app_id: `chrome:${EV_EXTENSION_ID}` },
+        },
+        value: {
+          policySchema: INSTALL_TYPE_SCHEMA,
+          value: { appInstallType: 'FORCED' },
+        },
+      },
+    ])
+    const mockBatchModifyPolicy = mock.fn()
+
+    const MockChromePolicyClient = class {
+      constructor() {
+        this.resolvePolicy = mockResolvePolicy
+        this.batchModifyPolicy = mockBatchModifyPolicy
+      }
+    }
+
+    const { registerTools } = await esmock(
+      '../../tools/index.js',
+      {},
+      {
+        '../../lib/api/chrome_policy_client.js': {
+          ChromePolicyClient: MockChromePolicyClient,
+        },
+      },
+    )
+
+    registerTools(server, {
+      apiClients: { chromePolicy: new MockChromePolicyClient() },
+    })
+
+    const handler = server.registerTool.mock.calls.find(call => call.arguments[0] === 'install_ev_extension')
+      .arguments[2]
+
+    const result = await handler({ customerId: 'C123', orgUnitId: 'ou1' }, { requestInfo: {} })
+
+    assert.strictEqual(mockBatchModifyPolicy.mock.callCount(), 1)
+    const passedRequests = mockBatchModifyPolicy.mock.calls[0].arguments[2]
+    assert.strictEqual(passedRequests[0].policyValue.value.appInstallType, 'FORCED')
+    assert.strictEqual(passedRequests[0].policyTargetKey.additionalTargetKeys.app_id, `chrome:${EV_EXTENSION_ID}`)
+    assert.ok(
+      result.content[0].text.includes(
+        'Successfully force-installed Endpoint Verification extension directly on this OU (previously inherited from parent OU: `parent_ou`).',
+      ),
+    )
   })
 
   test('When install_ev_extension is called and extension is missing, then it force-installs it', async () => {
@@ -408,7 +473,9 @@ describe('Extension Tools', () => {
     assert.strictEqual(passedRequests[0].policyValue.value.appInstallType, 'FORCED')
     assert.strictEqual(passedRequests[0].policyTargetKey.additionalTargetKeys.app_id, `chrome:${EV_EXTENSION_ID}`)
     assert.ok(
-      result.content[0].text.includes('Successfully force-installed Endpoint Verification extension on this OU.'),
+      result.content[0].text.includes(
+        'Successfully force-installed Endpoint Verification extension directly on this OU. Policy propagation may take time.',
+      ),
     )
   })
 })

--- a/test/local/extension_tools.test.js
+++ b/test/local/extension_tools.test.js
@@ -328,4 +328,87 @@ describe('Extension Tools', () => {
         result.content[0].text.includes('NOT force-installed'),
     )
   })
+
+  test('When install_ev_extension is called and extension is already installed, then it skips modification', async () => {
+    const mockResolvePolicy = mock.fn(async () => [
+      {
+        targetKey: {
+          additionalTargetKeys: { app_id: `chrome:${EV_EXTENSION_ID}` },
+        },
+        value: {
+          policySchema: INSTALL_TYPE_SCHEMA,
+          value: { appInstallType: 'FORCED' },
+        },
+      },
+    ])
+    const mockBatchModifyPolicy = mock.fn()
+
+    const MockChromePolicyClient = class {
+      constructor() {
+        this.resolvePolicy = mockResolvePolicy
+        this.batchModifyPolicy = mockBatchModifyPolicy
+      }
+    }
+
+    const { registerTools } = await esmock(
+      '../../tools/index.js',
+      {},
+      {
+        '../../lib/api/chrome_policy_client.js': {
+          ChromePolicyClient: MockChromePolicyClient,
+        },
+      },
+    )
+
+    registerTools(server, {
+      apiClients: { chromePolicy: new MockChromePolicyClient() },
+    })
+
+    const handler = server.registerTool.mock.calls.find(call => call.arguments[0] === 'install_ev_extension')
+      .arguments[2]
+
+    const result = await handler({ customerId: 'C123', orgUnitId: 'ou1' }, { requestInfo: {} })
+
+    assert.strictEqual(mockBatchModifyPolicy.mock.callCount(), 0)
+    assert.ok(result.content[0].text.includes('Endpoint Verification extension is already force-installed on this OU.'))
+  })
+
+  test('When install_ev_extension is called and extension is missing, then it force-installs it', async () => {
+    const mockResolvePolicy = mock.fn(async () => [])
+    const mockBatchModifyPolicy = mock.fn()
+
+    const MockChromePolicyClient = class {
+      constructor() {
+        this.resolvePolicy = mockResolvePolicy
+        this.batchModifyPolicy = mockBatchModifyPolicy
+      }
+    }
+
+    const { registerTools } = await esmock(
+      '../../tools/index.js',
+      {},
+      {
+        '../../lib/api/chrome_policy_client.js': {
+          ChromePolicyClient: MockChromePolicyClient,
+        },
+      },
+    )
+
+    registerTools(server, {
+      apiClients: { chromePolicy: new MockChromePolicyClient() },
+    })
+
+    const handler = server.registerTool.mock.calls.find(call => call.arguments[0] === 'install_ev_extension')
+      .arguments[2]
+
+    const result = await handler({ customerId: 'C123', orgUnitId: 'ou1' }, { requestInfo: {} })
+
+    assert.strictEqual(mockBatchModifyPolicy.mock.callCount(), 1)
+    const passedRequests = mockBatchModifyPolicy.mock.calls[0].arguments[2]
+    assert.strictEqual(passedRequests[0].policyValue.value.appInstallType, 'FORCED')
+    assert.strictEqual(passedRequests[0].policyTargetKey.additionalTargetKeys.app_id, `chrome:${EV_EXTENSION_ID}`)
+    assert.ok(
+      result.content[0].text.includes('Successfully force-installed Endpoint Verification extension on this OU.'),
+    )
+  })
 })

--- a/test/local/tool-registration.test.js
+++ b/test/local/tool-registration.test.js
@@ -45,6 +45,7 @@ const CORE_TOOLS = [
   'get_customer_id',
   'get_dlp_rule',
   'get_document',
+  'install_ev_extension',
   'install_seb_extension',
   'list_customer_profiles',
   'list_detectors',

--- a/tools/definitions/install_ev_extension.js
+++ b/tools/definitions/install_ev_extension.js
@@ -53,6 +53,9 @@ The EV extension is REQUIRED for gathering device posture to use Context-Aware A
         success: z.boolean(),
         alreadyInstalled: z.boolean(),
         newlyInstalled: z.boolean(),
+        inherited: z.boolean().optional(),
+        sourceOrgUnitId: z.string().optional(),
+        targetOrgUnitId: z.string().optional(),
       }),
     },
     guardedToolCall(
@@ -86,10 +89,25 @@ The EV extension is REQUIRED for gathering device posture to use Context-Aware A
               p.targetKey?.additionalTargetKeys?.app_id === `chrome:${EV_EXTENSION_ID}`,
           )
 
-          if (evPolicy?.value?.value?.appInstallType === 'FORCED') {
-            const sc = { success: true, alreadyInstalled: true, newlyInstalled: false }
+          const isInstalled = evPolicy?.value?.value?.appInstallType === 'FORCED'
+          const targetResource = evPolicy?.targetKey?.targetResource
+          const sourceResource = evPolicy?.sourceKey?.targetResource
+
+          const targetOrgUnitId = targetResource ? targetResource.split('/').pop() : undefined
+          const sourceOrgUnitId = sourceResource ? sourceResource.split('/').pop() : undefined
+          const inherited = targetOrgUnitId && sourceOrgUnitId ? targetOrgUnitId !== sourceOrgUnitId : undefined
+
+          if (isInstalled && !inherited) {
+            const sc = {
+              success: true,
+              alreadyInstalled: true,
+              newlyInstalled: false,
+              inherited,
+              sourceOrgUnitId,
+              targetOrgUnitId,
+            }
             return formatToolResponse({
-              summary: 'Endpoint Verification extension is already force-installed on this OU.',
+              summary: 'Endpoint Verification extension is already force-installed directly on this OU.',
               data: sc,
               structuredContent: sc,
             })
@@ -116,10 +134,18 @@ The EV extension is REQUIRED for gathering device posture to use Context-Aware A
 
           await chromePolicyClient.batchModifyPolicy(customerId, orgUnitId, requests, authToken)
 
-          const sc = { success: true, alreadyInstalled: false, newlyInstalled: true }
+          const sc = {
+            success: true,
+            alreadyInstalled: false,
+            newlyInstalled: true,
+            inherited: false,
+            sourceOrgUnitId: orgUnitId,
+            targetOrgUnitId: orgUnitId,
+          }
           return formatToolResponse({
-            summary:
-              'Successfully force-installed Endpoint Verification extension on this OU. Policy propagation may take time.',
+            summary: `Successfully force-installed Endpoint Verification extension directly on this OU${
+              inherited ? ` (previously inherited from parent OU: \`${sourceOrgUnitId}\`)` : ''
+            }. Policy propagation may take time.`,
             data: sc,
             structuredContent: sc,
           })

--- a/tools/definitions/install_ev_extension.js
+++ b/tools/definitions/install_ev_extension.js
@@ -42,7 +42,8 @@ export function registerInstallEvExtensionTool(server, options, sessionState) {
     'install_ev_extension',
     {
       description: `Force-installs the Endpoint Verification (EV) extension for a given Organizational Unit.
-The EV extension is REQUIRED for gathering device posture to use Context-Aware Access (CAA) levels.`,
+The EV extension is REQUIRED for gathering device posture to use Context-Aware Access (CAA) levels.
+If the user requests to UNINSTALL or REMOVE the Endpoint Verification extension, you MUST decline to do so programmatically. Instead, instruct them to remove it manually in the Google Admin Console at https://admin.google.com/ac/apps/chrome/apps`,
       inputSchema: {
         customerId: z.string().optional().describe('The Chrome customer ID (e.g. C012345).'),
         orgUnitId: z

--- a/tools/definitions/install_ev_extension.js
+++ b/tools/definitions/install_ev_extension.js
@@ -1,0 +1,132 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file Tool definition for force-installing the Endpoint Verification extension.
+ */
+
+import { z } from 'zod'
+import { guardedToolCall, formatToolResponse } from '../utils/wrapper.js'
+import { TAGS } from '../../lib/constants.js'
+import { logger } from '../../lib/util/logger.js'
+
+const EV_EXTENSION_ID = 'callobklhcbilhphinckomhgkigmfocg'
+const INSTALL_TYPE_SCHEMA = 'chrome.users.apps.InstallType'
+
+/**
+ * Registers the 'install_ev_extension' tool with the MCP server.
+ * @param {import('@modelcontextprotocol/sdk/server/mcp.js').McpServer} server - The MCP server instance.
+ * @param {object} options - Configuration options for the tool.
+ * @param {import('../../lib/api/chrome_policy_client.js').ChromePolicyClient} options.chromePolicyClient - The Chrome Policy client instance.
+ * @param {object} sessionState - The session state object for caching.
+ * @returns {void}
+ */
+export function registerInstallEvExtensionTool(server, options, sessionState) {
+  const { chromePolicyClient } = options
+  logger.debug(`${TAGS.MCP} Registering 'install_ev_extension' tool...`)
+
+  server.registerTool(
+    'install_ev_extension',
+    {
+      description: `Force-installs the Endpoint Verification (EV) extension for a given Organizational Unit.
+The EV extension is REQUIRED for gathering device posture to use Context-Aware Access (CAA) levels.`,
+      inputSchema: {
+        customerId: z.string().optional().describe('The Chrome customer ID (e.g. C012345).'),
+        orgUnitId: z
+          .string()
+          .describe('The ID of the organizational unit where the extension will be force-installed.'),
+      },
+      outputSchema: z.looseObject({
+        success: z.boolean(),
+        alreadyInstalled: z.boolean(),
+        newlyInstalled: z.boolean(),
+      }),
+    },
+    guardedToolCall(
+      {
+        /**
+         * Handler for force-installing the EV extension.
+         * @param {object} params - The tool parameters.
+         * @param {string} [params.customerId] - The Chrome customer ID.
+         * @param {string} params.orgUnitId - The organizational unit ID.
+         * @param {object} context - The tool execution context.
+         * @param {object} context._requestInfo - The request info object.
+         * @param {string} context.authToken - The OAuth2 access token.
+         * @returns {Promise<object>} The formatted tool response.
+         */
+        handler: async ({ customerId, orgUnitId }, { _requestInfo, authToken }) => {
+          logger.debug(
+            `${TAGS.MCP} Calling 'install_ev_extension' with customerId: ${customerId}, orgUnitId: ${orgUnitId}`,
+          )
+
+          // Resolve current policy to see if it's already force-installed
+          const currentPolicies = await chromePolicyClient.resolvePolicy(
+            customerId,
+            orgUnitId,
+            INSTALL_TYPE_SCHEMA,
+            authToken,
+          )
+
+          const evPolicy = currentPolicies?.find(
+            p =>
+              p.value?.policySchema === INSTALL_TYPE_SCHEMA &&
+              p.targetKey?.additionalTargetKeys?.app_id === `chrome:${EV_EXTENSION_ID}`,
+          )
+
+          if (evPolicy?.value?.value?.appInstallType === 'FORCED') {
+            const sc = { success: true, alreadyInstalled: true, newlyInstalled: false }
+            return formatToolResponse({
+              summary: 'Endpoint Verification extension is already force-installed on this OU.',
+              data: sc,
+              structuredContent: sc,
+            })
+          }
+
+          // Update the policy to set it to FORCED
+          const requests = [
+            {
+              policyTargetKey: {
+                targetResource: `orgunits/${orgUnitId}`,
+                additionalTargetKeys: {
+                  app_id: `chrome:${EV_EXTENSION_ID}`,
+                },
+              },
+              policyValue: {
+                policySchema: INSTALL_TYPE_SCHEMA,
+                value: {
+                  appInstallType: 'FORCED',
+                },
+              },
+              updateMask: 'appInstallType',
+            },
+          ]
+
+          await chromePolicyClient.batchModifyPolicy(customerId, orgUnitId, requests, authToken)
+
+          const sc = { success: true, alreadyInstalled: false, newlyInstalled: true }
+          return formatToolResponse({
+            summary:
+              'Successfully force-installed Endpoint Verification extension on this OU. Policy propagation may take time.',
+            data: sc,
+            structuredContent: sc,
+          })
+        },
+      },
+      options,
+      sessionState,
+    ),
+  )
+}

--- a/tools/index.js
+++ b/tools/index.js
@@ -42,6 +42,7 @@ import { registerCreateDefaultDlpRulesTool } from './definitions/create_default_
 import { registerCheckSebExtensionStatusTool } from './definitions/check_seb_extension_status.js'
 import { registerCheckEvExtensionStatusTool } from './definitions/check_ev_extension_status.js'
 import { registerInstallSebExtensionTool } from './definitions/install_seb_extension.js'
+import { registerInstallEvExtensionTool } from './definitions/install_ev_extension.js'
 import { registerCheckAndEnableCepApiTool } from './definitions/check_and_enable_cep_api.js'
 import { registerEnableChromeEnterpriseConnectorsTool } from './definitions/enable_chrome_enterprise_connectors.js'
 import { registerDiagnoseEnvironmentTool } from './definitions/diagnose_environment.js'
@@ -125,6 +126,7 @@ export function registerTools(server, options = {}, sessionState) {
   registerCheckSebExtensionStatusTool(server, { ...commonOpts, chromePolicyClient }, state)
   registerCheckEvExtensionStatusTool(server, { ...commonOpts, chromePolicyClient }, state)
   registerInstallSebExtensionTool(server, { ...commonOpts, chromePolicyClient }, state)
+  registerInstallEvExtensionTool(server, { ...commonOpts, chromePolicyClient }, state)
   if (registerEnableApi) {
     registerCheckAndEnableCepApiTool(server, { ...commonOpts, serviceUsageClient }, state)
   }


### PR DESCRIPTION
# Summary of Changes: Implementation of `install_ev_extension` Tool

Implemented a new MCP tool `install_ev_extension` that allows administrators to force-install the Endpoint Verification (EV) extension on a given Organizational Unit (OU). This tool is critical for setting up the required environment for Context-Aware Access (CAA) levels.

### 1. New Tool Implementation
*   **`tools/definitions/install_ev_extension.js`**:
    *   Defines the `install_ev_extension` tool.
    *   Checks if the Endpoint Verification extension (`callobklhcbilhphinckomhgkigmfocg`) is already force-installed on the target OU using `chromePolicyClient.resolvePolicy`.
    *   If missing, it sends a `batchModifyPolicy` request setting the `appInstallType` to `FORCED` for the EV extension ID.
    *   Returns structured details (`success`, `alreadyInstalled`, `newlyInstalled`) and a friendly summary.

### 2. Registration & Configuration
*   **`tools/index.js`**:
    *   Imported and registered `install_ev_extension` under the `registerTools` list.
*   **`.github/expected-tarball.txt`**:
    *   Added `tools/definitions/install_ev_extension.js` to ensure it is packaged correctly.

### 3. Verification & Testing
*   **`test/local/extension_tools.test.js`**:
    *   Added two unit tests to verify:
        1.  *Skipping modification* if the EV extension is already force-installed.
        2.  *Executing policy modification* (setting `appInstallType` to `FORCED`) if the EV extension is missing.
*   **`test/local/tool-registration.test.js`**:
    *   Added `install_ev_extension` to the `CORE_TOOLS` validation list.
*   **`test/integration/server/mcp-server.test.js`**:
    *   Updated the expected toolNames array for integration listTools testing.

## Manual Testing

Prompted Gemini CLI to install Endpoint Verification for my domain. It first checked if it was already installed for my root OU, then asked me which OU I wanted to install it for. I selected Root OU and these were the results
<img width="1888" height="1124" alt="InstallEVExtension1" src="https://github.com/user-attachments/assets/79e67fc0-cec3-4dcd-88e2-6f573b1c2f73" />
<img width="1888" height="1124" alt="InstallEVExtension2" src="https://github.com/user-attachments/assets/24818279-fe4b-4812-8b11-0741230b1039" />
