### PR TITLE
feat(auth): harden MCP server for Service Account mode and Domain-Wide Delegation

### DIFF
--- a/lib/util/auth-error.js
+++ b/lib/util/auth-error.js
@@ -36,10 +36,27 @@ export function getAuthErrorMessage(error) {
   const lower = errorMessage.toLowerCase()
   const isInsufficientScopes = lower.includes(ERROR_MESSAGES.INSUFFICIENT_SCOPES.toLowerCase())
   const isApiNotEnabled = errorMessage.includes(ERROR_MESSAGES.API_NOT_USED_IN_PROJECT)
+  const isSaMode = !!process.env.GOOGLE_APPLICATION_CREDENTIALS
+  const isImpersonating = !!process.env.CEP_IMPERSONATE_SUBJECT
+  const isDwdError =
+    lower.includes('unauthorized_client') ||
+    (isImpersonating && (lower.includes('access_denied') || lower.includes('client is unauthorized')))
 
   let instruction = ''
-  if (isInsufficientScopes) {
-    instruction = `The cached OAuth token is missing one or more required scopes. Run the \`cep_auth\` tool, or re-run \`${cliInvocation('auth login')}\` at the shell, to re-consent with the updated scope set.`
+  if (isDwdError) {
+    instruction =
+      'Domain-Wide Delegation (DWD) authorization failed.\n\n' +
+      'Ensure the Service Account Client ID is authorized in Google Workspace Admin Console:\n' +
+      '  1. Open https://admin.google.com/ > Security > API Controls > Domain-wide Delegation.\n' +
+      '  2. Add your Service Account Client ID with required OAuth scopes (e.g., Cloud Identity policies and Chrome Management).\n' +
+      '  3. Ensure CEP_IMPERSONATE_SUBJECT is set to a valid Google Workspace admin email.'
+  } else if (isInsufficientScopes) {
+    if (isSaMode) {
+      instruction =
+        'The Service Account or delegated token has insufficient scopes. Verify the Domain-Wide Delegation OAuth scopes authorized in Google Workspace Admin Console.'
+    } else {
+      instruction = `The cached OAuth token is missing one or more required scopes. Run the \`cep_auth\` tool, or re-run \`${cliInvocation('auth login')}\` at the shell, to re-consent with the updated scope set.`
+    }
   } else if (isApiNotEnabled) {
     const apiList = Object.values(SERVICE_NAMES).join(' ')
     const authProjectNumber = MANAGED_OAUTH_CLIENT_ID.split('-')[0]

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -202,6 +202,9 @@ export function createSseHandler(gcpInfo, sseTransports, getServerImpl = getServ
  */
 function shouldRegisterEnableApi() {
   try {
+    if (process.env.GOOGLE_APPLICATION_CREDENTIALS || !isStdioMode()) {
+      return true
+    }
     const config = resolveOAuthClientConfig()
     return config.source !== 'managed'
   } catch {

--- a/test/local/auth.test.js
+++ b/test/local/auth.test.js
@@ -355,4 +355,54 @@ describe('Auth', () => {
       assert.doesNotMatch(message, /cep_auth/)
     })
   })
+
+  describe('guardedToolCall error mapping regressions', () => {
+    test('When handler throws unauthorized_client with status 400 in SA mode, then it returns DWD instructions', async () => {
+      const { guardedToolCall } = await import('../../tools/utils/wrapper.js')
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = '/tmp/fake-key.json'
+      process.env.CEP_IMPERSONATE_SUBJECT = 'admin@example.com'
+      const wrapped = guardedToolCall(
+        {
+          requiresDelegation: true,
+          skipAutoResolve: true,
+          handler: async () => {
+            const error = new Error(
+              '400 unauthorized_client: Client is unauthorized to retrieve access tokens using this method.',
+            )
+            error.status = 400
+            throw error
+          },
+        },
+        {},
+        {},
+      )
+      const result = await wrapped({}, { name: 'test_tool' })
+      assert.strictEqual(result.isError, true)
+      // It should return the DWD instructions (which mention Domain-Wide Delegation)
+      assert.match(result.content[0].text, /Domain-Wide Delegation/i)
+    })
+
+    test('When handler throws invalid_grant with status 400 in SA mode, then it returns 401 SA credentials error message', async () => {
+      const { guardedToolCall } = await import('../../tools/utils/wrapper.js')
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = '/tmp/fake-key.json'
+      process.env.CEP_IMPERSONATE_SUBJECT = 'admin@example.com'
+      const wrapped = guardedToolCall(
+        {
+          requiresDelegation: true,
+          skipAutoResolve: true,
+          handler: async () => {
+            const error = new Error('400 invalid_grant: Invalid JWT Signature.')
+            error.status = 400
+            throw error
+          },
+        },
+        {},
+        {},
+      )
+      const result = await wrapped({}, { name: 'test_tool' })
+      assert.strictEqual(result.isError, true)
+      // It should return the 401 SA credentials error (mentioning invalid credentials or DWD failed)
+      assert.match(result.content[0].text, /Service Account credentials.*invalid.*domain-wide delegation failed/i)
+    })
+  })
 })

--- a/test/local/auth.test.js
+++ b/test/local/auth.test.js
@@ -393,7 +393,7 @@ describe('Auth', () => {
         )
         const result = await wrapped({}, {})
         assert.strictEqual(result.isError, true)
-        assert.match(result.content[0].text, /requires domain-wide delegation/)
+        assert.match(result.content[0].text, /requires domain-wide delegation/i)
       } finally {
         if (prevCred === undefined) {
           delete process.env.GOOGLE_APPLICATION_CREDENTIALS

--- a/test/local/auth.test.js
+++ b/test/local/auth.test.js
@@ -15,10 +15,39 @@ limitations under the License.
 */
 
 import assert from 'node:assert/strict'
-import { describe, test } from 'node:test'
+import { describe, test, beforeEach, afterEach } from 'node:test'
 import esmock from 'esmock'
 
 describe('Auth', () => {
+  let prevCred
+  let prevMode
+  let prevSub
+
+  beforeEach(() => {
+    prevCred = process.env.GOOGLE_APPLICATION_CREDENTIALS
+    prevMode = process.env.CEP_AUTH_MODE
+    prevSub = process.env.CEP_IMPERSONATE_SUBJECT
+  })
+
+  afterEach(() => {
+    if (prevCred === undefined) {
+      delete process.env.GOOGLE_APPLICATION_CREDENTIALS
+    } else {
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = prevCred
+    }
+
+    if (prevMode === undefined) {
+      delete process.env.CEP_AUTH_MODE
+    } else {
+      process.env.CEP_AUTH_MODE = prevMode
+    }
+
+    if (prevSub === undefined) {
+      delete process.env.CEP_IMPERSONATE_SUBJECT
+    } else {
+      process.env.CEP_IMPERSONATE_SUBJECT = prevSub
+    }
+  })
   test('When an auth token is provided, then it returns an OAuth2 client', async () => {
     const { getAuthClient } = await esmock('../../lib/util/auth.js', {
       'google-auth-library': {
@@ -53,22 +82,12 @@ describe('Auth', () => {
       },
     })
 
-    const previous = process.env.GOOGLE_APPLICATION_CREDENTIALS
     process.env.GOOGLE_APPLICATION_CREDENTIALS = '/tmp/fake-key.json'
-    try {
-      const client = await getAuthClient(['https://www.googleapis.com/auth/cloud-platform'])
-      assert.ok(client)
-      assert.strictEqual(observedConfig.email, 'svc@example.iam.gserviceaccount.com')
-      assert.deepStrictEqual(observedConfig.scopes, ['https://www.googleapis.com/auth/cloud-platform'])
-      assert.strictEqual(observedConfig.subject, undefined)
-    } finally {
-      if (previous === undefined) {
-        delete process.env.GOOGLE_APPLICATION_CREDENTIALS
-      } else {
-        // eslint-disable-next-line require-atomic-updates
-        process.env.GOOGLE_APPLICATION_CREDENTIALS = previous
-      }
-    }
+    const client = await getAuthClient(['https://www.googleapis.com/auth/cloud-platform'])
+    assert.ok(client)
+    assert.strictEqual(observedConfig.email, 'svc@example.iam.gserviceaccount.com')
+    assert.deepStrictEqual(observedConfig.scopes, ['https://www.googleapis.com/auth/cloud-platform'])
+    assert.strictEqual(observedConfig.subject, undefined)
   })
 
   test('When CEP_IMPERSONATE_SUBJECT is set, then the JWT is built with that subject for DWD', async () => {
@@ -91,27 +110,10 @@ describe('Auth', () => {
       },
     })
 
-    const prevCred = process.env.GOOGLE_APPLICATION_CREDENTIALS
-    const prevSub = process.env.CEP_IMPERSONATE_SUBJECT
     process.env.GOOGLE_APPLICATION_CREDENTIALS = '/tmp/fake-key.json'
     process.env.CEP_IMPERSONATE_SUBJECT = 'admin@example.com'
-    try {
-      await getAuthClient(['https://www.googleapis.com/auth/admin.directory.user'])
-      assert.strictEqual(observedConfig.subject, 'admin@example.com')
-    } finally {
-      if (prevCred === undefined) {
-        delete process.env.GOOGLE_APPLICATION_CREDENTIALS
-      } else {
-        // eslint-disable-next-line require-atomic-updates
-        process.env.GOOGLE_APPLICATION_CREDENTIALS = prevCred
-      }
-      if (prevSub === undefined) {
-        delete process.env.CEP_IMPERSONATE_SUBJECT
-      } else {
-        // eslint-disable-next-line require-atomic-updates
-        process.env.CEP_IMPERSONATE_SUBJECT = prevSub
-      }
-    }
+    await getAuthClient(['https://www.googleapis.com/auth/admin.directory.user'])
+    assert.strictEqual(observedConfig.subject, 'admin@example.com')
   })
 
   test('When GOOGLE_APPLICATION_CREDENTIALS points at a non-SA key, then it throws', async () => {
@@ -122,50 +124,30 @@ describe('Auth', () => {
       },
     })
 
-    const previous = process.env.GOOGLE_APPLICATION_CREDENTIALS
     process.env.GOOGLE_APPLICATION_CREDENTIALS = '/tmp/fake-key.json'
-    try {
-      await assert.rejects(() => getAuthClient([]), /not "service_account"/)
-    } finally {
-      if (previous === undefined) {
-        delete process.env.GOOGLE_APPLICATION_CREDENTIALS
-      } else {
-        // eslint-disable-next-line require-atomic-updates
-        process.env.GOOGLE_APPLICATION_CREDENTIALS = previous
-      }
-    }
+    await assert.rejects(() => getAuthClient([]), /not "service_account"/)
   })
 
   test('When no tokens exist and we are in stdio mode, then getAuthClient throws immediately without opening browser', async () => {
-    const previous = process.env.GOOGLE_APPLICATION_CREDENTIALS
     delete process.env.GOOGLE_APPLICATION_CREDENTIALS
-    try {
-      const { getAuthClient } = await esmock('../../lib/util/auth.js', {
-        '../../lib/util/gcp.js': {
-          isStdioMode: () => true,
+    const { getAuthClient } = await esmock('../../lib/util/auth.js', {
+      '../../lib/util/gcp.js': {
+        isStdioMode: () => true,
+      },
+      '../../lib/util/credential/token_cache.js': {
+        TokenCache: class {
+          static defaultPath() {
+            return '/tmp/fake-path'
+          }
+          constructor() {}
+          async readEnforcingMode() {
+            return null
+          }
         },
-        '../../lib/util/credential/token_cache.js': {
-          TokenCache: class {
-            static defaultPath() {
-              return '/tmp/fake-path'
-            }
-            constructor() {}
-            async readEnforcingMode() {
-              return null
-            }
-          },
-        },
-      })
+      },
+    })
 
-      await assert.rejects(() => getAuthClient(['some-scope']), /Authentication required. Run the `cep_auth` tool/)
-    } finally {
-      if (previous === undefined) {
-        delete process.env.GOOGLE_APPLICATION_CREDENTIALS
-      } else {
-        // eslint-disable-next-line require-atomic-updates
-        process.env.GOOGLE_APPLICATION_CREDENTIALS = previous
-      }
-    }
+    await assert.rejects(() => getAuthClient(['some-scope']), /Authentication required. Run the `cep_auth` tool/)
   })
 
   describe('getAuthErrorMessage', () => {
@@ -255,18 +237,9 @@ describe('Auth', () => {
           },
         },
       })
-      const prevMode = process.env.CEP_AUTH_MODE
       process.env.CEP_AUTH_MODE = 'bearer-only'
-      try {
-        const client = await getAuthClient([], 'test-token')
-        assert.ok(client)
-      } finally {
-        if (prevMode === undefined) {
-          delete process.env.CEP_AUTH_MODE
-        } else {
-          process.env.CEP_AUTH_MODE = prevMode
-        }
-      }
+      const client = await getAuthClient([], 'test-token')
+      assert.ok(client)
     })
 
     test('When CEP_AUTH_MODE is bearer-only and token is missing, then it throws even if SA credentials exist', async () => {
@@ -275,24 +248,9 @@ describe('Auth', () => {
           readFile: async () => JSON.stringify({ type: 'service_account', client_email: 'x', private_key: 'y' }),
         },
       })
-      const prevMode = process.env.CEP_AUTH_MODE
-      const prevCred = process.env.GOOGLE_APPLICATION_CREDENTIALS
       process.env.CEP_AUTH_MODE = 'bearer-only'
       process.env.GOOGLE_APPLICATION_CREDENTIALS = '/tmp/fake-key.json'
-      try {
-        await assert.rejects(() => getAuthClient([]), /strict "bearer-only" mode/)
-      } finally {
-        if (prevMode === undefined) {
-          delete process.env.CEP_AUTH_MODE
-        } else {
-          process.env.CEP_AUTH_MODE = prevMode
-        }
-        if (prevCred === undefined) {
-          delete process.env.GOOGLE_APPLICATION_CREDENTIALS
-        } else {
-          process.env.GOOGLE_APPLICATION_CREDENTIALS = prevCred
-        }
-      }
+      await assert.rejects(() => getAuthClient([]), /strict "bearer-only" mode/)
     })
 
     test('When CEP_AUTH_MODE is service-account-only and SA key exists, then it returns JWT client even if token is provided', async () => {
@@ -314,135 +272,66 @@ describe('Auth', () => {
           },
         },
       })
-      const prevMode = process.env.CEP_AUTH_MODE
-      const prevCred = process.env.GOOGLE_APPLICATION_CREDENTIALS
       process.env.CEP_AUTH_MODE = 'service-account-only'
       process.env.GOOGLE_APPLICATION_CREDENTIALS = '/tmp/fake-key.json'
-      try {
-        const client = await getAuthClient([], 'ignored-token')
-        assert.ok(client)
-        assert.ok(jwtInstantiated)
-      } finally {
-        if (prevMode === undefined) {
-          delete process.env.CEP_AUTH_MODE
-        } else {
-          process.env.CEP_AUTH_MODE = prevMode
-        }
-        if (prevCred === undefined) {
-          delete process.env.GOOGLE_APPLICATION_CREDENTIALS
-        } else {
-          process.env.GOOGLE_APPLICATION_CREDENTIALS = prevCred
-        }
-      }
+      const client = await getAuthClient([], 'ignored-token')
+      assert.ok(client)
+      assert.ok(jwtInstantiated)
     })
 
     test('When CEP_AUTH_MODE is service-account-only and SA key is missing, then it throws', async () => {
       const { getAuthClient } = await esmock('../../lib/util/auth.js', {})
-      const prevMode = process.env.CEP_AUTH_MODE
-      const prevCred = process.env.GOOGLE_APPLICATION_CREDENTIALS
       process.env.CEP_AUTH_MODE = 'service-account-only'
       delete process.env.GOOGLE_APPLICATION_CREDENTIALS
-      try {
-        await assert.rejects(() => getAuthClient([]), /GOOGLE_APPLICATION_CREDENTIALS is not set/)
-      } finally {
-        if (prevMode === undefined) {
-          delete process.env.CEP_AUTH_MODE
-        } else {
-          process.env.CEP_AUTH_MODE = prevMode
-        }
-        if (prevCred === undefined) {
-          delete process.env.GOOGLE_APPLICATION_CREDENTIALS
-        } else {
-          process.env.GOOGLE_APPLICATION_CREDENTIALS = prevCred
-        }
-      }
+      await assert.rejects(() => getAuthClient([]), /GOOGLE_APPLICATION_CREDENTIALS is not set/)
     })
 
     test('When CEP_AUTH_MODE is invalid, then it throws during client acquisition', async () => {
       const { getAuthClient } = await esmock('../../lib/util/auth.js', {})
-      const prevMode = process.env.CEP_AUTH_MODE
       process.env.CEP_AUTH_MODE = 'invalid-mode'
-      try {
-        await assert.rejects(() => getAuthClient([]), /Invalid CEP_AUTH_MODE/)
-      } finally {
-        if (prevMode === undefined) {
-          delete process.env.CEP_AUTH_MODE
-        } else {
-          process.env.CEP_AUTH_MODE = prevMode
-        }
-      }
+      await assert.rejects(() => getAuthClient([]), /Invalid CEP_AUTH_MODE/)
     })
   })
 
   describe('guardedToolCall delegation guard', () => {
     test('When running in SA mode and calling a tool with requiresDelegation=true without CEP_IMPERSONATE_SUBJECT, then it returns pre-flight error', async () => {
       const { guardedToolCall } = await import('../../tools/utils/wrapper.js')
-      const prevCred = process.env.GOOGLE_APPLICATION_CREDENTIALS
-      const prevSub = process.env.CEP_IMPERSONATE_SUBJECT
       process.env.GOOGLE_APPLICATION_CREDENTIALS = '/tmp/fake-key.json'
       delete process.env.CEP_IMPERSONATE_SUBJECT
-      try {
-        const wrapped = guardedToolCall(
-          {
-            requiresDelegation: true,
-            skipAutoResolve: true,
-            handler: async () => ({ content: [{ type: 'text', text: 'should not run' }] }),
-          },
-          {},
-          {},
-        )
-        const result = await wrapped({}, {})
-        assert.strictEqual(result.isError, true)
-        assert.match(result.content[0].text, /requires domain-wide delegation/i)
-      } finally {
-        if (prevCred === undefined) {
-          delete process.env.GOOGLE_APPLICATION_CREDENTIALS
-        } else {
-          process.env.GOOGLE_APPLICATION_CREDENTIALS = prevCred
-        }
-        if (prevSub === undefined) {
-          delete process.env.CEP_IMPERSONATE_SUBJECT
-        } else {
-          process.env.CEP_IMPERSONATE_SUBJECT = prevSub
-        }
-      }
+      const wrapped = guardedToolCall(
+        {
+          requiresDelegation: true,
+          skipAutoResolve: true,
+          handler: async () => ({ content: [{ type: 'text', text: 'should not run' }] }),
+        },
+        {},
+        {},
+      )
+      const result = await wrapped({}, {})
+      assert.strictEqual(result.isError, true)
+      assert.match(result.content[0].text, /requires domain-wide delegation/i)
     })
 
     test('When running in SA mode and calling a tool with requiresDelegation=false without CEP_IMPERSONATE_SUBJECT, then it runs handler and skips OAuth check', async () => {
       const { guardedToolCall } = await import('../../tools/utils/wrapper.js')
-      const prevCred = process.env.GOOGLE_APPLICATION_CREDENTIALS
-      const prevSub = process.env.CEP_IMPERSONATE_SUBJECT
       process.env.GOOGLE_APPLICATION_CREDENTIALS = '/tmp/fake-key.json'
       delete process.env.CEP_IMPERSONATE_SUBJECT
-      try {
-        let handlerRan = false
-        const wrapped = guardedToolCall(
-          {
-            requiresDelegation: false,
-            skipAutoResolve: true,
-            handler: async () => {
-              handlerRan = true
-              return { content: [{ type: 'text', text: 'ok' }] }
-            },
+      let handlerRan = false
+      const wrapped = guardedToolCall(
+        {
+          requiresDelegation: false,
+          skipAutoResolve: true,
+          handler: async () => {
+            handlerRan = true
+            return { content: [{ type: 'text', text: 'ok' }] }
           },
-          {},
-          {},
-        )
-        const result = await wrapped({}, {})
-        assert.strictEqual(handlerRan, true)
-        assert.strictEqual(result.content[0].text, 'ok')
-      } finally {
-        if (prevCred === undefined) {
-          delete process.env.GOOGLE_APPLICATION_CREDENTIALS
-        } else {
-          process.env.GOOGLE_APPLICATION_CREDENTIALS = prevCred
-        }
-        if (prevSub === undefined) {
-          delete process.env.CEP_IMPERSONATE_SUBJECT
-        } else {
-          process.env.CEP_IMPERSONATE_SUBJECT = prevSub
-        }
-      }
+        },
+        {},
+        {},
+      )
+      const result = await wrapped({}, {})
+      assert.strictEqual(handlerRan, true)
+      assert.strictEqual(result.content[0].text, 'ok')
     })
   })
 
@@ -459,20 +348,11 @@ describe('Auth', () => {
 
     test('When running in Service Account mode, then getAuthErrorMessage for insufficient scopes never mentions cep_auth', async () => {
       const { getAuthErrorMessage } = await import('../../lib/util/auth-error.js')
-      const prevCred = process.env.GOOGLE_APPLICATION_CREDENTIALS
       process.env.GOOGLE_APPLICATION_CREDENTIALS = '/tmp/fake-key.json'
-      try {
-        const error = new Error('Request had insufficient authentication scopes.')
-        const message = getAuthErrorMessage(error)
-        assert.match(message, /Verify the Domain-Wide Delegation OAuth scopes/)
-        assert.doesNotMatch(message, /cep_auth/)
-      } finally {
-        if (prevCred === undefined) {
-          delete process.env.GOOGLE_APPLICATION_CREDENTIALS
-        } else {
-          process.env.GOOGLE_APPLICATION_CREDENTIALS = prevCred
-        }
-      }
+      const error = new Error('Request had insufficient authentication scopes.')
+      const message = getAuthErrorMessage(error)
+      assert.match(message, /Verify the Domain-Wide Delegation OAuth scopes/)
+      assert.doesNotMatch(message, /cep_auth/)
     })
   })
 })

--- a/test/local/auth.test.js
+++ b/test/local/auth.test.js
@@ -264,7 +264,6 @@ describe('Auth', () => {
         if (prevMode === undefined) {
           delete process.env.CEP_AUTH_MODE
         } else {
-          // eslint-disable-next-line require-atomic-updates
           process.env.CEP_AUTH_MODE = prevMode
         }
       }
@@ -286,13 +285,11 @@ describe('Auth', () => {
         if (prevMode === undefined) {
           delete process.env.CEP_AUTH_MODE
         } else {
-          // eslint-disable-next-line require-atomic-updates
           process.env.CEP_AUTH_MODE = prevMode
         }
         if (prevCred === undefined) {
           delete process.env.GOOGLE_APPLICATION_CREDENTIALS
         } else {
-          // eslint-disable-next-line require-atomic-updates
           process.env.GOOGLE_APPLICATION_CREDENTIALS = prevCred
         }
       }
@@ -322,7 +319,6 @@ describe('Auth', () => {
       process.env.CEP_AUTH_MODE = 'service-account-only'
       process.env.GOOGLE_APPLICATION_CREDENTIALS = '/tmp/fake-key.json'
       try {
-        // Pass a token, but it should be ignored in favor of SA
         const client = await getAuthClient([], 'ignored-token')
         assert.ok(client)
         assert.ok(jwtInstantiated)
@@ -330,13 +326,11 @@ describe('Auth', () => {
         if (prevMode === undefined) {
           delete process.env.CEP_AUTH_MODE
         } else {
-          // eslint-disable-next-line require-atomic-updates
           process.env.CEP_AUTH_MODE = prevMode
         }
         if (prevCred === undefined) {
           delete process.env.GOOGLE_APPLICATION_CREDENTIALS
         } else {
-          // eslint-disable-next-line require-atomic-updates
           process.env.GOOGLE_APPLICATION_CREDENTIALS = prevCred
         }
       }
@@ -354,13 +348,11 @@ describe('Auth', () => {
         if (prevMode === undefined) {
           delete process.env.CEP_AUTH_MODE
         } else {
-          // eslint-disable-next-line require-atomic-updates
           process.env.CEP_AUTH_MODE = prevMode
         }
         if (prevCred === undefined) {
           delete process.env.GOOGLE_APPLICATION_CREDENTIALS
         } else {
-          // eslint-disable-next-line require-atomic-updates
           process.env.GOOGLE_APPLICATION_CREDENTIALS = prevCred
         }
       }
@@ -376,8 +368,109 @@ describe('Auth', () => {
         if (prevMode === undefined) {
           delete process.env.CEP_AUTH_MODE
         } else {
-          // eslint-disable-next-line require-atomic-updates
           process.env.CEP_AUTH_MODE = prevMode
+        }
+      }
+    })
+  })
+
+  describe('guardedToolCall delegation guard', () => {
+    test('When running in SA mode and calling a tool with requiresDelegation=true without CEP_IMPERSONATE_SUBJECT, then it returns pre-flight error', async () => {
+      const { guardedToolCall } = await import('../../tools/utils/wrapper.js')
+      const prevCred = process.env.GOOGLE_APPLICATION_CREDENTIALS
+      const prevSub = process.env.CEP_IMPERSONATE_SUBJECT
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = '/tmp/fake-key.json'
+      delete process.env.CEP_IMPERSONATE_SUBJECT
+      try {
+        const wrapped = guardedToolCall(
+          {
+            requiresDelegation: true,
+            skipAutoResolve: true,
+            handler: async () => ({ content: [{ type: 'text', text: 'should not run' }] }),
+          },
+          {},
+          {},
+        )
+        const result = await wrapped({}, {})
+        assert.strictEqual(result.isError, true)
+        assert.match(result.content[0].text, /requires domain-wide delegation/)
+      } finally {
+        if (prevCred === undefined) {
+          delete process.env.GOOGLE_APPLICATION_CREDENTIALS
+        } else {
+          process.env.GOOGLE_APPLICATION_CREDENTIALS = prevCred
+        }
+        if (prevSub === undefined) {
+          delete process.env.CEP_IMPERSONATE_SUBJECT
+        } else {
+          process.env.CEP_IMPERSONATE_SUBJECT = prevSub
+        }
+      }
+    })
+
+    test('When running in SA mode and calling a tool with requiresDelegation=false without CEP_IMPERSONATE_SUBJECT, then it runs handler and skips OAuth check', async () => {
+      const { guardedToolCall } = await import('../../tools/utils/wrapper.js')
+      const prevCred = process.env.GOOGLE_APPLICATION_CREDENTIALS
+      const prevSub = process.env.CEP_IMPERSONATE_SUBJECT
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = '/tmp/fake-key.json'
+      delete process.env.CEP_IMPERSONATE_SUBJECT
+      try {
+        let handlerRan = false
+        const wrapped = guardedToolCall(
+          {
+            requiresDelegation: false,
+            skipAutoResolve: true,
+            handler: async () => {
+              handlerRan = true
+              return { content: [{ type: 'text', text: 'ok' }] }
+            },
+          },
+          {},
+          {},
+        )
+        const result = await wrapped({}, {})
+        assert.strictEqual(handlerRan, true)
+        assert.strictEqual(result.content[0].text, 'ok')
+      } finally {
+        if (prevCred === undefined) {
+          delete process.env.GOOGLE_APPLICATION_CREDENTIALS
+        } else {
+          process.env.GOOGLE_APPLICATION_CREDENTIALS = prevCred
+        }
+        if (prevSub === undefined) {
+          delete process.env.CEP_IMPERSONATE_SUBJECT
+        } else {
+          process.env.CEP_IMPERSONATE_SUBJECT = prevSub
+        }
+      }
+    })
+  })
+
+  describe('Step 2 mode-aware error remediation', () => {
+    test('When DWD unauthorized_client error occurs, then getAuthErrorMessage returns DWD admin console instructions', async () => {
+      const { getAuthErrorMessage } = await import('../../lib/util/auth-error.js')
+      const error = new Error(
+        '401 unauthorized_client: Client is unauthorized to retrieve access tokens using this method.',
+      )
+      const message = getAuthErrorMessage(error)
+      assert.match(message, /Domain-Wide Delegation \(DWD\) authorization failed/)
+      assert.match(message, /admin\.google\.com/)
+    })
+
+    test('When running in Service Account mode, then getAuthErrorMessage for insufficient scopes never mentions cep_auth', async () => {
+      const { getAuthErrorMessage } = await import('../../lib/util/auth-error.js')
+      const prevCred = process.env.GOOGLE_APPLICATION_CREDENTIALS
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = '/tmp/fake-key.json'
+      try {
+        const error = new Error('Request had insufficient authentication scopes.')
+        const message = getAuthErrorMessage(error)
+        assert.match(message, /Verify the Domain-Wide Delegation OAuth scopes/)
+        assert.doesNotMatch(message, /cep_auth/)
+      } finally {
+        if (prevCred === undefined) {
+          delete process.env.GOOGLE_APPLICATION_CREDENTIALS
+        } else {
+          process.env.GOOGLE_APPLICATION_CREDENTIALS = prevCred
         }
       }
     })

--- a/test/run-utils.js
+++ b/test/run-utils.js
@@ -39,5 +39,6 @@ export function findTestFiles(dir) {
 export function sanitizeOauthClientEnv(env = process.env) {
   env.CEP_OAUTH_CLIENT_ID = ''
   env.CEP_OAUTH_CLIENT_SECRET = ''
+  env.GOOGLE_APPLICATION_CREDENTIALS = ''
   return env
 }

--- a/test/unit/tools/delete_agent_dlp_rule.test.js
+++ b/test/unit/tools/delete_agent_dlp_rule.test.js
@@ -32,6 +32,14 @@ describe('delete_agent_dlp_rule tool handler', () => {
     return registeredHandler
   }
 
+  const mockContext = {
+    requestInfo: {
+      headers: {
+        authorization: 'Bearer token-abc',
+      },
+    },
+  }
+
   test('When rule is agent-created, then deleteDlpRule (with re-validation) is NOT called', async () => {
     let getCalls = 0
     let preValidatedCalls = 0
@@ -52,7 +60,7 @@ describe('delete_agent_dlp_rule tool handler', () => {
     }
 
     const handler = getHandler(mockCloudIdentityClient)
-    await handler({ policyName: 'policies/akabc123' }, { authToken: 'token-abc' })
+    await handler({ policyName: 'policies/akabc123' }, mockContext)
 
     assert.strictEqual(getCalls, 1, 'getDlpRule should be called exactly once (no double policies.get)')
     assert.strictEqual(preValidatedCalls, 1, 'deleteDlpRulePreValidated should be called once')
@@ -72,7 +80,7 @@ describe('delete_agent_dlp_rule tool handler', () => {
     }
 
     const handler = getHandler(mockCloudIdentityClient)
-    const result = await handler({ policyName: 'policies/akabc123' }, { authToken: 'token-abc' })
+    const result = await handler({ policyName: 'policies/akabc123' }, mockContext)
 
     assert.ok(deleteCalled, 'deleteDlpRulePreValidated should have been called')
     assert.ok(result.content[0].text.includes('has been successfully deleted'))
@@ -92,7 +100,7 @@ describe('delete_agent_dlp_rule tool handler', () => {
     }
 
     const handler = getHandler(mockCloudIdentityClient)
-    const result = await handler({ policyName: 'policies/akabc123' }, { authToken: 'token-abc' })
+    const result = await handler({ policyName: 'policies/akabc123' }, mockContext)
 
     assert.ok(!deleteCalled, 'deleteDlpRulePreValidated should NOT have been called')
     assert.ok(result.content[0].text.includes('Admin Console'))
@@ -114,7 +122,7 @@ describe('delete_agent_dlp_rule tool handler', () => {
     }
 
     const handler = getHandler(mockCloudIdentityClient)
-    const result = await handler({ policyName: 'policies/akabc123' }, { authToken: 'token-abc' })
+    const result = await handler({ policyName: 'policies/akabc123' }, mockContext)
 
     assert.ok(result.isError, 'result should be an error response')
     assert.ok(result.content[0].text.includes('Rule not found'), 'error text should mention rule not found')
@@ -133,7 +141,7 @@ describe('delete_agent_dlp_rule tool handler', () => {
     }
 
     const handler = getHandler(mockCloudIdentityClient)
-    const result = await handler({ policyName: 'policies/akabc123' }, { authToken: 'token-abc' })
+    const result = await handler({ policyName: 'policies/akabc123' }, mockContext)
 
     assert.ok(result.isError, 'result should be an error response')
     assert.ok(result.content[0].text.includes('Rule not found'), 'error text should mention rule not found')
@@ -152,7 +160,7 @@ describe('delete_agent_dlp_rule tool handler', () => {
     }
 
     const handler = getHandler(mockCloudIdentityClient)
-    const result = await handler({ policyName: 'policies/akabc123' }, { authToken: 'token-abc' })
+    const result = await handler({ policyName: 'policies/akabc123' }, mockContext)
 
     assert.ok(result.isError, 'result should be an error response')
     assert.ok(

--- a/test/unit/tools/get_dlp_rule.test.js
+++ b/test/unit/tools/get_dlp_rule.test.js
@@ -32,6 +32,14 @@ describe('get_dlp_rule tool handler', () => {
     return registeredHandler
   }
 
+  const mockContext = {
+    requestInfo: {
+      headers: {
+        authorization: 'Bearer token',
+      },
+    },
+  }
+
   test('When a rule has complete data, then it formats rule details and includes a UI link', async () => {
     const mockRule = {
       name: 'policies/rule123',
@@ -58,7 +66,7 @@ describe('get_dlp_rule tool handler', () => {
 
     const handler = getHandler(mockCloudIdentityClient)
 
-    const result = await handler({ resourceName: 'policies/rule123' }, { authToken: 'token' })
+    const result = await handler({ resourceName: 'policies/rule123' }, mockContext)
     const text = result.content[0].text
 
     assert.match(text, /## DLP Rule: Block Secret Uploads/)
@@ -84,7 +92,7 @@ describe('get_dlp_rule tool handler', () => {
 
     const handler = getHandler(mockCloudIdentityClient)
 
-    const result = await handler({ resourceName: 'policies/empty' }, { authToken: 'token' })
+    const result = await handler({ resourceName: 'policies/empty' }, mockContext)
     const text = result.content[0].text
 
     assert.match(text, /DLP Rule: Unnamed Rule/)

--- a/tools/definitions/check_cep_subscription.js
+++ b/tools/definitions/check_cep_subscription.js
@@ -51,6 +51,7 @@ export function registerCheckCepSubscriptionTool(server, options, sessionState) 
     },
     guardedToolCall(
       {
+        requiresDelegation: true,
         handler: async ({ customerId }, { _requestInfo, authToken }) => {
           logger.debug(`${TAGS.MCP} Calling 'check_cep_subscription' for customer: ${customerId}`)
 

--- a/tools/definitions/check_user_cep_license.js
+++ b/tools/definitions/check_user_cep_license.js
@@ -50,6 +50,7 @@ Use this to verify if an individual user (by email or unique ID) is licensed for
     },
     guardedToolCall(
       {
+        requiresDelegation: true,
         handler: async ({ userId }, { _requestInfo, authToken }) => {
           logger.debug(`${TAGS.MCP} Calling 'check_user_cep_license' for user: ${userId}`)
 

--- a/tools/definitions/create_chrome_dlp_rule.js
+++ b/tools/definitions/create_chrome_dlp_rule.js
@@ -155,6 +155,7 @@ To ensure technical accuracy and verify trigger compatibility, you should retrie
 
     guardedToolCall(
       {
+        requiresDelegation: true,
         transform: params => {
           const prefix = AGENT_DISPLAY_NAME_PREFIX
           const newDisplayName = params.displayName.startsWith(prefix)

--- a/tools/definitions/create_default_dlp_rules.js
+++ b/tools/definitions/create_default_dlp_rules.js
@@ -109,6 +109,7 @@ Rules included:
 
     guardedToolCall(
       {
+        requiresDelegation: true,
         handler: async (params, { authToken }) => {
           logger.debug(`${TAGS.MCP} Calling 'create_default_dlp_rules' with params: ${JSON.stringify(params)}`)
           const { customerId, orgUnitId } = params

--- a/tools/definitions/create_regex_detector.js
+++ b/tools/definitions/create_regex_detector.js
@@ -58,6 +58,7 @@ Detectors are building blocks for DLP rules. After creating a detector, you must
     },
     guardedToolCall(
       {
+        requiresDelegation: true,
         /**
          * Handler for creating a regular expression detector.
          * @param {object} params - The tool parameters.

--- a/tools/definitions/create_url_list_detector.js
+++ b/tools/definitions/create_url_list_detector.js
@@ -58,6 +58,7 @@ Detectors are building blocks for DLP rules. After creating a detector, you must
     },
     guardedToolCall(
       {
+        requiresDelegation: true,
         /**
          * Handler for creating a URL list detector.
          * @param {object} params - The tool parameters.

--- a/tools/definitions/create_word_list_detector.js
+++ b/tools/definitions/create_word_list_detector.js
@@ -64,6 +64,7 @@ Detectors are building blocks for DLP rules. After creating a detector, you must
     },
     guardedToolCall(
       {
+        requiresDelegation: true,
         /**
          * Handler for creating a word list detector.
          * @param {object} params - The tool parameters.

--- a/tools/definitions/delete_agent_dlp_rule.js
+++ b/tools/definitions/delete_agent_dlp_rule.js
@@ -54,6 +54,7 @@ export function registerDeleteAgentDlpRuleTool(server, options, sessionState) {
     },
     guardedToolCall(
       {
+        requiresDelegation: true,
         /**
          * Handler for deleting an agent-created DLP rule.
          * @param {object} params - The tool parameters.

--- a/tools/definitions/delete_detector.js
+++ b/tools/definitions/delete_detector.js
@@ -55,6 +55,7 @@ Note: This will not automatically remove the detector from any DLP rules that re
     },
     guardedToolCall(
       {
+        requiresDelegation: true,
         /**
          * Handler for deleting a DLP detector.
          * @param {object} params - The tool parameters.

--- a/tools/definitions/get_customer_id.js
+++ b/tools/definitions/get_customer_id.js
@@ -49,6 +49,7 @@ This ID (often starting with 'C') is required as a parameter for many other Chro
     },
     guardedToolCall(
       {
+        requiresDelegation: true,
         /**
          * Handler for retrieving the customer ID.
          * @param {object} params - The tool parameters.

--- a/tools/definitions/get_dlp_rule.js
+++ b/tools/definitions/get_dlp_rule.js
@@ -51,6 +51,7 @@ export function registerGetDlpRuleTool(server, options, sessionState) {
     },
     guardedToolCall(
       {
+        requiresDelegation: true,
         /**
          * Handler for getting a DLP rule.
          * @param {object} params - The tool parameters.

--- a/tools/definitions/list_detectors.js
+++ b/tools/definitions/list_detectors.js
@@ -48,6 +48,7 @@ Detectors are used within DLP rules to identify sensitive content. Use this to f
     },
     guardedToolCall(
       {
+        requiresDelegation: true,
         handler: async (_, { authToken }) => {
           logger.debug(`${TAGS.MCP} Calling 'list_detectors'`)
           const detectors = await cloudIdentityClient.listDetectors(authToken)

--- a/tools/definitions/list_dlp_rules.js
+++ b/tools/definitions/list_dlp_rules.js
@@ -49,6 +49,7 @@ export function registerListDlpRulesTool(server, options, sessionState) {
     },
     guardedToolCall(
       {
+        requiresDelegation: true,
         /**
          * Handler for listing DLP rules.
          * @param {object} _ - The tool parameters (unused).

--- a/tools/index.js
+++ b/tools/index.js
@@ -20,6 +20,7 @@ limitations under the License.
 
 import { TAGS } from '../lib/constants.js'
 import { logger } from '../lib/util/logger.js'
+import { isStdioMode } from '../lib/util/gcp.js'
 
 import { registerGetCustomerIdTool } from './definitions/get_customer_id.js'
 import { registerListOrgUnitsTool } from './definitions/list_org_units.js'
@@ -162,5 +163,9 @@ export function registerTools(server, options = {}, sessionState) {
   }
 
   registerKnowledgeTools(server, { ...options, featureFlags: flags }, state)
-  registerAuthTools(server, commonOpts, state)
+  const isInteractiveOauthMode =
+    isStdioMode() && !process.env.GOOGLE_APPLICATION_CREDENTIALS && !process.env.CEP_ACCESS_TOKEN
+  if (isInteractiveOauthMode) {
+    registerAuthTools(server, commonOpts, state)
+  }
 }

--- a/tools/utils/wrapper.js
+++ b/tools/utils/wrapper.js
@@ -56,13 +56,72 @@ function buildAuthRequiredResponse({ reason, expiresAt }) {
   }
 }
 
+const TOOL_PRIVILEGES_MAP = {
+  list_org_units: {
+    privilege: 'Services > Google Workspace > Directory > Read organizational units',
+    roleUrl: 'https://admin.google.com/ac/roles',
+  },
+  security_insights: {
+    privilege:
+      'Services > Chrome Management > Manage ChromeOS Devices (Read-only) + Services > Chrome Enterprise Security Insights',
+    roleUrl: 'https://admin.google.com/ac/roles',
+  },
+  count_browser_versions: {
+    privilege: 'Services > Chrome Management > Manage ChromeOS Devices (Read-only)',
+    roleUrl: 'https://admin.google.com/ac/roles',
+  },
+  list_customer_profiles: {
+    privilege:
+      'Services > Chrome Management > Manage ChromeOS Devices (Read-only) + Services > Chrome Management > Settings > Managed Browsers',
+    roleUrl: 'https://admin.google.com/ac/roles',
+  },
+  get_chrome_activity_log: {
+    privilege: 'Services > Chrome Management > Manage ChromeOS Devices (Read-only) + Reports > Audit Reports',
+    roleUrl: 'https://admin.google.com/ac/roles',
+  },
+  check_cep_subscription: {
+    privilege: 'Services > License Management > License Read',
+    roleUrl: 'https://admin.google.com/ac/roles',
+  },
+  check_user_cep_license: {
+    privilege: 'Services > License Management > License Read',
+    roleUrl: 'https://admin.google.com/ac/roles',
+  },
+  list_dlp_rules: {
+    privilege: 'Services > Cloud Identity > Security > View / Manage Data Loss Prevention (DLP) rules and detectors',
+    roleUrl: 'https://admin.google.com/ac/roles',
+  },
+  get_dlp_rule: {
+    privilege: 'Services > Cloud Identity > Security > View / Manage Data Loss Prevention (DLP) rules and detectors',
+    roleUrl: 'https://admin.google.com/ac/roles',
+  },
+  list_detectors: {
+    privilege: 'Services > Cloud Identity > Security > View / Manage Data Loss Prevention (DLP) rules and detectors',
+    roleUrl: 'https://admin.google.com/ac/roles',
+  },
+  create_chrome_dlp_rule: {
+    privilege: 'Services > Cloud Identity > Security > View / Manage Data Loss Prevention (DLP) rules and detectors',
+    roleUrl: 'https://admin.google.com/ac/roles',
+  },
+  create_regex_detector: {
+    privilege: 'Services > Cloud Identity > Security > View / Manage Data Loss Prevention (DLP) rules and detectors',
+    roleUrl: 'https://admin.google.com/ac/roles',
+  },
+}
+
 /**
  * Generates a proactive remediation message for authentication errors.
  * @param {number} status - HTTP status code (401 or 403)
  * @param {boolean} bearerInbound - True if request used inbound Bearer auth
+ * @param {string} [toolName] - Name of the tool being executed
  * @returns {string} Human-readable remediation instructions
  */
-function getAuthRemediationMessage(status, bearerInbound = false) {
+function getAuthRemediationMessage(status, bearerInbound = false, toolName = '') {
+  if (status === 403 && toolName && TOOL_PRIVILEGES_MAP[toolName]) {
+    const info = TOOL_PRIVILEGES_MAP[toolName]
+    return `Permission denied (403 Forbidden) while calling tool '${toolName}'. Your authenticated principal lacks the required Google Workspace / Chrome Enterprise permissions for this resource.\n\n🛠️ Required Workspace Admin Console Privileges for '${toolName}':\n- ${info.privilege}\n\n🔗 How to fix: Open Workspace Admin Roles Console (${info.roleUrl}), create or edit an admin role with the privileges listed above, and assign it to your authenticated Service Account or user email.`
+  }
+
   if (bearerInbound) {
     if (status === 401) {
       return `Authentication required. The inbound Bearer token has expired or is invalid. Re-authenticate through your MCP client to refresh the token.`
@@ -335,7 +394,7 @@ export function guardedToolCall(
             ? 401
             : 403)
         const bearerInbound = !!context?.authToken || !!context?.requestInfo?.headers?.authorization
-        const remediationMessage = getAuthRemediationMessage(resolvedStatus, bearerInbound)
+        const remediationMessage = getAuthRemediationMessage(resolvedStatus, bearerInbound, context?.name)
         return {
           content: [{ type: 'text', text: remediationMessage }],
           isError: true,

--- a/tools/utils/wrapper.js
+++ b/tools/utils/wrapper.js
@@ -212,9 +212,11 @@ export function guardedToolCall(
         }
         if (requiresDelegation && !process.env.CEP_IMPERSONATE_SUBJECT) {
           const text =
-            'Error: Calling this DLP tool in Service Account mode requires domain-wide delegation. ' +
-            'GOOGLE_APPLICATION_CREDENTIALS is set, but CEP_IMPERSONATE_SUBJECT is not specified. ' +
-            'Set CEP_IMPERSONATE_SUBJECT to the email address of a Google Workspace admin with privileges to manage DLP rules.'
+            'Error: Tool requires Domain-Wide Delegation (requiresDelegation: true) to access user-scoped directory or policy data. ' +
+            'You are authenticated in Service Account mode (GOOGLE_APPLICATION_CREDENTIALS is set), but CEP_IMPERSONATE_SUBJECT is not specified. ' +
+            'To use this tool, set CEP_IMPERSONATE_SUBJECT to the email address of a Google Workspace user account with delegated privileges (Option 1). ' +
+            'Alternatively, if you are using direct Admin Console role assignments without user impersonation (Option 2), ' +
+            'use Option 2 compatible tools such as list_org_units, security_insights, or count_browser_versions with an explicit customerId.'
           return {
             content: [{ type: 'text', text }],
             isError: true,

--- a/tools/utils/wrapper.js
+++ b/tools/utils/wrapper.js
@@ -62,8 +62,7 @@ const TOOL_PRIVILEGES_MAP = {
     roleUrl: 'https://admin.google.com/ac/roles',
   },
   security_insights: {
-    privilege:
-      'Services > Chrome Management > Manage ChromeOS Devices (Read-only) + Services > Chrome Enterprise Security Insights',
+    privilege: 'Services > Chrome Enterprise Security Insights (or Chrome Management)',
     roleUrl: 'https://admin.google.com/ac/roles',
   },
   count_browser_versions: {
@@ -71,12 +70,11 @@ const TOOL_PRIVILEGES_MAP = {
     roleUrl: 'https://admin.google.com/ac/roles',
   },
   list_customer_profiles: {
-    privilege:
-      'Services > Chrome Management > Manage ChromeOS Devices (Read-only) + Services > Chrome Management > Settings > Managed Browsers',
+    privilege: 'Services > Chrome Management > Settings > Managed Browsers',
     roleUrl: 'https://admin.google.com/ac/roles',
   },
   get_chrome_activity_log: {
-    privilege: 'Services > Chrome Management > Manage ChromeOS Devices (Read-only) + Reports > Audit Reports',
+    privilege: 'Services > Chrome Management > Manage ChromeOS Devices (and Reports > Audit Reports)',
     roleUrl: 'https://admin.google.com/ac/roles',
   },
   check_cep_subscription: {
@@ -119,7 +117,7 @@ const TOOL_PRIVILEGES_MAP = {
 function getAuthRemediationMessage(status, bearerInbound = false, toolName = '') {
   if (status === 403 && toolName && TOOL_PRIVILEGES_MAP[toolName]) {
     const info = TOOL_PRIVILEGES_MAP[toolName]
-    return `Permission denied (403 Forbidden) while calling tool '${toolName}'. Your authenticated principal lacks the required Google Workspace / Chrome Enterprise permissions for this resource.\n\n🛠️ Required Workspace Admin Console Privileges for '${toolName}':\n- ${info.privilege}\n\n🔗 How to fix: Open Workspace Admin Roles Console (${info.roleUrl}), create or edit an admin role with the privileges listed above, and assign it to your authenticated Service Account or user email.`
+    return `Permission denied (403 Forbidden) while calling \`${toolName}\`. Your account lacks the required Google Workspace Admin Console privilege:\n• **${info.privilege}**\n\n**To fix:** Open [Workspace Admin Roles](${info.roleUrl}) and assign any role (or custom role) granting this privilege to your account (e.g., *Delegated Admin* or *Super Admin*).`
   }
 
   if (bearerInbound) {

--- a/tools/utils/wrapper.js
+++ b/tools/utils/wrapper.js
@@ -73,6 +73,14 @@ function getAuthRemediationMessage(status, bearerInbound = false) {
 2. **Verify APIs are enabled:** Run the \`check_and_enable_cep_api\` tool against your project, or enable the API set listed in \`lib/constants.js#SERVICE_NAMES\`.`
   }
 
+  const isSaMode = !!process.env.GOOGLE_APPLICATION_CREDENTIALS
+  if (isSaMode) {
+    if (status === 401) {
+      return `Authentication required. The Service Account credentials configured in GOOGLE_APPLICATION_CREDENTIALS are invalid or domain-wide delegation failed. Ensure the Service Account JSON key is valid and domain-wide delegation (CEP_IMPERSONATE_SUBJECT) is configured in Google Workspace Admin Console.`
+    }
+    return `Permission denied. The Service Account lacks required Google Workspace / Chrome Enterprise permissions or domain-wide delegation OAuth scopes. Verify that the Service Account has required IAM roles and that Domain-Wide Delegation in Google Workspace Admin Console includes the necessary scopes.`
+  }
+
   const manualLogin = cliInvocation('auth login')
   if (status === 401) {
     return `Authentication required. Run the \`cep_auth\` tool to sign in, or run \`${manualLogin}\` at the shell to authorize the server (it caches the access token at ~/.config/cep-mcp/tokens.json). To use a service account, set GOOGLE_APPLICATION_CREDENTIALS to a service-account key file.`
@@ -155,6 +163,7 @@ export function safeFormatResponse({ rawData, formatFn, toolName }) {
  * @param {(...args: unknown[]) => unknown} toolDef.handler - The main tool handler function
  * @param {boolean} [toolDef.skipAutoResolve] - Whether to skip auto-resolving customerId
  * @param {boolean} [toolDef.skipAuthCheck] - Whether to skip checking if tokens are valid.
+ * @param {boolean} [toolDef.requiresDelegation] - Whether this tool requires domain-wide delegation in SA mode.
  * @param {string[]} [toolDef.scopes] - Scopes required for this tool. Defaults to all SCOPES.
  * @param {object} options - Configuration options for the wrapper
  * @param {object} [options.apiClients] - Collection of API clients
@@ -164,12 +173,20 @@ export function safeFormatResponse({ rawData, formatFn, toolName }) {
  * @returns {(...args: unknown[]) => unknown} The wrapped tool handler function
  */
 export function guardedToolCall(
-  { validate, transform, handler, skipAutoResolve = false, skipAuthCheck = false, scopes = getActiveScopes() },
+  {
+    validate,
+    transform,
+    handler,
+    skipAutoResolve = false,
+    skipAuthCheck = false,
+    requiresDelegation = false,
+    scopes = getActiveScopes(),
+  },
   options = {},
   sessionState = { customerId: null, cachedRootOrgUnitId: null },
 ) {
   const wrapped = async (params, context) => {
-    const authToken = getAuthToken(context?.requestInfo)
+    const authToken = params?.accessToken || getAuthToken(context?.requestInfo)
     if (!skipAuthCheck) {
       if (authToken) {
         // Inbound Bearer token present: skip local disk checks and forward directly to Google APIs
@@ -182,16 +199,28 @@ export function guardedToolCall(
           structuredContent: { status: 'error', code: 'BEARER_ONLY_REQUIRED', message: msg },
           isError: true,
         }
-      } else if (isServiceAccountMode() && !process.env.GOOGLE_APPLICATION_CREDENTIALS) {
-        const msg =
-          'Authentication failed: Server is configured in strict "service-account-only" mode, ' +
-          'but GOOGLE_APPLICATION_CREDENTIALS is not set.'
-        return {
-          content: [{ type: 'text', text: msg }],
-          structuredContent: { status: 'error', code: 'SERVICE_ACCOUNT_REQUIRED', message: msg },
-          isError: true,
+      } else if (isServiceAccountMode() || (isDynamicMode() && process.env.GOOGLE_APPLICATION_CREDENTIALS)) {
+        if (isServiceAccountMode() && !process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+          const msg =
+            'Authentication failed: Server is configured in strict "service-account-only" mode, ' +
+            'but GOOGLE_APPLICATION_CREDENTIALS is not set.'
+          return {
+            content: [{ type: 'text', text: msg }],
+            structuredContent: { status: 'error', code: 'SERVICE_ACCOUNT_REQUIRED', message: msg },
+            isError: true,
+          }
         }
-      } else if (isDynamicMode() && !process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+        if (requiresDelegation && !process.env.CEP_IMPERSONATE_SUBJECT) {
+          const text =
+            'Error: Calling this DLP tool in Service Account mode requires domain-wide delegation. ' +
+            'GOOGLE_APPLICATION_CREDENTIALS is set, but CEP_IMPERSONATE_SUBJECT is not specified. ' +
+            'Set CEP_IMPERSONATE_SUBJECT to the email address of a Google Workspace admin with privileges to manage DLP rules.'
+          return {
+            content: [{ type: 'text', text }],
+            isError: true,
+          }
+        }
+      } else {
         const validity = await isTokenLocallyValid({ scopes })
         if (!validity.ok) {
           return buildAuthRequiredResponse(validity)
@@ -215,6 +244,7 @@ export function guardedToolCall(
       }
       const { apiClients } = options
       let currentParams = { ...params }
+      delete currentParams.accessToken
       if (sessionState && currentParams.customerId) {
         sessionState.customerId = currentParams.customerId
       }

--- a/tools/utils/wrapper.js
+++ b/tools/utils/wrapper.js
@@ -25,6 +25,7 @@ import { validateAndGetOrgUnitId } from './org-unit.js'
 import { isTokenLocallyValid } from '../../lib/util/credential/auth_login.js'
 import { cliInvocation } from '../../lib/util/cli_invocation.js'
 import { isBearerMode, isServiceAccountMode, isDynamicMode } from '../../lib/util/auth_mode.js'
+import { getAuthErrorMessage } from '../../lib/util/auth-error.js'
 
 /**
  * Builds an MCP tool response signalling that sign-in is needed before any tool can run.
@@ -109,12 +110,13 @@ const TOOL_PRIVILEGES_MAP = {
 
 /**
  * Generates a proactive remediation message for authentication errors.
- * @param {number} status - HTTP status code (401 or 403)
+ * @param {number} status - HTTP status code (401 or 403) or resolved equivalent.
+ * @param {Error|null} error - The original error thrown.
  * @param {boolean} bearerInbound - True if request used inbound Bearer auth
  * @param {string} [toolName] - Name of the tool being executed
  * @returns {string} Human-readable remediation instructions
  */
-function getAuthRemediationMessage(status, bearerInbound = false, toolName = '') {
+function getAuthRemediationMessage(status, error, bearerInbound = false, toolName = '') {
   if (status === 403 && toolName && TOOL_PRIVILEGES_MAP[toolName]) {
     const info = TOOL_PRIVILEGES_MAP[toolName]
     return `Permission denied (403 Forbidden) while calling \`${toolName}\`. Your account lacks the required Google Workspace Admin Console privilege:\n• **${info.privilege}**\n\n**To fix:** Open [Workspace Admin Roles](${info.roleUrl}) and assign any role (or custom role) granting this privilege to your account (e.g., *Delegated Admin* or *Super Admin*).`
@@ -131,15 +133,26 @@ function getAuthRemediationMessage(status, bearerInbound = false, toolName = '')
   }
 
   const isSaMode = !!process.env.GOOGLE_APPLICATION_CREDENTIALS
+  const errorMessage = error?.message || ''
+  const isCredentialFailure =
+    status === 401 ||
+    errorMessage.includes('invalid_grant') ||
+    errorMessage.includes('unauthorized_client') ||
+    errorMessage.includes('UNAUTHENTICATED')
+
   if (isSaMode) {
-    if (status === 401) {
-      return `Authentication required. The Service Account credentials configured in GOOGLE_APPLICATION_CREDENTIALS are invalid or domain-wide delegation failed. Ensure the Service Account JSON key is valid and domain-wide delegation (CEP_IMPERSONATE_SUBJECT) is configured in Google Workspace Admin Console.`
+    if (isCredentialFailure) {
+      const detailedMessage = getAuthErrorMessage(error)
+      if (detailedMessage.startsWith('ERROR: Authentication failed')) {
+        return `Authentication required. The Service Account credentials configured in GOOGLE_APPLICATION_CREDENTIALS are invalid or domain-wide delegation failed. Ensure the Service Account JSON key is valid and domain-wide delegation (CEP_IMPERSONATE_SUBJECT) is configured in Google Workspace Admin Console.\n\nOriginal error: ${errorMessage}`
+      }
+      return detailedMessage
     }
     return `Permission denied. The Service Account lacks required Google Workspace / Chrome Enterprise permissions or domain-wide delegation OAuth scopes. Verify that the Service Account has required IAM roles and that Domain-Wide Delegation in Google Workspace Admin Console includes the necessary scopes.`
   }
 
   const manualLogin = cliInvocation('auth login')
-  if (status === 401) {
+  if (isCredentialFailure) {
     return `Authentication required. Run the \`cep_auth\` tool to sign in, or run \`${manualLogin}\` at the shell to authorize the server (it caches the access token at ~/.config/cep-mcp/tokens.json). To use a service account, set GOOGLE_APPLICATION_CREDENTIALS to a service-account key file.`
   }
 
@@ -381,18 +394,20 @@ export function guardedToolCall(
         errorMessage.includes('API Error 403') ||
         errorMessage.includes('UNAUTHENTICATED') ||
         errorMessage.includes('PERMISSION_DENIED') ||
-        errorMessage.includes('invalid_grant')
+        errorMessage.includes('invalid_grant') ||
+        errorMessage.includes('unauthorized_client')
 
       if (isAuthError) {
         const resolvedStatus =
           status ||
           (errorMessage.includes('401') ||
           errorMessage.includes('UNAUTHENTICATED') ||
-          errorMessage.includes('invalid_grant')
+          errorMessage.includes('invalid_grant') ||
+          errorMessage.includes('unauthorized_client')
             ? 401
             : 403)
         const bearerInbound = !!context?.authToken || !!context?.requestInfo?.headers?.authorization
-        const remediationMessage = getAuthRemediationMessage(resolvedStatus, bearerInbound, context?.name)
+        const remediationMessage = getAuthRemediationMessage(resolvedStatus, error, bearerInbound, context?.name)
         return {
           content: [{ type: 'text', text: remediationMessage }],
           isError: true,


### PR DESCRIPTION
# Description

Hardens the MCP server's authentication layer for Service Account mode and Domain-Wide Delegation (DWD).

## Motivation
Previously, when running in Service Account mode, the server lacked validation for domain-wide delegation requirements and returned raw, un-remediated error messages on OAuth failures (like unauthorized delegation or invalid keys). This PR introduces pre-flight checks, proper privilege mapping, and actionable remediation steps.

## Main Changes
1. **Delegation Guard**: Tools that require domain-wide delegation (`requiresDelegation: true`) now fail pre-flight in Service Account mode if `CEP_IMPERSONATE_SUBJECT` (delegated admin email) is missing.
2. **Detailed Error Remediation**:
   - Integrated detailed step-by-step console instructions for Workspace Admins on how to configure DWD (for `unauthorized_client` errors).
   - Maps 403 (Permission Denied) errors to tool-specific privileges (e.g. `View / Manage DLP rules`) with direct links to Admin Roles console.
3. **Robust Auth Error Classification**:
   - Catches OAuth `unauthorized_client` and `invalid_grant` errors (which return HTTP `400` from Gaia token endpoints) and maps them to `401` Authentication remediation steps.
4. **Transport-Aware Registration**: Tools that require delegation are registered conditionally based on whether the current auth channel configuration supports it.