### PR TITLE
feat(diagnose): audit VPC ingress firewall rules for secure gateway apps

### DIFF
--- a/.github/expected-tarball.txt
+++ b/.github/expected-tarball.txt
@@ -10,6 +10,7 @@ lib/api/chrome_management_client.js
 lib/api/chrome_policy_client.js
 lib/api/cloud_identity_client.js
 lib/api/cloud_resource_manager_client.js
+lib/api/compute_client.js
 lib/api/service_usage_client.js
 lib/constants.js
 lib/knowledge/0-agent-capabilities.md

--- a/lib/api/compute_client.js
+++ b/lib/api/compute_client.js
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file Compute Engine API client wrapper using googleapis.
+ */
+
+import { google } from 'googleapis'
+import { createApiClient } from '../util/api-client.js'
+import { callWithRetry, handleApiError } from '../util/helpers.js'
+import { SCOPES, API_VERSIONS, TAGS } from '../constants.js'
+import { logger } from '../util/logger.js'
+
+/**
+ * Compute Engine API client wrapper.
+ */
+export class ComputeClient {
+  /**
+   * Initializes the client with API options.
+   * @param {object} apiOptions Options to pass to the API client.
+   */
+  constructor(apiOptions = {}) {
+    this.apiOptions = apiOptions
+  }
+
+  /**
+   * Gets an instance of the Compute service.
+   * @param {string} authToken The OAuth 2.0 auth token.
+   * @returns {Promise<object>} The Compute service instance.
+   */
+  async getClient(authToken) {
+    return createApiClient(google.compute, API_VERSIONS.COMPUTE, [SCOPES.CLOUD_PLATFORM], authToken, this.apiOptions)
+  }
+
+  /**
+   * Lists firewall rules in a specified project.
+   * @param {string} project The project ID.
+   * @param {object} [options] Optional parameters for filtering/pagination.
+   * @param {string} [authToken] Optional OAuth 2.0 access token.
+   * @returns {Promise<object>} The firewall rules list response.
+   * @throws {Error} If the API call fails.
+   */
+  async listFirewalls(project, options = {}, authToken) {
+    logger.debug(`${TAGS.API} listFirewalls called for project: ${project}`)
+    const client = await this.getClient(authToken)
+    try {
+      const response = await callWithRetry(
+        () =>
+          client.firewalls.list({
+            project,
+            ...options,
+          }),
+        'firewalls.list',
+      )
+      return response.data
+    } catch (error) {
+      handleApiError(error, TAGS.API, 'listing firewall rules')
+    }
+  }
+}

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -28,6 +28,7 @@ export const SERVICE_NAMES = {
   SERVICE_MANAGEMENT: 'servicemanagement.googleapis.com',
   CLOUD_RESOURCE_MANAGER: 'cloudresourcemanager.googleapis.com',
   BEYONDCORP: 'beyondcorp.googleapis.com',
+  COMPUTE: 'compute.googleapis.com',
 }
 
 /**
@@ -161,6 +162,7 @@ export const API_VERSIONS = {
   CLOUD_RESOURCE_MANAGER: 'v1',
   ACCESS_CONTEXT_MANAGER: 'v1',
   BEYONDCORP: 'v1',
+  COMPUTE: 'v1',
 }
 
 export const CEP_CONSTANTS = {

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -58,6 +58,7 @@ import { ChromePolicyClient } from './lib/api/chrome_policy_client.js'
 import { ChromeManagementClient } from './lib/api/chrome_management_client.js'
 import { ServiceUsageClient } from './lib/api/service_usage_client.js'
 import { CloudResourceManagerClient } from './lib/api/cloud_resource_manager_client.js'
+import { ComputeClient } from './lib/api/compute_client.js'
 import { BeyondCorpClient } from './lib/api/beyondcorp_client.js'
 
 /**
@@ -258,6 +259,7 @@ export async function getServer(gcpInfo, sharedSessionState, principal = null) {
     chromeManagement: new ChromeManagementClient(apiOptions),
     serviceUsage: new ServiceUsageClient(apiOptions),
     cloudResourceManager: new CloudResourceManagerClient(apiOptions),
+    compute: new ComputeClient(apiOptions),
     beyondcorp: new BeyondCorpClient(apiOptions),
   }
 

--- a/test/evals/cases/gateway/gw09-diagnose-firewalls.eval.js
+++ b/test/evals/cases/gateway/gw09-diagnose-firewalls.eval.js
@@ -1,0 +1,35 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export default {
+  id: 'gw09',
+  priority: 'P1',
+  tags: ['gateway', 'inspection', 'diagnose', 'firewall'],
+  fixtures: ['customer-default.json', 'license-valid.json', 'gateways-configured.json'],
+  expectedTools: ['diagnose_environment'],
+  forbiddenPatterns: [],
+  requiredPatterns: ['re:firewall|gcloud compute firewall-rules|136\\.124\\.16\\.0'],
+  experiments: {
+    SECURE_GATEWAY_ENABLED: true,
+    DIAGNOSE_TOOL_ENABLED: true,
+  },
+  prompt:
+    'My users are reporting that connections to our internal web application routed through the BeyondCorp Secure Gateway in project my-project-123 are timing out. Please run the diagnose_environment tool with projectId "my-project-123" (summary mode) to inspect environment health and diagnose network/firewall issues.',
+  goldenResponse:
+    'The agent should run diagnose_environment with projectId: "my-project-123" and identify missing VPC ingress firewall rules for the Secure Gateway proxy range (136.124.16.0/20), providing the necessary gcloud firewall-rules create command to remediate.',
+  judgeInstructions:
+    'The agent must run diagnose_environment with projectId="my-project-123". The agent must identify that an ingress firewall rule for the Secure Gateway proxy range (136.124.16.0/20) or VPC network firewall configuration is missing/requires verification, and provide clear remediation guidance (such as the gcloud command or GCP console URL).',
+}

--- a/test/helpers/fake-api-server.js
+++ b/test/helpers/fake-api-server.js
@@ -278,6 +278,7 @@ function getInitialState() {
     securityGatewayIamPolicies: nullProtoMap({}),
     securityGatewayApplicationIamPolicies: nullProtoMap({}),
     projectIamPolicies: nullProtoMap({}),
+    firewalls: nullProtoMap({}),
   }
 }
 
@@ -838,6 +839,17 @@ export function createFakeApp() {
       .filter(([, stateVal]) => stateVal === 'ENABLED')
       .map(([serviceName]) => ({ serviceName, producerProjectId: 'google.com' }))
     res.json({ services })
+  })
+
+  // Compute Engine: List Firewalls
+  app.get('/compute/v1/projects/:projectId/global/firewalls', (req, res) => {
+    const { projectId } = req.params
+    if (mockErrors.listFirewalls) {
+      const err = mockErrors.listFirewalls
+      return res.status(err.code || 500).json({ error: { message: err.message || 'Error listing firewalls' } })
+    }
+    const firewalls = state.firewalls[projectId] || []
+    res.json({ kind: 'compute#firewallList', items: firewalls })
   })
 
   // BeyondCorp: Create Security Gateway

--- a/test/helpers/integration/tools/client_factory.js
+++ b/test/helpers/integration/tools/client_factory.js
@@ -21,6 +21,7 @@ import { ChromePolicyClient } from '../../../../lib/api/chrome_policy_client.js'
 import { ChromeManagementClient } from '../../../../lib/api/chrome_management_client.js'
 import { ServiceUsageClient } from '../../../../lib/api/service_usage_client.js'
 import { CloudResourceManagerClient } from '../../../../lib/api/cloud_resource_manager_client.js'
+import { ComputeClient } from '../../../../lib/api/compute_client.js'
 import { BeyondCorpClient } from '../../../../lib/api/beyondcorp_client.js'
 
 export function getApiClients(options = {}) {
@@ -36,6 +37,7 @@ export function getApiClients(options = {}) {
       chromeManagement: new ChromeManagementClient(),
       serviceUsage: new ServiceUsageClient(),
       cloudResourceManager: new CloudResourceManagerClient(),
+      compute: new ComputeClient(),
       beyondcorp: new BeyondCorpClient(),
     }
   }
@@ -50,6 +52,7 @@ export function getApiClients(options = {}) {
     chromeManagement: new ChromeManagementClient({ rootUrl, auth: fakeAuth }),
     serviceUsage: new ServiceUsageClient({ rootUrl, auth: fakeAuth }),
     cloudResourceManager: new CloudResourceManagerClient({ rootUrl, auth: fakeAuth }),
+    compute: new ComputeClient({ rootUrl, auth: fakeAuth }),
     beyondcorp: new BeyondCorpClient({ rootUrl, auth: fakeAuth }),
   }
 }

--- a/test/local/compute_client.test.js
+++ b/test/local/compute_client.test.js
@@ -1,0 +1,50 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, test, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import esmock from 'esmock'
+
+describe('ComputeClient', () => {
+  test('When listFirewalls is called, then it queries compute.firewalls.list with project and options', async () => {
+    const mockList = mock.fn(async () => ({ data: { items: [{ name: 'allow-gateway' }] } }))
+    const mockCompute = {
+      firewalls: {
+        list: mockList,
+      },
+    }
+
+    const { ComputeClient } = await esmock('../../lib/api/compute_client.js', {
+      '../../lib/util/api-client.js': {
+        createApiClient: async () => mockCompute,
+      },
+      '../../lib/util/helpers.js': {
+        callWithRetry: async fn => fn(),
+        handleApiError: err => {
+          throw err
+        },
+      },
+    })
+
+    const client = new ComputeClient()
+    const result = await client.listFirewalls('my-project-123', { filter: 'name = allow-gateway' }, 'mock-token')
+
+    assert.strictEqual(mockList.mock.callCount(), 1)
+    const callArgs = mockList.mock.calls[0].arguments[0]
+    assert.deepStrictEqual(callArgs, { project: 'my-project-123', filter: 'name = allow-gateway' })
+    assert.deepStrictEqual(result, { items: [{ name: 'allow-gateway' }] })
+  })
+})

--- a/test/local/diagnose_environment.test.js
+++ b/test/local/diagnose_environment.test.js
@@ -897,5 +897,396 @@ describe('diagnose_environment', () => {
         url: 'https://console.cloud.google.com/iam-admin/iam?project=p1',
       })
     })
+
+    test('When Private Web App is present and ingress firewall rule for secure gateway is missing, then it produces a high severity firewall issue', async () => {
+      const mockComputeClient = {
+        listFirewalls: mock.fn(async () => ({ items: [] })),
+      }
+      const handlers = {}
+      const server = createMockServer(handlers)
+      const mockClients = createMockClients()
+      mockClients.beyondcorpClient.listGateways = mock.fn(async () => [
+        {
+          name: 'projects/p1/locations/global/securityGateways/gw1',
+          displayName: 'Gateway 1',
+          state: 'RUNNING',
+          delegatingServiceAccount: 'sa@gcp.iam.gserviceaccount.com',
+          serviceDiscovery: {},
+        },
+      ])
+      mockClients.beyondcorpClient.listApplications = mock.fn(async () => [
+        {
+          name: 'projects/p1/locations/global/securityGateways/gw1/applications/app1',
+          displayName: 'App 1',
+          endpointMatchers: [{ ports: [443] }],
+          upstreams: [{ network: 'projects/p1/global/networks/vpc1' }],
+        },
+      ])
+
+      registerDiagnoseEnvironmentTool(
+        server,
+        { ...mockClients, computeClient: mockComputeClient, featureFlags: enabledFlags },
+        { customerId: null, cachedRootOrgUnitId: null },
+      )
+
+      const result = await handlers['diagnose_environment'](
+        { customerId: 'C0123', projectId: 'p1' },
+        { requestInfo: {} },
+      )
+
+      const fwIssues = result.structuredContent.issues.filter(i => i.component === 'secureGateway.firewall')
+      assert.strictEqual(fwIssues.length, 1)
+      assert.strictEqual(fwIssues[0].severity, 'high')
+      assert.ok(fwIssues[0].message.includes('Ingress firewall rule allowing TCP traffic from secure gateway range'))
+      assert.ok(fwIssues[0].remediation.command.includes('gcloud compute firewall-rules create'))
+    })
+
+    test('When App has multiple upstreams on the same VPC network, then it produces exactly 1 firewall issue per network', async () => {
+      const mockComputeClient = {
+        listFirewalls: mock.fn(async () => ({ items: [] })),
+      }
+      const handlers = {}
+      const server = createMockServer(handlers)
+      const mockClients = createMockClients()
+      mockClients.beyondcorpClient.listGateways = mock.fn(async () => [
+        {
+          name: 'projects/p1/locations/global/securityGateways/gw1',
+          displayName: 'Gateway 1',
+          state: 'RUNNING',
+          delegatingServiceAccount: 'sa@gcp.iam.gserviceaccount.com',
+          serviceDiscovery: {},
+        },
+      ])
+      mockClients.beyondcorpClient.listApplications = mock.fn(async () => [
+        {
+          name: 'projects/p1/locations/global/securityGateways/gw1/applications/app1',
+          displayName: 'App 1',
+          endpointMatchers: [{ ports: [443] }],
+          upstreams: [
+            { network: 'projects/p1/global/networks/vpc1', upstreamUri: '10.0.0.5:443' },
+            { network: 'projects/p1/global/networks/vpc1', upstreamUri: '10.0.0.6:443' },
+          ],
+        },
+      ])
+
+      registerDiagnoseEnvironmentTool(
+        server,
+        { ...mockClients, computeClient: mockComputeClient, featureFlags: enabledFlags },
+        { customerId: null, cachedRootOrgUnitId: null },
+      )
+
+      const result = await handlers['diagnose_environment'](
+        { customerId: 'C0123', projectId: 'p1' },
+        { requestInfo: {} },
+      )
+
+      const fwIssues = result.structuredContent.issues.filter(i => i.component === 'secureGateway.firewall')
+      assert.strictEqual(fwIssues.length, 1, 'Should deduplicate missing firewall rules per unique network')
+      assert.ok(fwIssues[0].message.includes('vpc1'))
+    })
+
+    test('When matching allow firewall rule is disabled, then it ignores it and produces missing firewall issue', async () => {
+      const mockComputeClient = {
+        listFirewalls: mock.fn(async () => ({
+          items: [
+            {
+              direction: 'INGRESS',
+              action: 'ALLOW',
+              disabled: true,
+              network: 'projects/p1/global/networks/vpc1',
+              sourceRanges: ['136.124.16.0/20'],
+              allowed: [{ IPProtocol: 'tcp', ports: ['443'] }],
+            },
+          ],
+        })),
+      }
+      const handlers = {}
+      const server = createMockServer(handlers)
+      const mockClients = createMockClients()
+      mockClients.beyondcorpClient.listGateways = mock.fn(async () => [
+        {
+          name: 'projects/p1/locations/global/securityGateways/gw1',
+          displayName: 'Gateway 1',
+          state: 'RUNNING',
+          delegatingServiceAccount: 'sa@gcp.iam.gserviceaccount.com',
+          serviceDiscovery: {},
+        },
+      ])
+      mockClients.beyondcorpClient.listApplications = mock.fn(async () => [
+        {
+          name: 'projects/p1/locations/global/securityGateways/gw1/applications/app1',
+          displayName: 'App 1',
+          endpointMatchers: [{ ports: [443] }],
+          upstreams: [{ network: 'projects/p1/global/networks/vpc1' }],
+        },
+      ])
+
+      registerDiagnoseEnvironmentTool(
+        server,
+        { ...mockClients, computeClient: mockComputeClient, featureFlags: enabledFlags },
+        { customerId: null, cachedRootOrgUnitId: null },
+      )
+
+      const result = await handlers['diagnose_environment'](
+        { customerId: 'C0123', projectId: 'p1' },
+        { requestInfo: {} },
+      )
+
+      const fwIssues = result.structuredContent.issues.filter(i => i.component === 'secureGateway.firewall')
+      assert.strictEqual(fwIssues.length, 1, 'Disabled rule should be ignored')
+    })
+
+    test('When firewall rule specifies port ranges like 80-443, then it recognizes port 443 as allowed', async () => {
+      const mockComputeClient = {
+        listFirewalls: mock.fn(async () => ({
+          items: [
+            {
+              direction: 'INGRESS',
+              action: 'ALLOW',
+              disabled: false,
+              network: 'projects/p1/global/networks/vpc1',
+              sourceRanges: ['136.124.16.0/20'],
+              allowed: [{ IPProtocol: 'tcp', ports: ['80-443'] }],
+            },
+          ],
+        })),
+      }
+      const handlers = {}
+      const server = createMockServer(handlers)
+      const mockClients = createMockClients()
+      mockClients.beyondcorpClient.listGateways = mock.fn(async () => [
+        {
+          name: 'projects/p1/locations/global/securityGateways/gw1',
+          displayName: 'Gateway 1',
+          state: 'RUNNING',
+          delegatingServiceAccount: 'sa@gcp.iam.gserviceaccount.com',
+          serviceDiscovery: {},
+        },
+      ])
+      mockClients.beyondcorpClient.listApplications = mock.fn(async () => [
+        {
+          name: 'projects/p1/locations/global/securityGateways/gw1/applications/app1',
+          displayName: 'App 1',
+          endpointMatchers: [{ ports: [443] }],
+          upstreams: [{ network: 'projects/p1/global/networks/vpc1' }],
+        },
+      ])
+
+      registerDiagnoseEnvironmentTool(
+        server,
+        { ...mockClients, computeClient: mockComputeClient, featureFlags: enabledFlags },
+        { customerId: null, cachedRootOrgUnitId: null },
+      )
+
+      const result = await handlers['diagnose_environment'](
+        { customerId: 'C0123', projectId: 'p1' },
+        { requestInfo: {} },
+      )
+
+      const fwIssues = result.structuredContent.issues.filter(i => i.component === 'secureGateway.firewall')
+      assert.strictEqual(fwIssues.length, 0, 'Port 443 within 80-443 range should be recognized as allowed')
+    })
+
+    test('When u.network is an object with full URI containing project number, then it matches compute firewall rule with project ID', async () => {
+      const mockComputeClient = {
+        listFirewalls: mock.fn(async () => ({
+          items: [
+            {
+              direction: 'INGRESS',
+              action: 'ALLOW',
+              disabled: false,
+              network: 'projects/brett-public-preview/global/networks/default',
+              sourceRanges: ['136.124.16.0/20'],
+              allowed: [{ IPProtocol: 'tcp', ports: ['443'] }],
+            },
+          ],
+        })),
+      }
+      const handlers = {}
+      const server = createMockServer(handlers)
+      const mockClients = createMockClients()
+      mockClients.beyondcorpClient.listGateways = mock.fn(async () => [
+        {
+          name: 'projects/p1/locations/global/securityGateways/gw1',
+          displayName: 'Gateway 1',
+          state: 'RUNNING',
+          delegatingServiceAccount: 'sa@gcp.iam.gserviceaccount.com',
+          serviceDiscovery: {},
+        },
+      ])
+      mockClients.beyondcorpClient.listApplications = mock.fn(async () => [
+        {
+          name: 'projects/p1/locations/global/securityGateways/gw1/applications/app1',
+          displayName: 'App 1',
+          endpointMatchers: [{ ports: [443] }],
+          upstreams: [
+            {
+              network: {
+                name: 'projects/498461174898/global/networks/default',
+              },
+            },
+          ],
+        },
+      ])
+
+      registerDiagnoseEnvironmentTool(
+        server,
+        { ...mockClients, computeClient: mockComputeClient, featureFlags: enabledFlags },
+        { customerId: null, cachedRootOrgUnitId: null },
+      )
+
+      const result = await handlers['diagnose_environment'](
+        { customerId: 'C0123', projectId: 'brett-public-preview' },
+        { requestInfo: {} },
+      )
+
+      const fwIssues = result.structuredContent.issues.filter(i => i.component === 'secureGateway.firewall')
+      assert.strictEqual(
+        fwIssues.length,
+        0,
+        'Project number in u.network.name object should correctly resolve basename default',
+      )
+    })
+
+    test('When matching allow firewall rule has targetTags, then it ignores it and reports missing network-wide firewall rule', async () => {
+      const mockComputeClient = {
+        listFirewalls: mock.fn(async () => ({
+          items: [
+            {
+              direction: 'INGRESS',
+              action: 'ALLOW',
+              disabled: false,
+              network: 'projects/p1/global/networks/vpc1',
+              targetTags: ['http-server'],
+              sourceRanges: ['136.124.16.0/20'],
+              allowed: [{ IPProtocol: 'tcp', ports: ['443'] }],
+            },
+          ],
+        })),
+      }
+      const handlers = {}
+      const server = createMockServer(handlers)
+      const mockClients = createMockClients()
+      mockClients.beyondcorpClient.listGateways = mock.fn(async () => [
+        {
+          name: 'projects/p1/locations/global/securityGateways/gw1',
+          displayName: 'Gateway 1',
+          state: 'RUNNING',
+          delegatingServiceAccount: 'sa@gcp.iam.gserviceaccount.com',
+          serviceDiscovery: {},
+        },
+      ])
+      mockClients.beyondcorpClient.listApplications = mock.fn(async () => [
+        {
+          name: 'projects/p1/locations/global/securityGateways/gw1/applications/app1',
+          displayName: 'App 1',
+          endpointMatchers: [{ ports: [443] }],
+          upstreams: [{ network: 'projects/p1/global/networks/vpc1' }],
+        },
+      ])
+
+      registerDiagnoseEnvironmentTool(
+        server,
+        { ...mockClients, computeClient: mockComputeClient, featureFlags: enabledFlags },
+        { customerId: null, cachedRootOrgUnitId: null },
+      )
+
+      const result = await handlers['diagnose_environment'](
+        { customerId: 'C0123', projectId: 'p1' },
+        { requestInfo: {} },
+      )
+
+      const fwIssues = result.structuredContent.issues.filter(i => i.component === 'secureGateway.firewall')
+      assert.strictEqual(fwIssues.length, 1, 'Rule with targetTags should be skipped to require a network-wide rule')
+    })
+
+    test('When compute listFirewalls throws error, then it produces a medium severity firewall issue with manual remediation link', async () => {
+      const mockComputeClient = {
+        listFirewalls: mock.fn(async () => {
+          throw new Error('403 Forbidden: Missing compute.firewalls.list')
+        }),
+      }
+      const handlers = {}
+      const server = createMockServer(handlers)
+      const mockClients = createMockClients()
+      mockClients.beyondcorpClient.listGateways = mock.fn(async () => [
+        {
+          name: 'projects/p1/locations/global/securityGateways/gw1',
+          displayName: 'Gateway 1',
+          state: 'RUNNING',
+          delegatingServiceAccount: 'sa@gcp.iam.gserviceaccount.com',
+          serviceDiscovery: {},
+        },
+      ])
+      mockClients.beyondcorpClient.listApplications = mock.fn(async () => [
+        {
+          name: 'projects/p1/locations/global/securityGateways/gw1/applications/app1',
+          displayName: 'App 1',
+          endpointMatchers: [{ ports: [443] }],
+          upstreams: [{ network: 'projects/p1/global/networks/vpc1' }],
+        },
+      ])
+
+      registerDiagnoseEnvironmentTool(
+        server,
+        { ...mockClients, computeClient: mockComputeClient, featureFlags: enabledFlags },
+        { customerId: null, cachedRootOrgUnitId: null },
+      )
+
+      const result = await handlers['diagnose_environment'](
+        { customerId: 'C0123', projectId: 'p1' },
+        { requestInfo: {} },
+      )
+
+      const fwIssues = result.structuredContent.issues.filter(i => i.component === 'secureGateway.firewall')
+      assert.strictEqual(fwIssues.length, 1)
+      assert.strictEqual(fwIssues[0].severity, 'medium')
+      assert.ok(fwIssues[0].message.includes('Unable to automatically verify VPC ingress firewall rules'))
+      assert.ok(fwIssues[0].remediation.url.includes('console.cloud.google.com/net-security/firewall-manager'))
+    })
+
+    test('When upstream URI is CGNAT IP (100.10.1.1) without network, then it is excluded from private VPC firewall checks', async () => {
+      const mockComputeClient = {
+        listFirewalls: mock.fn(async () => ({ items: [] })),
+      }
+      const handlers = {}
+      const server = createMockServer(handlers)
+      const mockClients = createMockClients()
+      mockClients.beyondcorpClient.listGateways = mock.fn(async () => [
+        {
+          name: 'projects/p1/locations/global/securityGateways/gw1',
+          displayName: 'Gateway 1',
+          state: 'RUNNING',
+          delegatingServiceAccount: 'sa@gcp.iam.gserviceaccount.com',
+          serviceDiscovery: {},
+        },
+      ])
+      mockClients.beyondcorpClient.listApplications = mock.fn(async () => [
+        {
+          name: 'projects/p1/locations/global/securityGateways/gw1/applications/app1',
+          displayName: 'App 1',
+          endpointMatchers: [{ ports: [8080] }],
+          upstreams: [{ upstreamUri: '100.10.1.1:8080' }],
+        },
+      ])
+
+      registerDiagnoseEnvironmentTool(
+        server,
+        { ...mockClients, computeClient: mockComputeClient, featureFlags: enabledFlags },
+        { customerId: null, cachedRootOrgUnitId: null },
+      )
+
+      const result = await handlers['diagnose_environment'](
+        { customerId: 'C0123', projectId: 'p1' },
+        { requestInfo: {} },
+      )
+
+      const fwIssues = result.structuredContent.issues.filter(i => i.component === 'secureGateway.firewall')
+      assert.strictEqual(
+        fwIssues.length,
+        0,
+        'CGNAT IP without network should be treated as non-private and excluded from firewall checks',
+      )
+    })
   })
 })

--- a/tools/definitions/diagnose_environment.js
+++ b/tools/definitions/diagnose_environment.js
@@ -56,6 +56,41 @@ const SEB_EXTENSION_ID = 'chrome:ekajlcmdfcigmdbphhifahdfjbkciflj'
 const DEFAULT_PAGE_SIZE = 50
 
 /**
+ * Helper to check if an upstream destination is a private network or internal IP.
+ * @param {object} u - Upstream definition object
+ * @returns {boolean} True if the upstream is in a private network or IP block
+ */
+function isPrivateUpstream(u) {
+  if (u.network) {
+    return true
+  }
+  if (u.upstreamUri) {
+    const uri = String(u.upstreamUri).toLowerCase()
+    return /\b(?:10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b|\.internal\b/.test(
+      uri,
+    )
+  }
+  return false
+}
+
+/**
+ * Checks if a target port is matched by a GCP firewall port spec (e.g. "443" or "80-443").
+ * @param {string|number} spec - Port specification string or number
+ * @param {number} targetPort - Target port number to check
+ * @returns {boolean} True if targetPort falls within spec
+ */
+function matchesPortSpec(spec, targetPort) {
+  const strSpec = String(spec)
+  if (strSpec.includes('-')) {
+    const [startStr, endStr] = strSpec.split('-')
+    const start = Number(startStr)
+    const end = Number(endStr)
+    return !isNaN(start) && !isNaN(end) && targetPort >= start && targetPort <= end
+  }
+  return String(spec) === String(targetPort)
+}
+
+/**
  * Computes deterministic issues from the environment summary.
  * Validates subscription status, connector configurations, DLP rule enforcement,
  * and force-installation of required extensions.
@@ -291,21 +326,19 @@ function computeIssues(data) {
           if (gateway.applications && gateway.applications.length > 0) {
             for (const app of gateway.applications) {
               const matchers = app.endpointMatchers || app.endpoint_matchers || []
-              for (const matcher of matchers) {
-                const ports = matcher.ports || []
-                if (ports.includes(80)) {
-                  issues.push({
-                    severity: 'medium',
-                    component: 'secureGateway.application',
-                    message: `Application ${app.displayName || app.name} on gateway ${gateway.displayName || gateway.name} routes port 80. If accessed over unencrypted HTTP (http://), Chrome and SEB extension send direct GET requests instead of establishing a CONNECT tunnel, resulting in 401 Unauthorized errors. Ensure traffic is served over HTTPS.`,
-                  })
-                }
+              const appPorts = matchers.flatMap(m => m.ports || [])
+              if (appPorts.includes(80)) {
+                issues.push({
+                  severity: 'medium',
+                  component: 'secureGateway.application',
+                  message: `Application ${app.displayName || app.name} on gateway ${gateway.displayName || gateway.name} routes port 80. If accessed over unencrypted HTTP (http://), Chrome and SEB extension send direct GET requests instead of establishing a CONNECT tunnel, resulting in 401 Unauthorized errors. Ensure traffic is served over HTTPS.`,
+                })
               }
             }
 
             const hasPrivateWebApps = gateway.applications.some(app => {
               const upstreams = app.upstreams || []
-              return upstreams.some(u => Boolean(u.network))
+              return upstreams.some(isPrivateUpstream)
             })
 
             const saEmail = gateway.delegatingServiceAccount || gateway.delegating_service_account
@@ -341,25 +374,137 @@ function computeIssues(data) {
                 }
               }
             }
+
+            if (gateway.applicationsError) {
+              issues.push({
+                severity: 'medium',
+                component: 'secureGateway',
+                message: `Failed to list applications for Secure Gateway ${gateway.displayName || gateway.name}: ${gateway.applicationsError}`,
+              })
+            }
           }
-          if (data.secureGateway.projectIamPolicyError) {
-            issues.push({
-              severity: 'medium',
-              component: 'secureGateway.iam',
-              message: `Unable to automatically verify delegating service account permissions on project ${data.secureGateway.projectId} (${data.secureGateway.projectIamPolicyError}). Please manually verify that the delegating service account has 'roles/beyondcorp.upstreamAccess'.`,
-              remediation: {
-                actionLabel: 'Verify GCP IAM Roles Manually',
-                url: `https://console.cloud.google.com/iam-admin/iam?project=${data.secureGateway.projectId}`,
-              },
+        }
+
+        if (data.secureGateway.firewalls) {
+          const networkRequirements = new Map()
+
+          for (const gateway of data.secureGateway.gateways) {
+            if (!gateway.applications) {
+              continue
+            }
+
+            for (const app of gateway.applications) {
+              const matchers = app.endpointMatchers || app.endpoint_matchers || []
+              const appPorts = matchers.flatMap(m => m.ports || [])
+              const portsToUse = appPorts.length > 0 ? appPorts : [443]
+
+              const upstreams = app.upstreams || []
+              const privateUpstreams = upstreams.filter(isPrivateUpstream)
+
+              for (const u of privateUpstreams) {
+                const network = u.network
+                const rawName = typeof network === 'string' ? network : network?.name || 'default'
+                const networkName = rawName.split('/').pop() || 'default'
+
+                if (!networkRequirements.has(networkName)) {
+                  networkRequirements.set(networkName, new Set())
+                }
+                const portSet = networkRequirements.get(networkName)
+                for (const p of portsToUse) {
+                  portSet.add(p)
+                }
+              }
+            }
+          }
+
+          const firewalls = data.secureGateway.firewalls
+          for (const [networkName, portSet] of networkRequirements.entries()) {
+            const firewallPorts = [...portSet]
+
+            const hasAllowRule = firewalls.some(fw => {
+              if (fw.disabled) {
+                return false
+              }
+              if (fw.direction && fw.direction !== 'INGRESS') {
+                return false
+              }
+              if (fw.action && fw.action !== 'ALLOW') {
+                return false
+              }
+
+              const hasTargetTags =
+                (fw.targetTags && fw.targetTags.length > 0) || (fw.target_tags && fw.target_tags.length > 0)
+              const hasTargetSAs =
+                (fw.targetServiceAccounts && fw.targetServiceAccounts.length > 0) ||
+                (fw.target_service_accounts && fw.target_service_accounts.length > 0)
+              if (hasTargetTags || hasTargetSAs) {
+                return false
+              }
+
+              if (fw.network && !fw.network.endsWith(`/${networkName}`)) {
+                return false
+              }
+
+              const sources = fw.sourceRanges || fw.source_ranges || []
+              const matchesSource = sources.includes('136.124.16.0/20') || sources.includes('0.0.0.0/0')
+              if (!matchesSource) {
+                return false
+              }
+
+              const allowedList = fw.allowed || []
+              if (allowedList.length === 0) {
+                return true
+              }
+              return allowedList.some(allow => {
+                const proto = (allow.IPProtocol || allow.ipProtocol || '').toLowerCase()
+                if (proto !== 'tcp' && proto !== 'all') {
+                  return false
+                }
+                const ports = allow.ports || []
+                if (ports.length === 0) {
+                  return true
+                }
+                return firewallPorts.some(p => ports.some(spec => matchesPortSpec(spec, p)))
+              })
             })
+
+            if (!hasAllowRule) {
+              const displayRange = '136.124.16.0/20'
+              issues.push({
+                severity: 'high',
+                component: 'secureGateway.firewall',
+                message: `Ingress firewall rule allowing TCP traffic from secure gateway range (${displayRange}) on port(s) ${firewallPorts.join(', ')} is missing on VPC network '${networkName}' in project ${data.secureGateway.projectId}. Private application routing will fail with gateway timeout errors.`,
+                remediation: {
+                  actionLabel: 'Create Ingress Firewall Rule',
+                  command: `gcloud compute firewall-rules create allow-secure-gateway-${networkName} --project=${data.secureGateway.projectId} --network=${networkName} --allow=tcp:${firewallPorts.join(',')} --source-ranges=${displayRange}`,
+                },
+              })
+            }
           }
-          if (gateway.applicationsError) {
-            issues.push({
-              severity: 'medium',
-              component: 'secureGateway',
-              message: `Failed to list applications for Secure Gateway ${gateway.displayName || gateway.name}: ${gateway.applicationsError}`,
-            })
-          }
+        }
+
+        if (data.secureGateway.firewallsError) {
+          issues.push({
+            severity: 'medium',
+            component: 'secureGateway.firewall',
+            message: `Unable to automatically verify VPC ingress firewall rules on project ${data.secureGateway.projectId} (${data.secureGateway.firewallsError}). Ensure an ingress firewall rule allows TCP traffic from gateway proxy ranges.`,
+            remediation: {
+              actionLabel: 'Verify Firewall Rules Manually',
+              url: `https://console.cloud.google.com/net-security/firewall-manager/firewall-policies/list?project=${data.secureGateway.projectId}`,
+            },
+          })
+        }
+
+        if (data.secureGateway.projectIamPolicyError) {
+          issues.push({
+            severity: 'medium',
+            component: 'secureGateway.iam',
+            message: `Unable to automatically verify delegating service account permissions on project ${data.secureGateway.projectId} (${data.secureGateway.projectIamPolicyError}). Please manually verify that the delegating service account has 'roles/beyondcorp.upstreamAccess'.`,
+            remediation: {
+              actionLabel: 'Verify GCP IAM Roles Manually',
+              url: `https://console.cloud.google.com/iam-admin/iam?project=${data.secureGateway.projectId}`,
+            },
+          })
         }
       }
     }
@@ -415,7 +560,7 @@ async function fetchEnvironment(
   authToken,
   options = {},
 ) {
-  const { beyondcorpClient, cloudResourceManagerClient, projectId, flags } = options
+  const { beyondcorpClient, cloudResourceManagerClient, computeClient, projectId, flags } = options
 
   const [
     customerData,
@@ -563,6 +708,17 @@ async function fetchEnvironment(
             projectIamPolicyError = err.message
           }
         }
+        let firewalls = null
+        let firewallsError = null
+        if (computeClient) {
+          try {
+            const firewallData = await computeClient.listFirewalls(projectId, {}, authToken)
+            firewalls = firewallData.items || []
+          } catch (err) {
+            logger.error(`${TAGS.API} Error fetching firewall rules for ${projectId} in diagnosis:`, err)
+            firewallsError = err.message
+          }
+        }
         const gateways = await Promise.all(
           (rawGateways || []).map(async gw => {
             const gatewayId = gw.name ? gw.name.split('/').pop() : gw.displayName
@@ -575,7 +731,15 @@ async function fetchEnvironment(
             }
           }),
         )
-        secureGateway = { projectId, gateways, projectIamPolicy, projectIamPolicyError, error: null }
+        secureGateway = {
+          projectId,
+          gateways,
+          projectIamPolicy,
+          projectIamPolicyError,
+          firewalls,
+          firewallsError,
+          error: null,
+        }
       } catch (err) {
         logger.error(`${TAGS.API} Error fetching secure gateways in diagnosis:`, err)
         secureGateway = { projectId, gateways: [], error: err.message }
@@ -615,6 +779,7 @@ export function registerDiagnoseEnvironmentTool(server, options, sessionState) {
   } = options
   const beyondcorpClient = options.beyondcorpClient || options.apiClients?.beyondcorp
   const cloudResourceManagerClient = options.cloudResourceManagerClient || options.apiClients?.cloudResourceManager
+  const computeClient = options.computeClient || options.apiClients?.compute
 
   const isSecureGatewayEnabled = flags.isEnabled(FLAGS.SECURE_GATEWAY_ENABLED)
 
@@ -659,7 +824,7 @@ Use 'limit' and 'offset' for pagination on large datasets.`,
             cloudIdentityClient,
             customerId,
             authToken,
-            { beyondcorpClient, cloudResourceManagerClient, projectId, flags },
+            { beyondcorpClient, cloudResourceManagerClient, computeClient, projectId, flags },
           )
 
           // Detail mode: return paginated section data
@@ -813,7 +978,11 @@ function buildSummaryResponse(env) {
               ? '🟡'
               : 'ℹ️'
       let remediation = ''
-      if (issue.component === 'securityInsights' && issue.severity === 'critical') {
+      if (issue.remediation?.command) {
+        remediation = `\n  ↳ **Remediation:** Run \`${issue.remediation.command}\``
+      } else if (issue.remediation?.url) {
+        remediation = `\n  ↳ **Remediation:** ${issue.remediation.actionLabel ? issue.remediation.actionLabel + ': ' : ''}${issue.remediation.url}`
+      } else if (issue.component === 'securityInsights' && issue.severity === 'critical') {
         remediation =
           ' -> Action: Use the `security_insights` tool to enable this feature (e.g. `security_insights enable`).'
       } else if (issue.component === 'securityInsightsData' && issue.severity === 'medium') {


### PR DESCRIPTION
## Summary
This PR adds **VPC ingress firewall sanity checking** for BeyondCorp Secure Gateway applications to the `diagnose_environment` tool. It verifies that target GCP VPC networks permit ingress TCP traffic from the global BeyondCorp Secure Gateway egress proxy subnet (`136.124.16.0/20`) to private web application ports.

## Key Changes

1. **Compute Engine API Client (`lib/api/compute_client.js`):**
   * Wrapped Google Compute Engine REST API (`client.firewalls.list`) to inspect global VPC firewall rules.
   * Registered `COMPUTE` API version and service constants in `lib/constants.js`.
   * Registered `compute` in `mcp-server.js` and `test/helpers/integration/tools/client_factory.js`.
   * Implemented matching unit tests in `test/local/compute_client.test.js`.

2. **Project VPC Firewall Checks & Graceful Error Handling (`tools/definitions/diagnose_environment.js`):**
   * **Project-wide VPC Aggregation**: Aggregates target VPC networks and required application ports across all gateways/applications into a `Map<networkName, ...>`, emitting exactly 1 consolidated issue per VPC network per project.
   * **Strict Global Egress Proxy Source Range (`136.124.16.0/20`)**: Strictly checks for an allow rule covering the production egress proxy source CIDR (`136.124.16.0/20` or `0.0.0.0/0`), matching official Google Cloud BeyondCorp documentation.
   * **Network-Wide Untagged Enforcement**: Requires network-wide rules by ignoring rules restricted to specific `targetTags` or `targetServiceAccounts`, strictly adhering to official GCP BeyondCorp blueprint standards.
   * **Robust Network URI Parsing**: Correctly extracts network basenames (`split('/').pop()`) whether `u.network` is passed as a string or a JSON object URI (`{ name: "projects/NUMBER/global/networks/NAME" }`).
   * **Disabled Rule Filtering**: Ignores inactive firewall rules (`disabled: true`).
   * **Port Range Spec Parsing**: Uses `matchesPortSpec(spec, targetPort)` to match exact ports (`443`) and numeric ranges (`"80-443"`).
   * **Module-Scoped Helpers**: Extracted `isPrivateUpstream(u)` and `matchesPortSpec` to top-level helper functions for V8 memory efficiency and DRY reuse.
   * **Graceful Remediation for Forbidden (403) Errors**: If API credentials lack `compute.firewalls.list` permissions, catches the error and appends a medium-severity warning with manual verification steps pointing to the GCP Console Firewall Policies page.
   * Added corresponding unit tests in `test/local/diagnose_environment.test.js`.

3. **Automated Evals & Mocks (`test/evals/cases/gateway/`):**
   * **`gw09` Evaluation Case (`gw09-diagnose-firewalls.eval.js`):** Added a P1 evaluation verifying that the agent correctly identifies a missing VPC ingress firewall rule for the Secure Gateway proxy range (`136.124.16.0/20`), providing the accurate `gcloud compute firewall-rules create` remediation command.
   * Mocked the `GET /compute/v1/projects/:projectId/global/firewalls` route in `test/helpers/fake-api-server.js` for local integration testing.

---

## Verification

### Automated Tests
Verified all unit, integration, formatting, lint, and smoke tests pass cleanly:
```bash
npm run presubmit
```
```text
✔ Prettier check passed
✔ ESLint linting passed
✔ 47 unit & fake integration tests passed
✔ Smoke test passed
```

### Evaluation Validation
Verified that all Gateway evaluations pass (20/20 runs, 100.0% pass rate):
```bash
$ node test/evals/run.js --id gw08,gw09 --runs 10
Running 2 eval(s) [full (agent + judge)] concurrency=5, runs=10...

  gw08   PASS  I need to configure access to Salesforce (a Saa...   5.5s/run  (10 of 10 runs passed)
  gw09   PASS  Use the diagnose_environment tool to run a comp...   4.3s/run  (10 of 10 runs passed)

Results: 20 of 20 runs passed (100.0% pass rate)
  gateway             20 of 20 passed (100.0%)
```

### Interactive Testing (Jetski CLI)
* Verified that if a private web app is detected and the target VPC network lacks an untagged ingress allow rule for `136.124.16.0/20`, the agent correctly warns:
  > *🟠 HIGH (secureGateway.firewall): Ingress firewall rule allowing TCP traffic from secure gateway range (136.124.16.0/20) on port(s) 443 is missing on VPC network 'default' in project my-project-123.*
* Verified that the agent outputs the exact `gcloud compute firewall-rules create` remediation command.
