### PR TITLE
feat(auth): support strict auth modes via CEP_AUTH_MODE configuration

### DIFF
--- a/lib/util/auth-error.js
+++ b/lib/util/auth-error.js
@@ -36,10 +36,27 @@ export function getAuthErrorMessage(error) {
   const lower = errorMessage.toLowerCase()
   const isInsufficientScopes = lower.includes(ERROR_MESSAGES.INSUFFICIENT_SCOPES.toLowerCase())
   const isApiNotEnabled = errorMessage.includes(ERROR_MESSAGES.API_NOT_USED_IN_PROJECT)
+  const isSaMode = !!process.env.GOOGLE_APPLICATION_CREDENTIALS
+  const isImpersonating = !!process.env.CEP_IMPERSONATE_SUBJECT
+  const isDwdError =
+    lower.includes('unauthorized_client') ||
+    (isImpersonating && (lower.includes('access_denied') || lower.includes('client is unauthorized')))
 
   let instruction = ''
-  if (isInsufficientScopes) {
-    instruction = `The cached OAuth token is missing one or more required scopes. Run the \`cep_auth\` tool, or re-run \`${cliInvocation('auth login')}\` at the shell, to re-consent with the updated scope set.`
+  if (isDwdError) {
+    instruction =
+      'Domain-Wide Delegation (DWD) authorization failed.\n\n' +
+      'Ensure the Service Account Client ID is authorized in Google Workspace Admin Console:\n' +
+      '  1. Open https://admin.google.com/ > Security > API Controls > Domain-wide Delegation.\n' +
+      '  2. Add your Service Account Client ID with required OAuth scopes (e.g., Cloud Identity policies and Chrome Management).\n' +
+      '  3. Ensure CEP_IMPERSONATE_SUBJECT is set to a valid Google Workspace admin email.'
+  } else if (isInsufficientScopes) {
+    if (isSaMode) {
+      instruction =
+        'The Service Account or delegated token has insufficient scopes. Verify the Domain-Wide Delegation OAuth scopes authorized in Google Workspace Admin Console.'
+    } else {
+      instruction = `The cached OAuth token is missing one or more required scopes. Run the \`cep_auth\` tool, or re-run \`${cliInvocation('auth login')}\` at the shell, to re-consent with the updated scope set.`
+    }
   } else if (isApiNotEnabled) {
     const apiList = Object.values(SERVICE_NAMES).join(' ')
     const authProjectNumber = MANAGED_OAUTH_CLIENT_ID.split('-')[0]

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -202,6 +202,9 @@ export function createSseHandler(gcpInfo, sseTransports, getServerImpl = getServ
  */
 function shouldRegisterEnableApi() {
   try {
+    if (process.env.GOOGLE_APPLICATION_CREDENTIALS || !isStdioMode()) {
+      return true
+    }
     const config = resolveOAuthClientConfig()
     return config.source !== 'managed'
   } catch {

--- a/test/local/auth.test.js
+++ b/test/local/auth.test.js
@@ -393,7 +393,7 @@ describe('Auth', () => {
         )
         const result = await wrapped({}, {})
         assert.strictEqual(result.isError, true)
-        assert.match(result.content[0].text, /requires domain-wide delegation/)
+        assert.match(result.content[0].text, /requires domain-wide delegation/i)
       } finally {
         if (prevCred === undefined) {
           delete process.env.GOOGLE_APPLICATION_CREDENTIALS

--- a/test/local/auth.test.js
+++ b/test/local/auth.test.js
@@ -264,7 +264,6 @@ describe('Auth', () => {
         if (prevMode === undefined) {
           delete process.env.CEP_AUTH_MODE
         } else {
-          // eslint-disable-next-line require-atomic-updates
           process.env.CEP_AUTH_MODE = prevMode
         }
       }
@@ -286,13 +285,11 @@ describe('Auth', () => {
         if (prevMode === undefined) {
           delete process.env.CEP_AUTH_MODE
         } else {
-          // eslint-disable-next-line require-atomic-updates
           process.env.CEP_AUTH_MODE = prevMode
         }
         if (prevCred === undefined) {
           delete process.env.GOOGLE_APPLICATION_CREDENTIALS
         } else {
-          // eslint-disable-next-line require-atomic-updates
           process.env.GOOGLE_APPLICATION_CREDENTIALS = prevCred
         }
       }
@@ -322,7 +319,6 @@ describe('Auth', () => {
       process.env.CEP_AUTH_MODE = 'service-account-only'
       process.env.GOOGLE_APPLICATION_CREDENTIALS = '/tmp/fake-key.json'
       try {
-        // Pass a token, but it should be ignored in favor of SA
         const client = await getAuthClient([], 'ignored-token')
         assert.ok(client)
         assert.ok(jwtInstantiated)
@@ -330,13 +326,11 @@ describe('Auth', () => {
         if (prevMode === undefined) {
           delete process.env.CEP_AUTH_MODE
         } else {
-          // eslint-disable-next-line require-atomic-updates
           process.env.CEP_AUTH_MODE = prevMode
         }
         if (prevCred === undefined) {
           delete process.env.GOOGLE_APPLICATION_CREDENTIALS
         } else {
-          // eslint-disable-next-line require-atomic-updates
           process.env.GOOGLE_APPLICATION_CREDENTIALS = prevCred
         }
       }
@@ -354,13 +348,11 @@ describe('Auth', () => {
         if (prevMode === undefined) {
           delete process.env.CEP_AUTH_MODE
         } else {
-          // eslint-disable-next-line require-atomic-updates
           process.env.CEP_AUTH_MODE = prevMode
         }
         if (prevCred === undefined) {
           delete process.env.GOOGLE_APPLICATION_CREDENTIALS
         } else {
-          // eslint-disable-next-line require-atomic-updates
           process.env.GOOGLE_APPLICATION_CREDENTIALS = prevCred
         }
       }
@@ -376,8 +368,109 @@ describe('Auth', () => {
         if (prevMode === undefined) {
           delete process.env.CEP_AUTH_MODE
         } else {
-          // eslint-disable-next-line require-atomic-updates
           process.env.CEP_AUTH_MODE = prevMode
+        }
+      }
+    })
+  })
+
+  describe('guardedToolCall delegation guard', () => {
+    test('When running in SA mode and calling a tool with requiresDelegation=true without CEP_IMPERSONATE_SUBJECT, then it returns pre-flight error', async () => {
+      const { guardedToolCall } = await import('../../tools/utils/wrapper.js')
+      const prevCred = process.env.GOOGLE_APPLICATION_CREDENTIALS
+      const prevSub = process.env.CEP_IMPERSONATE_SUBJECT
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = '/tmp/fake-key.json'
+      delete process.env.CEP_IMPERSONATE_SUBJECT
+      try {
+        const wrapped = guardedToolCall(
+          {
+            requiresDelegation: true,
+            skipAutoResolve: true,
+            handler: async () => ({ content: [{ type: 'text', text: 'should not run' }] }),
+          },
+          {},
+          {},
+        )
+        const result = await wrapped({}, {})
+        assert.strictEqual(result.isError, true)
+        assert.match(result.content[0].text, /requires domain-wide delegation/)
+      } finally {
+        if (prevCred === undefined) {
+          delete process.env.GOOGLE_APPLICATION_CREDENTIALS
+        } else {
+          process.env.GOOGLE_APPLICATION_CREDENTIALS = prevCred
+        }
+        if (prevSub === undefined) {
+          delete process.env.CEP_IMPERSONATE_SUBJECT
+        } else {
+          process.env.CEP_IMPERSONATE_SUBJECT = prevSub
+        }
+      }
+    })
+
+    test('When running in SA mode and calling a tool with requiresDelegation=false without CEP_IMPERSONATE_SUBJECT, then it runs handler and skips OAuth check', async () => {
+      const { guardedToolCall } = await import('../../tools/utils/wrapper.js')
+      const prevCred = process.env.GOOGLE_APPLICATION_CREDENTIALS
+      const prevSub = process.env.CEP_IMPERSONATE_SUBJECT
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = '/tmp/fake-key.json'
+      delete process.env.CEP_IMPERSONATE_SUBJECT
+      try {
+        let handlerRan = false
+        const wrapped = guardedToolCall(
+          {
+            requiresDelegation: false,
+            skipAutoResolve: true,
+            handler: async () => {
+              handlerRan = true
+              return { content: [{ type: 'text', text: 'ok' }] }
+            },
+          },
+          {},
+          {},
+        )
+        const result = await wrapped({}, {})
+        assert.strictEqual(handlerRan, true)
+        assert.strictEqual(result.content[0].text, 'ok')
+      } finally {
+        if (prevCred === undefined) {
+          delete process.env.GOOGLE_APPLICATION_CREDENTIALS
+        } else {
+          process.env.GOOGLE_APPLICATION_CREDENTIALS = prevCred
+        }
+        if (prevSub === undefined) {
+          delete process.env.CEP_IMPERSONATE_SUBJECT
+        } else {
+          process.env.CEP_IMPERSONATE_SUBJECT = prevSub
+        }
+      }
+    })
+  })
+
+  describe('Step 2 mode-aware error remediation', () => {
+    test('When DWD unauthorized_client error occurs, then getAuthErrorMessage returns DWD admin console instructions', async () => {
+      const { getAuthErrorMessage } = await import('../../lib/util/auth-error.js')
+      const error = new Error(
+        '401 unauthorized_client: Client is unauthorized to retrieve access tokens using this method.',
+      )
+      const message = getAuthErrorMessage(error)
+      assert.match(message, /Domain-Wide Delegation \(DWD\) authorization failed/)
+      assert.match(message, /admin\.google\.com/)
+    })
+
+    test('When running in Service Account mode, then getAuthErrorMessage for insufficient scopes never mentions cep_auth', async () => {
+      const { getAuthErrorMessage } = await import('../../lib/util/auth-error.js')
+      const prevCred = process.env.GOOGLE_APPLICATION_CREDENTIALS
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = '/tmp/fake-key.json'
+      try {
+        const error = new Error('Request had insufficient authentication scopes.')
+        const message = getAuthErrorMessage(error)
+        assert.match(message, /Verify the Domain-Wide Delegation OAuth scopes/)
+        assert.doesNotMatch(message, /cep_auth/)
+      } finally {
+        if (prevCred === undefined) {
+          delete process.env.GOOGLE_APPLICATION_CREDENTIALS
+        } else {
+          process.env.GOOGLE_APPLICATION_CREDENTIALS = prevCred
         }
       }
     })

--- a/tools/definitions/check_cep_subscription.js
+++ b/tools/definitions/check_cep_subscription.js
@@ -51,6 +51,7 @@ export function registerCheckCepSubscriptionTool(server, options, sessionState) 
     },
     guardedToolCall(
       {
+        requiresDelegation: true,
         handler: async ({ customerId }, { _requestInfo, authToken }) => {
           logger.debug(`${TAGS.MCP} Calling 'check_cep_subscription' for customer: ${customerId}`)
 

--- a/tools/definitions/check_user_cep_license.js
+++ b/tools/definitions/check_user_cep_license.js
@@ -50,6 +50,7 @@ Use this to verify if an individual user (by email or unique ID) is licensed for
     },
     guardedToolCall(
       {
+        requiresDelegation: true,
         handler: async ({ userId }, { _requestInfo, authToken }) => {
           logger.debug(`${TAGS.MCP} Calling 'check_user_cep_license' for user: ${userId}`)
 

--- a/tools/definitions/create_chrome_dlp_rule.js
+++ b/tools/definitions/create_chrome_dlp_rule.js
@@ -155,6 +155,7 @@ To ensure technical accuracy and verify trigger compatibility, you should retrie
 
     guardedToolCall(
       {
+        requiresDelegation: true,
         transform: params => {
           const prefix = AGENT_DISPLAY_NAME_PREFIX
           const newDisplayName = params.displayName.startsWith(prefix)

--- a/tools/definitions/create_default_dlp_rules.js
+++ b/tools/definitions/create_default_dlp_rules.js
@@ -109,6 +109,7 @@ Rules included:
 
     guardedToolCall(
       {
+        requiresDelegation: true,
         handler: async (params, { authToken }) => {
           logger.debug(`${TAGS.MCP} Calling 'create_default_dlp_rules' with params: ${JSON.stringify(params)}`)
           const { customerId, orgUnitId } = params

--- a/tools/definitions/create_regex_detector.js
+++ b/tools/definitions/create_regex_detector.js
@@ -58,6 +58,7 @@ Detectors are building blocks for DLP rules. After creating a detector, you must
     },
     guardedToolCall(
       {
+        requiresDelegation: true,
         /**
          * Handler for creating a regular expression detector.
          * @param {object} params - The tool parameters.

--- a/tools/definitions/create_url_list_detector.js
+++ b/tools/definitions/create_url_list_detector.js
@@ -58,6 +58,7 @@ Detectors are building blocks for DLP rules. After creating a detector, you must
     },
     guardedToolCall(
       {
+        requiresDelegation: true,
         /**
          * Handler for creating a URL list detector.
          * @param {object} params - The tool parameters.

--- a/tools/definitions/create_word_list_detector.js
+++ b/tools/definitions/create_word_list_detector.js
@@ -64,6 +64,7 @@ Detectors are building blocks for DLP rules. After creating a detector, you must
     },
     guardedToolCall(
       {
+        requiresDelegation: true,
         /**
          * Handler for creating a word list detector.
          * @param {object} params - The tool parameters.

--- a/tools/definitions/delete_agent_dlp_rule.js
+++ b/tools/definitions/delete_agent_dlp_rule.js
@@ -54,6 +54,7 @@ export function registerDeleteAgentDlpRuleTool(server, options, sessionState) {
     },
     guardedToolCall(
       {
+        requiresDelegation: true,
         /**
          * Handler for deleting an agent-created DLP rule.
          * @param {object} params - The tool parameters.

--- a/tools/definitions/delete_detector.js
+++ b/tools/definitions/delete_detector.js
@@ -55,6 +55,7 @@ Note: This will not automatically remove the detector from any DLP rules that re
     },
     guardedToolCall(
       {
+        requiresDelegation: true,
         /**
          * Handler for deleting a DLP detector.
          * @param {object} params - The tool parameters.

--- a/tools/definitions/get_customer_id.js
+++ b/tools/definitions/get_customer_id.js
@@ -49,6 +49,7 @@ This ID (often starting with 'C') is required as a parameter for many other Chro
     },
     guardedToolCall(
       {
+        requiresDelegation: true,
         /**
          * Handler for retrieving the customer ID.
          * @param {object} params - The tool parameters.

--- a/tools/definitions/get_dlp_rule.js
+++ b/tools/definitions/get_dlp_rule.js
@@ -51,6 +51,7 @@ export function registerGetDlpRuleTool(server, options, sessionState) {
     },
     guardedToolCall(
       {
+        requiresDelegation: true,
         /**
          * Handler for getting a DLP rule.
          * @param {object} params - The tool parameters.

--- a/tools/definitions/list_detectors.js
+++ b/tools/definitions/list_detectors.js
@@ -48,6 +48,7 @@ Detectors are used within DLP rules to identify sensitive content. Use this to f
     },
     guardedToolCall(
       {
+        requiresDelegation: true,
         handler: async (_, { authToken }) => {
           logger.debug(`${TAGS.MCP} Calling 'list_detectors'`)
           const detectors = await cloudIdentityClient.listDetectors(authToken)

--- a/tools/definitions/list_dlp_rules.js
+++ b/tools/definitions/list_dlp_rules.js
@@ -49,6 +49,7 @@ export function registerListDlpRulesTool(server, options, sessionState) {
     },
     guardedToolCall(
       {
+        requiresDelegation: true,
         /**
          * Handler for listing DLP rules.
          * @param {object} _ - The tool parameters (unused).

--- a/tools/index.js
+++ b/tools/index.js
@@ -20,6 +20,7 @@ limitations under the License.
 
 import { TAGS } from '../lib/constants.js'
 import { logger } from '../lib/util/logger.js'
+import { isStdioMode } from '../lib/util/gcp.js'
 
 import { registerGetCustomerIdTool } from './definitions/get_customer_id.js'
 import { registerListOrgUnitsTool } from './definitions/list_org_units.js'
@@ -162,5 +163,9 @@ export function registerTools(server, options = {}, sessionState) {
   }
 
   registerKnowledgeTools(server, { ...options, featureFlags: flags }, state)
-  registerAuthTools(server, commonOpts, state)
+  const isInteractiveOauthMode =
+    isStdioMode() && !process.env.GOOGLE_APPLICATION_CREDENTIALS && !process.env.CEP_ACCESS_TOKEN
+  if (isInteractiveOauthMode) {
+    registerAuthTools(server, commonOpts, state)
+  }
 }

--- a/tools/utils/wrapper.js
+++ b/tools/utils/wrapper.js
@@ -56,13 +56,72 @@ function buildAuthRequiredResponse({ reason, expiresAt }) {
   }
 }
 
+const TOOL_PRIVILEGES_MAP = {
+  list_org_units: {
+    privilege: 'Services > Google Workspace > Directory > Read organizational units',
+    roleUrl: 'https://admin.google.com/ac/roles',
+  },
+  security_insights: {
+    privilege:
+      'Services > Chrome Management > Manage ChromeOS Devices (Read-only) + Services > Chrome Enterprise Security Insights',
+    roleUrl: 'https://admin.google.com/ac/roles',
+  },
+  count_browser_versions: {
+    privilege: 'Services > Chrome Management > Manage ChromeOS Devices (Read-only)',
+    roleUrl: 'https://admin.google.com/ac/roles',
+  },
+  list_customer_profiles: {
+    privilege:
+      'Services > Chrome Management > Manage ChromeOS Devices (Read-only) + Services > Chrome Management > Settings > Managed Browsers',
+    roleUrl: 'https://admin.google.com/ac/roles',
+  },
+  get_chrome_activity_log: {
+    privilege: 'Services > Chrome Management > Manage ChromeOS Devices (Read-only) + Reports > Audit Reports',
+    roleUrl: 'https://admin.google.com/ac/roles',
+  },
+  check_cep_subscription: {
+    privilege: 'Services > License Management > License Read',
+    roleUrl: 'https://admin.google.com/ac/roles',
+  },
+  check_user_cep_license: {
+    privilege: 'Services > License Management > License Read',
+    roleUrl: 'https://admin.google.com/ac/roles',
+  },
+  list_dlp_rules: {
+    privilege: 'Services > Cloud Identity > Security > View / Manage Data Loss Prevention (DLP) rules and detectors',
+    roleUrl: 'https://admin.google.com/ac/roles',
+  },
+  get_dlp_rule: {
+    privilege: 'Services > Cloud Identity > Security > View / Manage Data Loss Prevention (DLP) rules and detectors',
+    roleUrl: 'https://admin.google.com/ac/roles',
+  },
+  list_detectors: {
+    privilege: 'Services > Cloud Identity > Security > View / Manage Data Loss Prevention (DLP) rules and detectors',
+    roleUrl: 'https://admin.google.com/ac/roles',
+  },
+  create_chrome_dlp_rule: {
+    privilege: 'Services > Cloud Identity > Security > View / Manage Data Loss Prevention (DLP) rules and detectors',
+    roleUrl: 'https://admin.google.com/ac/roles',
+  },
+  create_regex_detector: {
+    privilege: 'Services > Cloud Identity > Security > View / Manage Data Loss Prevention (DLP) rules and detectors',
+    roleUrl: 'https://admin.google.com/ac/roles',
+  },
+}
+
 /**
  * Generates a proactive remediation message for authentication errors.
  * @param {number} status - HTTP status code (401 or 403)
  * @param {boolean} bearerInbound - True if request used inbound Bearer auth
+ * @param {string} [toolName] - Name of the tool being executed
  * @returns {string} Human-readable remediation instructions
  */
-function getAuthRemediationMessage(status, bearerInbound = false) {
+function getAuthRemediationMessage(status, bearerInbound = false, toolName = '') {
+  if (status === 403 && toolName && TOOL_PRIVILEGES_MAP[toolName]) {
+    const info = TOOL_PRIVILEGES_MAP[toolName]
+    return `Permission denied (403 Forbidden) while calling tool '${toolName}'. Your authenticated principal lacks the required Google Workspace / Chrome Enterprise permissions for this resource.\n\n🛠️ Required Workspace Admin Console Privileges for '${toolName}':\n- ${info.privilege}\n\n🔗 How to fix: Open Workspace Admin Roles Console (${info.roleUrl}), create or edit an admin role with the privileges listed above, and assign it to your authenticated Service Account or user email.`
+  }
+
   if (bearerInbound) {
     if (status === 401) {
       return `Authentication required. The inbound Bearer token has expired or is invalid. Re-authenticate through your MCP client to refresh the token.`
@@ -335,7 +394,7 @@ export function guardedToolCall(
             ? 401
             : 403)
         const bearerInbound = !!context?.authToken || !!context?.requestInfo?.headers?.authorization
-        const remediationMessage = getAuthRemediationMessage(resolvedStatus, bearerInbound)
+        const remediationMessage = getAuthRemediationMessage(resolvedStatus, bearerInbound, context?.name)
         return {
           content: [{ type: 'text', text: remediationMessage }],
           isError: true,

--- a/tools/utils/wrapper.js
+++ b/tools/utils/wrapper.js
@@ -212,9 +212,11 @@ export function guardedToolCall(
         }
         if (requiresDelegation && !process.env.CEP_IMPERSONATE_SUBJECT) {
           const text =
-            'Error: Calling this DLP tool in Service Account mode requires domain-wide delegation. ' +
-            'GOOGLE_APPLICATION_CREDENTIALS is set, but CEP_IMPERSONATE_SUBJECT is not specified. ' +
-            'Set CEP_IMPERSONATE_SUBJECT to the email address of a Google Workspace admin with privileges to manage DLP rules.'
+            'Error: Tool requires Domain-Wide Delegation (requiresDelegation: true) to access user-scoped directory or policy data. ' +
+            'You are authenticated in Service Account mode (GOOGLE_APPLICATION_CREDENTIALS is set), but CEP_IMPERSONATE_SUBJECT is not specified. ' +
+            'To use this tool, set CEP_IMPERSONATE_SUBJECT to the email address of a Google Workspace user account with delegated privileges (Option 1). ' +
+            'Alternatively, if you are using direct Admin Console role assignments without user impersonation (Option 2), ' +
+            'use Option 2 compatible tools such as list_org_units, security_insights, or count_browser_versions with an explicit customerId.'
           return {
             content: [{ type: 'text', text }],
             isError: true,

--- a/tools/utils/wrapper.js
+++ b/tools/utils/wrapper.js
@@ -62,8 +62,7 @@ const TOOL_PRIVILEGES_MAP = {
     roleUrl: 'https://admin.google.com/ac/roles',
   },
   security_insights: {
-    privilege:
-      'Services > Chrome Management > Manage ChromeOS Devices (Read-only) + Services > Chrome Enterprise Security Insights',
+    privilege: 'Services > Chrome Enterprise Security Insights (or Chrome Management)',
     roleUrl: 'https://admin.google.com/ac/roles',
   },
   count_browser_versions: {
@@ -71,12 +70,11 @@ const TOOL_PRIVILEGES_MAP = {
     roleUrl: 'https://admin.google.com/ac/roles',
   },
   list_customer_profiles: {
-    privilege:
-      'Services > Chrome Management > Manage ChromeOS Devices (Read-only) + Services > Chrome Management > Settings > Managed Browsers',
+    privilege: 'Services > Chrome Management > Settings > Managed Browsers',
     roleUrl: 'https://admin.google.com/ac/roles',
   },
   get_chrome_activity_log: {
-    privilege: 'Services > Chrome Management > Manage ChromeOS Devices (Read-only) + Reports > Audit Reports',
+    privilege: 'Services > Chrome Management > Manage ChromeOS Devices (and Reports > Audit Reports)',
     roleUrl: 'https://admin.google.com/ac/roles',
   },
   check_cep_subscription: {
@@ -119,7 +117,7 @@ const TOOL_PRIVILEGES_MAP = {
 function getAuthRemediationMessage(status, bearerInbound = false, toolName = '') {
   if (status === 403 && toolName && TOOL_PRIVILEGES_MAP[toolName]) {
     const info = TOOL_PRIVILEGES_MAP[toolName]
-    return `Permission denied (403 Forbidden) while calling tool '${toolName}'. Your authenticated principal lacks the required Google Workspace / Chrome Enterprise permissions for this resource.\n\n🛠️ Required Workspace Admin Console Privileges for '${toolName}':\n- ${info.privilege}\n\n🔗 How to fix: Open Workspace Admin Roles Console (${info.roleUrl}), create or edit an admin role with the privileges listed above, and assign it to your authenticated Service Account or user email.`
+    return `Permission denied (403 Forbidden) while calling \`${toolName}\`. Your account lacks the required Google Workspace Admin Console privilege:\n• **${info.privilege}**\n\n**To fix:** Open [Workspace Admin Roles](${info.roleUrl}) and assign any role (or custom role) granting this privilege to your account (e.g., *Delegated Admin* or *Super Admin*).`
   }
 
   if (bearerInbound) {

--- a/tools/utils/wrapper.js
+++ b/tools/utils/wrapper.js
@@ -73,6 +73,14 @@ function getAuthRemediationMessage(status, bearerInbound = false) {
 2. **Verify APIs are enabled:** Run the \`check_and_enable_cep_api\` tool against your project, or enable the API set listed in \`lib/constants.js#SERVICE_NAMES\`.`
   }
 
+  const isSaMode = !!process.env.GOOGLE_APPLICATION_CREDENTIALS
+  if (isSaMode) {
+    if (status === 401) {
+      return `Authentication required. The Service Account credentials configured in GOOGLE_APPLICATION_CREDENTIALS are invalid or domain-wide delegation failed. Ensure the Service Account JSON key is valid and domain-wide delegation (CEP_IMPERSONATE_SUBJECT) is configured in Google Workspace Admin Console.`
+    }
+    return `Permission denied. The Service Account lacks required Google Workspace / Chrome Enterprise permissions or domain-wide delegation OAuth scopes. Verify that the Service Account has required IAM roles and that Domain-Wide Delegation in Google Workspace Admin Console includes the necessary scopes.`
+  }
+
   const manualLogin = cliInvocation('auth login')
   if (status === 401) {
     return `Authentication required. Run the \`cep_auth\` tool to sign in, or run \`${manualLogin}\` at the shell to authorize the server (it caches the access token at ~/.config/cep-mcp/tokens.json). To use a service account, set GOOGLE_APPLICATION_CREDENTIALS to a service-account key file.`
@@ -155,6 +163,7 @@ export function safeFormatResponse({ rawData, formatFn, toolName }) {
  * @param {(...args: unknown[]) => unknown} toolDef.handler - The main tool handler function
  * @param {boolean} [toolDef.skipAutoResolve] - Whether to skip auto-resolving customerId
  * @param {boolean} [toolDef.skipAuthCheck] - Whether to skip checking if tokens are valid.
+ * @param {boolean} [toolDef.requiresDelegation] - Whether this tool requires domain-wide delegation in SA mode.
  * @param {string[]} [toolDef.scopes] - Scopes required for this tool. Defaults to all SCOPES.
  * @param {object} options - Configuration options for the wrapper
  * @param {object} [options.apiClients] - Collection of API clients
@@ -164,12 +173,20 @@ export function safeFormatResponse({ rawData, formatFn, toolName }) {
  * @returns {(...args: unknown[]) => unknown} The wrapped tool handler function
  */
 export function guardedToolCall(
-  { validate, transform, handler, skipAutoResolve = false, skipAuthCheck = false, scopes = getActiveScopes() },
+  {
+    validate,
+    transform,
+    handler,
+    skipAutoResolve = false,
+    skipAuthCheck = false,
+    requiresDelegation = false,
+    scopes = getActiveScopes(),
+  },
   options = {},
   sessionState = { customerId: null, cachedRootOrgUnitId: null },
 ) {
   const wrapped = async (params, context) => {
-    const authToken = getAuthToken(context?.requestInfo)
+    const authToken = params?.accessToken || getAuthToken(context?.requestInfo)
     if (!skipAuthCheck) {
       if (authToken) {
         // Inbound Bearer token present: skip local disk checks and forward directly to Google APIs
@@ -182,16 +199,28 @@ export function guardedToolCall(
           structuredContent: { status: 'error', code: 'BEARER_ONLY_REQUIRED', message: msg },
           isError: true,
         }
-      } else if (isServiceAccountMode() && !process.env.GOOGLE_APPLICATION_CREDENTIALS) {
-        const msg =
-          'Authentication failed: Server is configured in strict "service-account-only" mode, ' +
-          'but GOOGLE_APPLICATION_CREDENTIALS is not set.'
-        return {
-          content: [{ type: 'text', text: msg }],
-          structuredContent: { status: 'error', code: 'SERVICE_ACCOUNT_REQUIRED', message: msg },
-          isError: true,
+      } else if (isServiceAccountMode() || (isDynamicMode() && process.env.GOOGLE_APPLICATION_CREDENTIALS)) {
+        if (isServiceAccountMode() && !process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+          const msg =
+            'Authentication failed: Server is configured in strict "service-account-only" mode, ' +
+            'but GOOGLE_APPLICATION_CREDENTIALS is not set.'
+          return {
+            content: [{ type: 'text', text: msg }],
+            structuredContent: { status: 'error', code: 'SERVICE_ACCOUNT_REQUIRED', message: msg },
+            isError: true,
+          }
         }
-      } else if (isDynamicMode() && !process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+        if (requiresDelegation && !process.env.CEP_IMPERSONATE_SUBJECT) {
+          const text =
+            'Error: Calling this DLP tool in Service Account mode requires domain-wide delegation. ' +
+            'GOOGLE_APPLICATION_CREDENTIALS is set, but CEP_IMPERSONATE_SUBJECT is not specified. ' +
+            'Set CEP_IMPERSONATE_SUBJECT to the email address of a Google Workspace admin with privileges to manage DLP rules.'
+          return {
+            content: [{ type: 'text', text }],
+            isError: true,
+          }
+        }
+      } else {
         const validity = await isTokenLocallyValid({ scopes })
         if (!validity.ok) {
           return buildAuthRequiredResponse(validity)
@@ -215,6 +244,7 @@ export function guardedToolCall(
       }
       const { apiClients } = options
       let currentParams = { ...params }
+      delete currentParams.accessToken
       if (sessionState && currentParams.customerId) {
         sessionState.customerId = currentParams.customerId
       }


### PR DESCRIPTION
#### Motivation
The MCP server by default runs in a dynamic, fallback-based authentication mode (Bearer Token -> Service Account key -> local cached CLI token). While convenient for development, this implicit fallback is undesirable in production or strict environments where administrators want to guarantee that only a specific, intended authentication method is used.

This PR introduces the ability to disable the fallback behavior and enforce a single auth mechanism for safety, preventing accidental deviation (e.g. failing immediately if a client token is missing instead of falling back to a server-wide Service Account).

#### Main Changes
* Introduce the `CEP_AUTH_MODE` environment variable to control fallback behavior:
  * `dynamic` (default): Preserves the existing fallback behavior (bearer -> SA -> cache).
  * `bearer-only`: Enforces that only the passed bearer token is used, failing immediately if missing.
  * `service-account-only`: Enforces that only the local Service Account credentials are used, ignoring inbound tokens.
* Update `guardedToolCall` wrapper and `getAuthClient` to respect the configured mode.
* Add unit tests in `auth.test.ts` verifying correct enforcement and failure conditions for each mode.

TAG=agy
CONV=ff58ca61-3763-4cf3-aef4-4a279152b67a
