### PR TITLE
docs(knowledge): Add knowledge articles for CAA access levels features

### DIFF
--- a/.github/expected-tarball.txt
+++ b/.github/expected-tarball.txt
@@ -40,6 +40,9 @@ lib/knowledge/32-security-gateway-saas-apps.md
 lib/knowledge/33-security-gateway-private-web-apps.md
 lib/knowledge/34-troubleshoot-security-gateway.md
 lib/knowledge/35-manage-security-gateway.md
+lib/knowledge/36-caa-access-levels-overview.md
+lib/knowledge/37-creating-a-basic-access-level.md
+lib/knowledge/38-access-level-examples.md
 lib/knowledge/98-agent-knowledge-addendum.md
 lib/knowledge/README.md
 lib/knowledge/instructions.js

--- a/lib/knowledge/36-caa-access-levels-overview.md
+++ b/lib/knowledge/36-caa-access-levels-overview.md
@@ -1,0 +1,9 @@
+---
+summary: 'Overview of Access Context Manager and Context-Aware Access (CAA) Access Levels. Details how access levels define conditions under which users and devices can access GCP and Workspace resources based on device security posture, IP subnets, user identity, and regions.'
+title: 'Access Context Manager Access Levels Overview'
+articleId: 36
+url: 'https://docs.cloud.google.com/access-context-manager/docs/overview'
+---
+
+This article is now hosted on the official Google Cloud documentation.
+The 'get_document' tool will automatically fetch the latest version for you.

--- a/lib/knowledge/37-creating-a-basic-access-level.md
+++ b/lib/knowledge/37-creating-a-basic-access-level.md
@@ -1,0 +1,9 @@
+---
+summary: 'Guide on creating and configuring basic access levels in Access Context Manager. Details how to specify device policies, IP subnet restrictions, user identity conditions, and region constraints for Context-Aware Access (CAA).'
+title: 'Creating a Basic Access Level'
+articleId: 37
+url: 'https://docs.cloud.google.com/access-context-manager/docs/create-basic-access-level'
+---
+
+This article is now hosted on the official Google Cloud documentation.
+The 'get_document' tool will automatically fetch the latest version for you.

--- a/lib/knowledge/38-access-level-examples.md
+++ b/lib/knowledge/38-access-level-examples.md
@@ -1,0 +1,9 @@
+---
+summary: 'Examples and common policy recipes for Context-Aware Access (CAA) basic mode, including device security requirements, OS version constraints, screenlock enforcement, corp-ownership, and location-based access controls.'
+title: 'Context-Aware Access Examples for Basic Mode'
+articleId: 38
+url: 'https://knowledge.workspace.google.com/admin/security/context-aware-access-examples-for-basic-mode'
+---
+
+This article is now hosted on the official Google Workspace Knowledge Base.
+The 'get_document' tool will automatically fetch the latest version for you.


### PR DESCRIPTION
### Summary of Knowledge Base Additions (`caa-knowledge` branch)

Added 3 new curated knowledge base articles under `lib/knowledge/` to support Context-Aware Access (CAA) and Access Context Manager lookup and document retrieval.

#### New Articles Added:

1. **`lib/knowledge/36-caa-access-levels-overview.md`**
   - **Article ID**: `36`
   - **Title**: `Access Context Manager Access Levels Overview`
   - **Source URL**: `https://docs.cloud.google.com/access-context-manager/docs/overview`
   - **Summary**: Overview of Access Context Manager and Context-Aware Access (CAA) Access Levels. Details how access levels define conditions under which users and devices can access GCP and Workspace resources based on device security posture, IP subnets, user identity, and regions.

2. **`lib/knowledge/37-creating-a-basic-access-level.md`**
   - **Article ID**: `37`
   - **Title**: `Creating a Basic Access Level`
   - **Source URL**: `https://docs.cloud.google.com/access-context-manager/docs/create-basic-access-level`
   - **Summary**: Guide on creating and configuring basic access levels in Access Context Manager. Details how to specify device policies, IP subnet restrictions, user identity conditions, and region constraints for Context-Aware Access (CAA).

3. **`lib/knowledge/38-access-level-examples.md`**
   - **Article ID**: `38`
   - **Title**: `Context-Aware Access Examples for Basic Mode`
   - **Source URL**: `https://knowledge.workspace.google.com/admin/security/context-aware-access-examples-for-basic-mode`
   - **Summary**: Examples and common policy recipes for Context-Aware Access (CAA) basic mode, including device security requirements, OS version constraints, screenlock enforcement, corp-ownership, and location-based access controls.

#### Verification & Testing:
- All 557 unit tests passed cleanly via `npm run test:unit`.
- Formatted via Prettier style guidelines.