### PR TITLE
docs(acm): update list_caa_access_levels tool description to check existing levels before creation

### DIFF
--- a/tools/definitions/create_caa_access_level.js
+++ b/tools/definitions/create_caa_access_level.js
@@ -64,6 +64,8 @@ export function registerCreateCaaAccessLevelTool(server, options, sessionState) 
 If the organization does not have an Access Policy, this tool will attempt to create a default one first.
 This tool blocks and waits for the Access Level creation to complete before returning.
 
+Before calling 'create_caa_access_level', agents should first invoke 'list_caa_access_levels' to check if an access level matching the user's described conditions already exists for the organization. If a matching access level exists, present it to the user and confirm whether they still wish to create a new one.
+
 If an API returns a 403 Permission Denied error, the likely cause is missing IAM permissions.
 Guide the user on fixing it by linking: https://docs.cloud.google.com/iam/docs/grant-role-console
 Explicitly mention the required permissions as listed in the public API docs or recommend granting the 'Access Context Manager Policy Admin' role (roles/accesscontextmanager.policyAdmin):

--- a/tools/definitions/list_caa_access_levels.js
+++ b/tools/definitions/list_caa_access_levels.js
@@ -81,6 +81,8 @@ export function registerListCaaAccessLevelsTool(server, options, sessionState) {
       description: `Lists Context-Aware Access (CAA) access levels for an organization.
 Resolves the Access Policy for the specified (or cached) Organization ID, then lists all defined access levels within that policy.
 
+When a user requests to create a new access level, agents should first invoke 'list_caa_access_levels' to check if an access level matching the user's described conditions already exists for the organization. If a matching access level is found, present that access level to the user and ask if they still wish to create a new one before proceeding with creation.
+
 If an API returns a 403 Permission Denied error, the likely cause is missing IAM permissions.
 Guide the user on fixing it by linking: https://docs.cloud.google.com/iam/docs/grant-role-console
 Explicitly mention the required permissions as listed in the public API docs or recommend granting the 'Access Context Manager Reader' (roles/accesscontextmanager.policyReader) or 'Policy Admin' role (roles/accesscontextmanager.policyAdmin):


### PR DESCRIPTION
This PR updates the description of list access levels to direct agentic clients to call it first to see if an access level meeting the users conditions already exists before creating one 

## Manual Testing

<img width="1911" height="1148" alt="Screenshot 2026-07-20 9 04 25 AM" src="https://github.com/user-attachments/assets/f27375f8-e70c-40be-aa5b-484842ed6168" />
