### PR TITLE
docs: remove unsupported Gemini Enterprise references

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,6 @@ Reference documentation for operating and extending the Chrome Enterprise Premiu
 - [`architecture.md`](./architecture.md): Code layout, the client abstraction, retry behavior, and CEL validation.
 - [`faq.md`](./faq.md): License requirements, service accounts, experimental features, and other recurring questions.
 - [`auth-bring-your-own-oauth-client.md`](./auth-bring-your-own-oauth-client.md): How to create a Desktop OAuth client and run the CLI's `auth login` subcommand.
-- [`auth-cloud-run-and-gemini-enterprise.md`](./auth-cloud-run-and-gemini-enterprise.md): How to deploy the server behind Cloud Run with Gemini Enterprise.
+- [`auth-cloud-run.md`](./auth-cloud-run.md): How to deploy the server behind Cloud Run.
 
 For contributing changes, see [`CONTRIBUTING.md`](../CONTRIBUTING.md). For the test infrastructure, see [`test/README.md`](../test/README.md).

--- a/docs/auth-cloud-run.md
+++ b/docs/auth-cloud-run.md
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Cloud Run and Gemini Enterprise deployment
+# Cloud Run deployment
 
 For hosted deployments, OAuth is the recommended authentication path. A service account with domain-wide delegation is the alternative when OAuth is not viable; the service account setup is at the end of this page.
 
@@ -44,7 +44,7 @@ Register the OAuth client with Vertex AI Agent Engine through the Agent Engine c
 
 For the scope list, use the full scope set the server requests (defined in `lib/constants.js`).
 
-A reference walkthrough of an end-to-end ADK agent on Vertex AI Agent Engine with OAuth is the third-party blog post [Powering up your agent in production with ADK, OAuth, and Gemini Enterprise](https://fmind.medium.com/powering-up-your-agent-in-production-with-adk-oauth-and-gemini-enterprise-a52b0716fcba).
+A reference walkthrough of an end-to-end ADK agent on Vertex AI Agent Engine with OAuth is the third-party blog post [Powering up your agent in production with ADK and OAuth](https://fmind.medium.com/powering-up-your-agent-in-production-with-adk-oauth-and-gemini-enterprise-a52b0716fcba).
 
 ## Alternative: service account with domain-wide delegation
 


### PR DESCRIPTION
### Motivation
Remove documentation references to Gemini Enterprise from the server repository, as Gemini Enterprise is currently unsupported. References were mostly in titles with little actual documentation content.

### Main Changes
- Renamed `docs/auth-cloud-run-and-gemini-enterprise.md` to `docs/auth-cloud-run.md` and updated title to `# Cloud Run deployment`.
- Updated index link in `docs/README.md` and Medium blog link text.

### Verification
- Confirmed zero remaining `Gemini Enterprise` references exist outside `node_modules/`.
- All unit and integration tests passing (`npm run presubmit`).