### PR TITLE
docs: clarify Workspace role requirements for DLP and diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Before setting up the MCP server, ensure you have the following:
 1.  **Node.js & npm:** Node.js version `20.0.0` or higher installed locally.
 2.  **Google Workspace Account:**
     - Any Workspace edition with a [Chrome Enterprise Premium](https://docs.cloud.google.com/chrome-enterprise-premium/docs/overview) license.
-    - An administrator role in the [Admin Console](https://admin.google.com/) (Super Admin or delegated with **Chrome Management** and **DLP** permissions). Standard Workspace accounts (or Google Cloud IAM permissions alone) do not grant access and will return `403 Permission Denied` errors with no indication that a Workspace role is missing.
+    - An administrator role in the [Admin Console](https://admin.google.com/). Note that **Super Admin is required** for DLP features and running full diagnostics, while delegated roles with Chrome Management permissions are sufficient for other tools (see [Administrator Role Requirements](docs/configuration.md#administrator-role-requirements) for details). Standard Workspace accounts (or Google Cloud IAM permissions alone) do not grant access.
 3.  **OAuth App Trust (if required):** If your organization restricts third-party app access, a Super Admin must [trust the OAuth client](docs/troubleshooting.md#configure-oauth-app-for-sensitive-scopes) in the Admin Console before you can authenticate.
 4.  **MCP Client:** A compatible MCP host application (such as Gemini CLI, Claude Desktop, Cursor, Windsurf, or VS Code).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,7 +80,7 @@ If you're not sure which path applies to you, see the [Which auth path should I 
 
 ### Service Account & Domain-Wide Delegation (DWD)
 
-When running in Service Account mode without per-user OAuth, set `GOOGLE_APPLICATION_CREDENTIALS` to your Service Account JSON key path. For Workspace APIs (such as DLP rules, Organizational Units, and Customer ID retrieval), you must also set `CEP_IMPERSONATE_SUBJECT` to the email address of a Google Workspace administrator (e.g., `admin@example.com`). This is because Google Workspace APIs do not allow direct machine-identity access from Service Accounts; the Service Account must use Domain-Wide Delegation to impersonate a human administrator who has the necessary privileges to read or manage those resources.
+When running in Service Account mode without per-user OAuth, set `GOOGLE_APPLICATION_CREDENTIALS` to your Service Account JSON key path. For Workspace APIs (such as DLP rules, Organizational Units, and Customer ID retrieval), you must also set `CEP_IMPERSONATE_SUBJECT` to the email address of a Google Workspace administrator (e.g., `admin@example.com`). This is because Google Workspace APIs do not allow direct machine-identity access from Service Accounts; the Service Account must use Domain-Wide Delegation to impersonate a human administrator (see [Administrator Role Requirements](#administrator-role-requirements) for required privileges).
 
 **Google Workspace Admin Console Authorization Steps:**
 
@@ -126,3 +126,20 @@ For HTTP-mode deployments behind an OAuth-bearing caller (such as Vertex AI Agen
 **Finding the right `sub` value.**
 
 Start the server with `CEP_BEARER_AUDIENCE` set and `LOG_LEVEL=debug`, then have the desired principal send one request. The server logs `Request authenticated as <email> (sub=<sub>)`. Copy the `sub` value into `CEP_BEARER_PRINCIPAL_SUB` and restart.
+
+## Administrator Role Requirements
+
+The CEP MCP server calls various Google Workspace APIs. The Google Workspace user account used for authentication (or impersonated via Service Account) must have appropriate administrative privileges.
+
+Depending on the tools you want to use, different roles are required:
+
+| Features / Tools                                                                | Required Privilege / Role                                   | API Called                                 |
+| :------------------------------------------------------------------------------ | :---------------------------------------------------------- | :----------------------------------------- |
+| **DLP Rules & Detectors**<br>(e.g., `list_dlp_rules`, `create_chrome_dlp_rule`) | **Super Administrator**                                     | Cloud Identity Policies API                |
+| **Diagnostics**<br>(`diagnose_environment`)                                     | **Super Administrator**                                     | Cloud Identity Policies API (among others) |
+| **Chrome Policy**<br>(e.g., connectors, extensions)                             | **Delegated Admin** with **Chrome Management** permissions  | Chrome Policy API                          |
+| **Chrome Telemetry**<br>(e.g., browser counts, security insights)               | **Delegated Admin** with **Chrome Management** permissions  | Chrome Management API                      |
+| **Activity Logs**<br>(`get_chrome_activity_log`)                                | **Delegated Admin** with **Reports** permissions            | Admin SDK Reports API                      |
+| **Subscription Checks**                                                         | **Delegated Admin** with **License Management** permissions | Licensing API                              |
+
+Because the underlying Cloud Identity Policies API strictly enforces a Super Admin check, **you cannot use a custom/delegated role to manage DLP features**, even if you grant it "all privileges" in the Admin Console.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -66,7 +66,7 @@ allow-listed.
 The cause is almost always one of three things.
 
 1. **An API is not enabled.** Run the `gcloud services enable` command from the [Quick Start](../README.md#2-enable-required-apis). This is the most common cause on first setup.
-2. **A Workspace admin role is missing.** Chrome Management and Admin SDK APIs require a Google Workspace admin role (Super Admin or delegated) configured in the [Admin Console](https://admin.google.com/) under **Account > Admin roles**. Google Cloud IAM roles alone are not sufficient for Workspace APIs.
+2. **A Workspace admin role is missing or insufficient.** Chrome Management and Admin SDK APIs require a Google Workspace admin role configured in the Admin Console under **Account > Admin roles**. Note that DLP-related tools and the full `diagnose_environment` tool strictly require a **Super Admin** role. See [Administrator Role Requirements](configuration.md#administrator-role-requirements) for details on required privileges. Google Cloud IAM roles alone are not sufficient.
 3. **A Google Cloud IAM role is missing.** The user needs roles on the Google Cloud project itself, such as `roles/browser.admin` or `roles/serviceusage.serviceUsageAdmin`.
 
 ### "PERMISSION_DENIED" followed by retries


### PR DESCRIPTION
## Motivation
Users setting up the CEP MCP server with custom/delegated administrator roles encountered permission errors (403 Forbidden) when using DLP-related features or running the environment diagnostics. 

Investigation of the underlying Google APIs confirmed that the **Cloud Identity Policies API** (which manages DLP rules and detectors) strictly enforces a Super Administrator check at the API layer. Custom roles, even with "all privileges" assigned in the Workspace Admin Console, do not satisfy this requirement. 

Our documentation previously claimed that delegated administrator roles with Chrome Management and DLP permissions were sufficient. This PR corrects the documentation to prevent user confusion and guide correct setup.

## Main Changes
*   **`README.md`**: Clarified that viewing/managing DLP rules and detectors, as well as running the full `diagnose_environment` tool, strictly requires a **Super Admin** role. Noted that delegated admins (with **Chrome Management** permissions) can still use Chrome Policy and telemetry tools.
*   **`docs/troubleshooting.md`**: Added guidance for "Workspace admin role is missing or insufficient" to explain the Super Admin requirement for DLP.
*   **`docs/configuration.md`**: Updated the Service Account & Domain-Wide Delegation section to note that the impersonated user must be a Super Admin to use DLP features.

## Design Decisions
*   **Documentation-only fix**: Addressed the immediate need for accurate documentation. (Code-level resilience for `diagnose_environment` to handle 403s gracefully is planned as a separate follow-up).
