### PR TITLE
feat(connector_policy_helper): inspect enum variants for delayDeliveryUntilVerdict posture alerts

### DIFF
--- a/lib/util/connector_policy_helper.js
+++ b/lib/util/connector_policy_helper.js
@@ -129,7 +129,15 @@ export function analyzeConnectorPolicy(policyType, resolvedPolicies) {
         cfg.serviceProvider === 'SERVICE_PROVIDER_UNSPECIFIED'
 
       if (isCEP) {
-        if (!cfg.delayDeliveryUntilVerdict && !cfg.delay_delivery_until_verdict) {
+        const delayVal = cfg.delayDeliveryUntilVerdict ?? cfg.delay_delivery_until_verdict
+        const isDelayDisabled =
+          !delayVal ||
+          delayVal === false ||
+          delayVal === 'DELAY_DELIVERY_UNTIL_VERDICT_ENUM_DISABLED' ||
+          delayVal === 'DELAY_DELIVERY_UNTIL_VERDICT_DISABLED' ||
+          delayVal === 'DELAY_DELIVERY_UNTIL_VERDICT_ENUM_UNSPECIFIED'
+
+        if (isDelayDisabled) {
           findings.push({
             message: 'Delay enforcement is disabled. Users are unprotected during content analysis',
             remediationType: 'manual',


### PR DESCRIPTION
### Rationale
In Chrome Policy API, the `delayDeliveryUntilVerdict` setting can be returned as boolean `false` or as enum strings such as `DELAY_DELIVERY_UNTIL_VERDICT_ENUM_DISABLED` and `DELAY_DELIVERY_UNTIL_VERDICT_DISABLED`. JavaScript's `!` check evaluates non-empty strings as truthy, which caused disabled delay enforcement setting variants to be missed during posture evaluation.

### Impact
Updates `analyzeConnectorPolicy` to check enum string variants alongside booleans, allowing posture health checks to reliably flag when Delay Enforcement is disabled.