### PR TITLE
fix(diagnose_environment): fallback rootOUId and differentiate unverified status

### DIFF
--- a/lib/api/chrome_management_client.js
+++ b/lib/api/chrome_management_client.js
@@ -64,12 +64,10 @@ export class ChromeManagementClient {
    */
   async countBrowserVersions(customerId, orgUnitId, authToken) {
     logger.debug(`${TAGS.API} countBrowserVersions called with customerId: ${customerId}, orgUnitId: ${orgUnitId}`)
-    if (!customerId) {
-      throw new Error('customerId is required for countBrowserVersions')
-    }
+    const targetCustId = customerId && customerId !== 'unknown' ? customerId : 'my_customer'
     const client = await this.getClient(authToken)
     try {
-      const request = { customer: `customers/${customerId}` }
+      const request = { customer: `customers/${targetCustId}` }
       if (orgUnitId) {
         request.orgUnitId = orgUnitId
       }

--- a/tools/definitions/diagnose_environment.js
+++ b/tools/definitions/diagnose_environment.js
@@ -162,7 +162,19 @@ function computeIssues(data) {
     const manualLink = page ? `https://admin.google.com/ac/chrome/settings/user/details/${page}` : null
     const actionSuffix = manualLink ? `. Update settings manually at ${manualLink}` : ''
 
-    if (!connector.configured) {
+    if (connector.error) {
+      issues.push({
+        severity: 'medium',
+        component: `connector.${key}`,
+        message: `${name} connector status could not be verified (lookup error).${actionSuffix}`,
+        ...(manualLink && {
+          remediation: {
+            actionLabel: `Check ${name} connector settings`,
+            url: manualLink,
+          },
+        }),
+      })
+    } else if (!connector.configured) {
       issues.push({
         severity: 'critical',
         component: `connector.${key}`,
@@ -598,7 +610,7 @@ async function fetchEnvironment(
 
   const orgUnits = orgUnitsData?.organizationUnits || []
   const rootOU = orgUnits.find(ou => ou.orgUnitPath === '/') || orgUnits[0]
-  const rootOUId = rootOU?.orgUnitId?.replace('id:', '') || null
+  const rootOUId = rootOU?.orgUnitId?.replace('id:', '') || 'my_customer'
 
   const customer = {
     customerId: customerData?.id || customerId || 'unknown',


### PR DESCRIPTION
### Rationale
When running `diagnose_environment`, if administrative Directory API permissions are absent or `orgUnitId` resolution returns `null`, or if `customerId` is passed as an empty string (`""`), `diagnose_environment` previously failed policy lookups and skipped connector checks, falsely reporting connectors as unconfigured or producing unverified errors.

### Main Changes
1. Default `rootOUId` and `customerId` to `'my_customer'` (Google's standard alias for the root OU / customer domain) when directory lookup returns `null` or when `customerId` is unpopulated (`""`).
2. Check `connector.error` in `computeIssues` before checking `!connector.configured`, producing an explicit `medium` severity message (`connector status could not be verified`) rather than claiming configured connectors are absent.