### PR TITLE
fix(diagnose): escalate zero assigned licenses to high severity

### DIFF
--- a/test/local/diagnose_environment.test.js
+++ b/test/local/diagnose_environment.test.js
@@ -188,13 +188,13 @@ describe('diagnose_environment', () => {
       assert.strictEqual(critical[0].message, 'No active Chrome Enterprise Premium subscription found on this domain.')
     })
 
-    test('When subscription exists but has 0 users assigned, then it produces a warning issue', async () => {
+    test('When subscription exists but has 0 users assigned, then it produces a high issue', async () => {
       const { handler } = registerAndGetHandler({ subscription: { items: [] } })
       const result = await handler({ customerId: 'C0123' }, { requestInfo: {} })
-      const warning = result.structuredContent.issues.filter(i => i.severity === 'warning')
-      assert.ok(warning.some(i => i.component === 'subscription'))
+      const high = result.structuredContent.issues.filter(i => i.severity === 'high')
+      assert.ok(high.some(i => i.component === 'subscription'))
       assert.strictEqual(
-        warning[0].message,
+        high[0].message,
         'Chrome Enterprise Premium subscription is active, but 0 users have licenses assigned. You must assign licenses to users.',
       )
     })

--- a/tools/definitions/diagnose_environment.js
+++ b/tools/definitions/diagnose_environment.js
@@ -514,8 +514,7 @@ function computeIssues(data) {
     critical: 0,
     high: 1,
     medium: 2,
-    warning: 3,
-    info: 4,
+    info: 3,
   }
 
   return issues.sort((a, b) => {
@@ -906,7 +905,7 @@ function buildSummaryResponse(env) {
   const critical = sc.issues.filter(i => i.severity === 'critical').length
   const high = sc.issues.filter(i => i.severity === 'high').length
   const medium = sc.issues.filter(i => i.severity === 'medium').length
-  const warning = sc.issues.filter(i => i.severity === 'warning').length
+  const info = sc.issues.filter(i => i.severity === 'info').length
 
   let summary = `## Environment Health Check\n\n`
   summary += `> **Scope:** Health check is scoped to the Root Organizational Unit (/). Sub-OU overrides are not included in this summary.\n\n`
@@ -964,8 +963,8 @@ function buildSummaryResponse(env) {
     summary += `**Result: No issues found.** The environment appears healthy.\n`
   } else {
     let countsStr = `${critical} critical, ${high} high, ${medium} medium`
-    if (warning > 0) {
-      countsStr += `, ${warning} warning`
+    if (info > 0) {
+      countsStr += `, ${info} info`
     }
     summary += `**Result: ${issueCount} issue(s) found** (${countsStr})\n\n`
     for (const issue of sc.issues) {

--- a/tools/definitions/diagnose_environment.js
+++ b/tools/definitions/diagnose_environment.js
@@ -108,7 +108,7 @@ function computeIssues(data) {
     })
   } else if (data.subscription?.assignmentCount === 0) {
     issues.push({
-      severity: 'warning',
+      severity: 'high',
       component: 'subscription',
       message:
         'Chrome Enterprise Premium subscription is active, but 0 users have licenses assigned. You must assign licenses to users.',


### PR DESCRIPTION
## Summary
This PR escalates the diagnostic issue severity for active CEP subscriptions with zero assigned user licenses from `warning` to `high`. Since unassigned licenses leave all users unprotected and block core CEP security features (Foundation Step 1), treating this as high severity accurately reflects the administrative risk. Additionally, it removes the now-dead `warning` severity tier from `SEVERITY_ORDER` and includes `info` severity counts in the health check summary string.

## Key Changes
- **Issue Severity Escalation (`tools/definitions/diagnose_environment.js`):** Escalated unassigned licenses (`data.subscription?.assignmentCount === 0`) to `high` severity.
- **Severity Order & Summary Clean-up (`tools/definitions/diagnose_environment.js`):** Removed the unused `warning` tier from `SEVERITY_ORDER` and updated `buildSummaryResponse` to count and report `info` severity issues in the summary header.
- **Unit Tests (`test/local/diagnose_environment.test.js`):** Updated unit test assertions to expect `high` severity for zero assigned licenses.

## Verification
- `npm run presubmit`: 605 unit tests passed, 50 integration tests passed, 0 lint errors, smoke test clean.
- Cleanly based on latest `main`.